### PR TITLE
feat: implement bridge speed benchmarking module

### DIFF
--- a/src/bridge-benchmark/bridge-benchmark.controller.ts
+++ b/src/bridge-benchmark/bridge-benchmark.controller.ts
@@ -1,0 +1,103 @@
+import {
+  Controller,
+  Post,
+  Patch,
+  Get,
+  Param,
+  Body,
+  Query,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+} from '@nestjs/swagger';
+import { BridgeBenchmarkService } from './bridge-benchmark.service';
+import {
+  InitiateBenchmarkDto,
+  ConfirmBenchmarkDto,
+  UpdateBenchmarkStatusDto,
+  SpeedMetricsQueryDto,
+  SpeedMetricsResponseDto,
+} from './dto/bridge-benchmark.dto';
+import { BridgeBenchmark } from './entities/bridge-benchmark.entity';
+
+@ApiTags('Bridge Benchmarks')
+@Controller('api/v1/bridges')
+export class BridgeBenchmarkController {
+  constructor(
+    private readonly benchmarkService: BridgeBenchmarkService,
+  ) {}
+
+  @Post('benchmarks')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Initiate a bridge transaction benchmark',
+    description:
+      'Records the start of a bridge transaction lifecycle for speed tracking.',
+  })
+  @ApiResponse({ status: 201, description: 'Benchmark initiated', type: BridgeBenchmark })
+  initiate(@Body() dto: InitiateBenchmarkDto): Promise<BridgeBenchmark> {
+    return this.benchmarkService.initiate(dto);
+  }
+
+  @Patch('benchmarks/:id/confirm')
+  @ApiOperation({
+    summary: 'Confirm destination chain settlement',
+    description:
+      'Records the completion timestamp and calculates total settlement duration.',
+  })
+  @ApiParam({ name: 'id', description: 'Benchmark UUID' })
+  @ApiResponse({ status: 200, description: 'Benchmark confirmed', type: BridgeBenchmark })
+  confirm(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: ConfirmBenchmarkDto,
+  ): Promise<BridgeBenchmark> {
+    return this.benchmarkService.confirm(id, dto);
+  }
+
+  @Patch('benchmarks/:id/status')
+  @ApiOperation({
+    summary: 'Update benchmark transaction status',
+    description: 'Update the status (pending, submitted, confirmed, failed).',
+  })
+  @ApiParam({ name: 'id', description: 'Benchmark UUID' })
+  @ApiResponse({ status: 200, description: 'Status updated', type: BridgeBenchmark })
+  updateStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateBenchmarkStatusDto,
+  ): Promise<BridgeBenchmark> {
+    return this.benchmarkService.updateStatus(id, dto);
+  }
+
+  @Get('benchmarks/:id')
+  @ApiOperation({ summary: 'Get a single benchmark record' })
+  @ApiParam({ name: 'id', description: 'Benchmark UUID' })
+  @ApiResponse({ status: 200, type: BridgeBenchmark })
+  findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<BridgeBenchmark | null> {
+    return this.benchmarkService.findOne(id);
+  }
+
+  @Get('speed-metrics')
+  @ApiOperation({
+    summary: 'Get bridge speed metrics',
+    description:
+      'Returns aggregated speed metrics per bridge/route including rolling averages for the last N transactions (default 50). Suitable for consumption by the ranking engine.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Speed metrics per bridge route',
+    type: SpeedMetricsResponseDto,
+  })
+  getSpeedMetrics(
+    @Query() query: SpeedMetricsQueryDto,
+  ): Promise<SpeedMetricsResponseDto> {
+    return this.benchmarkService.getSpeedMetrics(query);
+  }
+}

--- a/src/bridge-benchmark/bridge-benchmark.module.ts
+++ b/src/bridge-benchmark/bridge-benchmark.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BridgeBenchmark } from './entities/bridge-benchmark.entity';
+import { BridgeBenchmarkService } from './bridge-benchmark.service';
+import { BridgeBenchmarkController } from './bridge-benchmark.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([BridgeBenchmark])],
+  controllers: [BridgeBenchmarkController],
+  providers: [BridgeBenchmarkService],
+  exports: [BridgeBenchmarkService],
+})
+export class BridgeBenchmarkModule {}

--- a/src/bridge-benchmark/bridge-benchmark.service.ts
+++ b/src/bridge-benchmark/bridge-benchmark.service.ts
@@ -1,0 +1,243 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  BridgeBenchmark,
+  TransactionStatus,
+} from './entities/bridge-benchmark.entity';
+import {
+  InitiateBenchmarkDto,
+  ConfirmBenchmarkDto,
+  UpdateBenchmarkStatusDto,
+  SpeedMetricsQueryDto,
+  RouteSpeedMetricDto,
+  SpeedMetricsResponseDto,
+} from './dto/bridge-benchmark.dto';
+
+@Injectable()
+export class BridgeBenchmarkService {
+  constructor(
+    @InjectRepository(BridgeBenchmark)
+    private readonly benchmarkRepository: Repository<BridgeBenchmark>,
+  ) {}
+
+  async initiate(dto: InitiateBenchmarkDto): Promise<BridgeBenchmark> {
+    const benchmark = this.benchmarkRepository.create({
+      bridgeName: dto.bridgeName,
+      sourceChain: dto.sourceChain,
+      destinationChain: dto.destinationChain,
+      token: dto.token,
+      sourceChainType: dto.sourceChainType,
+      destinationChainType: dto.destinationChainType,
+      amount: dto.amount,
+      quoteRequestedAt: dto.quoteRequestedAt
+        ? new Date(dto.quoteRequestedAt)
+        : null,
+      startTime: new Date(),
+      status: TransactionStatus.SUBMITTED,
+    });
+
+    return this.benchmarkRepository.save(benchmark);
+  }
+
+  async confirm(
+    id: string,
+    dto: ConfirmBenchmarkDto,
+  ): Promise<BridgeBenchmark> {
+    const benchmark = await this.findOneOrFail(id);
+
+    if (benchmark.status === TransactionStatus.CONFIRMED) {
+      throw new BadRequestException('Benchmark already confirmed');
+    }
+
+    const now = new Date();
+    const durationMs = now.getTime() - benchmark.startTime.getTime();
+
+    benchmark.destinationConfirmedAt = now;
+    benchmark.completionTime = now;
+    benchmark.durationMs = durationMs;
+    benchmark.status = TransactionStatus.CONFIRMED;
+
+    if (dto.transactionHash) {
+      benchmark.transactionHash = dto.transactionHash;
+    }
+    if (dto.destinationTxHash) {
+      benchmark.destinationTxHash = dto.destinationTxHash;
+    }
+
+    return this.benchmarkRepository.save(benchmark);
+  }
+
+  async updateStatus(
+    id: string,
+    dto: UpdateBenchmarkStatusDto,
+  ): Promise<BridgeBenchmark> {
+    const benchmark = await this.findOneOrFail(id);
+
+    benchmark.status = dto.status;
+    if (dto.transactionHash) {
+      benchmark.transactionHash = dto.transactionHash;
+    }
+
+    return this.benchmarkRepository.save(benchmark);
+  }
+
+  async getSpeedMetrics(
+    query: SpeedMetricsQueryDto,
+  ): Promise<SpeedMetricsResponseDto> {
+    const rollingWindow = query.rollingWindow ?? 50;
+
+    const qb = this.benchmarkRepository
+      .createQueryBuilder('b')
+      .select('b.bridge_name', 'bridgeName')
+      .addSelect('b.source_chain', 'sourceChain')
+      .addSelect('b.destination_chain', 'destinationChain')
+      .addSelect('b.token', 'token')
+      .addSelect('AVG(b.duration_ms)', 'avgDurationMs')
+      .addSelect('MIN(b.duration_ms)', 'minDurationMs')
+      .addSelect('MAX(b.duration_ms)', 'maxDurationMs')
+      .addSelect('COUNT(*)', 'totalTransactions')
+      .addSelect(
+        `COUNT(*) FILTER (WHERE b.status = '${TransactionStatus.CONFIRMED}')`,
+        'successfulTransactions',
+      )
+      .addSelect('MAX(b.completion_time)', 'lastUpdated')
+      .where('b.status = :status', { status: TransactionStatus.CONFIRMED })
+      .andWhere('b.duration_ms IS NOT NULL')
+      .groupBy('b.bridge_name')
+      .addGroupBy('b.source_chain')
+      .addGroupBy('b.destination_chain')
+      .addGroupBy('b.token');
+
+    if (query.bridgeName) {
+      qb.andWhere('b.bridge_name = :bridgeName', {
+        bridgeName: query.bridgeName,
+      });
+    }
+    if (query.sourceChain) {
+      qb.andWhere('b.source_chain = :sourceChain', {
+        sourceChain: query.sourceChain,
+      });
+    }
+    if (query.destinationChain) {
+      qb.andWhere('b.destination_chain = :destinationChain', {
+        destinationChain: query.destinationChain,
+      });
+    }
+    if (query.token) {
+      qb.andWhere('b.token = :token', { token: query.token });
+    }
+
+    const rawMetrics: Array<{
+      bridgeName: string;
+      sourceChain: string;
+      destinationChain: string;
+      token: string;
+      avgDurationMs: string;
+      minDurationMs: string;
+      maxDurationMs: string;
+      totalTransactions: string;
+      successfulTransactions: string;
+      lastUpdated: Date;
+    }> = await qb.getRawMany();
+
+    const metrics: RouteSpeedMetricDto[] = await Promise.all(
+      rawMetrics.map(async (row) => {
+        const rollingAvgDurationMs = await this.computeRollingAverage(
+          row.bridgeName,
+          row.sourceChain,
+          row.destinationChain,
+          row.token,
+          rollingWindow,
+        );
+
+        const total = parseInt(row.totalTransactions, 10);
+        const successful = parseInt(row.successfulTransactions, 10);
+
+        return {
+          bridgeName: row.bridgeName,
+          sourceChain: row.sourceChain,
+          destinationChain: row.destinationChain,
+          token: row.token,
+          avgDurationMs: parseFloat(row.avgDurationMs),
+          minDurationMs: parseInt(row.minDurationMs, 10),
+          maxDurationMs: parseInt(row.maxDurationMs, 10),
+          totalTransactions: total,
+          successfulTransactions: successful,
+          successRate: total > 0 ? (successful / total) * 100 : 0,
+          rollingAvgDurationMs,
+          lastUpdated: row.lastUpdated,
+        };
+      }),
+    );
+
+    return {
+      metrics,
+      generatedAt: new Date(),
+    };
+  }
+
+  async getRankingMetrics(): Promise<
+    Array<{
+      bridgeName: string;
+      sourceChain: string;
+      destinationChain: string;
+      token: string;
+      rollingAvgDurationMs: number;
+      successRate: number;
+    }>
+  > {
+    const result = await this.getSpeedMetrics({ rollingWindow: 50 });
+
+    return result.metrics.map((m) => ({
+      bridgeName: m.bridgeName,
+      sourceChain: m.sourceChain,
+      destinationChain: m.destinationChain,
+      token: m.token,
+      rollingAvgDurationMs: m.rollingAvgDurationMs,
+      successRate: m.successRate,
+    }));
+  }
+
+  async findOne(id: string): Promise<BridgeBenchmark | null> {
+    return this.benchmarkRepository.findOne({ where: { id } });
+  }
+
+  private async findOneOrFail(id: string): Promise<BridgeBenchmark> {
+    const benchmark = await this.findOne(id);
+    if (!benchmark) {
+      throw new NotFoundException(`Benchmark with id ${id} not found`);
+    }
+    return benchmark;
+  }
+
+  private async computeRollingAverage(
+    bridgeName: string,
+    sourceChain: string,
+    destinationChain: string,
+    token: string,
+    windowSize: number,
+  ): Promise<number> {
+    const rows = await this.benchmarkRepository
+      .createQueryBuilder('b')
+      .select('b.duration_ms', 'durationMs')
+      .where('b.bridge_name = :bridgeName', { bridgeName })
+      .andWhere('b.source_chain = :sourceChain', { sourceChain })
+      .andWhere('b.destination_chain = :destinationChain', { destinationChain })
+      .andWhere('b.token = :token', { token })
+      .andWhere('b.status = :status', { status: TransactionStatus.CONFIRMED })
+      .andWhere('b.duration_ms IS NOT NULL')
+      .orderBy('b.completion_time', 'DESC')
+      .limit(windowSize)
+      .getRawMany<{ durationMs: string }>();
+
+    if (rows.length === 0) return 0;
+
+    const sum = rows.reduce((acc, r) => acc + parseInt(r.durationMs, 10), 0);
+    return sum / rows.length;
+  }
+}

--- a/src/bridge-benchmark/dto/bridge-benchmark.dto.ts
+++ b/src/bridge-benchmark/dto/bridge-benchmark.dto.ts
@@ -1,0 +1,128 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsEnum,
+  IsNumber,
+  IsDateString,
+  IsPositive,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ChainType, TransactionStatus } from '../entities/bridge-benchmark.entity';
+
+export class InitiateBenchmarkDto {
+  @ApiProperty({ example: 'Stargate' })
+  @IsString()
+  @IsNotEmpty()
+  bridgeName: string;
+
+  @ApiProperty({ example: 'ethereum' })
+  @IsString()
+  @IsNotEmpty()
+  sourceChain: string;
+
+  @ApiProperty({ example: 'polygon' })
+  @IsString()
+  @IsNotEmpty()
+  destinationChain: string;
+
+  @ApiProperty({ example: 'USDC' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+
+  @ApiPropertyOptional({ enum: ChainType, default: ChainType.EVM })
+  @IsOptional()
+  @IsEnum(ChainType)
+  sourceChainType?: ChainType;
+
+  @ApiPropertyOptional({ enum: ChainType, default: ChainType.EVM })
+  @IsOptional()
+  @IsEnum(ChainType)
+  destinationChainType?: ChainType;
+
+  @ApiPropertyOptional({ example: '1000.00' })
+  @IsOptional()
+  @IsNumber()
+  @IsPositive()
+  amount?: number;
+
+  @ApiPropertyOptional({ description: 'ISO timestamp when quote was requested' })
+  @IsOptional()
+  @IsDateString()
+  quoteRequestedAt?: string;
+}
+
+export class ConfirmBenchmarkDto {
+  @ApiPropertyOptional({ description: 'Source chain transaction hash' })
+  @IsOptional()
+  @IsString()
+  transactionHash?: string;
+
+  @ApiPropertyOptional({ description: 'Destination chain transaction hash' })
+  @IsOptional()
+  @IsString()
+  destinationTxHash?: string;
+}
+
+export class UpdateBenchmarkStatusDto {
+  @ApiProperty({ enum: TransactionStatus })
+  @IsEnum(TransactionStatus)
+  status: TransactionStatus;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  transactionHash?: string;
+}
+
+export class SpeedMetricsQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by bridge name' })
+  @IsOptional()
+  @IsString()
+  bridgeName?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by source chain' })
+  @IsOptional()
+  @IsString()
+  sourceChain?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by destination chain' })
+  @IsOptional()
+  @IsString()
+  destinationChain?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by token' })
+  @IsOptional()
+  @IsString()
+  token?: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of recent transactions used for rolling average',
+    default: 50,
+  })
+  @IsOptional()
+  @IsNumber()
+  @IsPositive()
+  rollingWindow?: number;
+}
+
+export class RouteSpeedMetricDto {
+  bridgeName: string;
+  sourceChain: string;
+  destinationChain: string;
+  token: string;
+  avgDurationMs: number;
+  minDurationMs: number;
+  maxDurationMs: number;
+  totalTransactions: number;
+  successfulTransactions: number;
+  successRate: number;
+  rollingAvgDurationMs: number;
+  lastUpdated: Date;
+}
+
+export class SpeedMetricsResponseDto {
+  metrics: RouteSpeedMetricDto[];
+  generatedAt: Date;
+}

--- a/src/bridge-benchmark/entities/bridge-benchmark.entity.ts
+++ b/src/bridge-benchmark/entities/bridge-benchmark.entity.ts
@@ -1,0 +1,88 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum TransactionStatus {
+  PENDING = 'pending',
+  SUBMITTED = 'submitted',
+  CONFIRMED = 'confirmed',
+  FAILED = 'failed',
+}
+
+export enum ChainType {
+  EVM = 'evm',
+  STELLAR = 'stellar',
+}
+
+@Entity('bridge_benchmarks')
+@Index(['bridgeName', 'sourceChain', 'destinationChain'])
+export class BridgeBenchmark {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'bridge_name' })
+  bridgeName: string;
+
+  @Column({ name: 'source_chain' })
+  sourceChain: string;
+
+  @Column({ name: 'destination_chain' })
+  destinationChain: string;
+
+  @Column()
+  token: string;
+
+  @Column({
+    name: 'source_chain_type',
+    type: 'enum',
+    enum: ChainType,
+    default: ChainType.EVM,
+  })
+  sourceChainType: ChainType;
+
+  @Column({
+    name: 'destination_chain_type',
+    type: 'enum',
+    enum: ChainType,
+    default: ChainType.EVM,
+  })
+  destinationChainType: ChainType;
+
+  @Column({
+    type: 'enum',
+    enum: TransactionStatus,
+    default: TransactionStatus.PENDING,
+  })
+  status: TransactionStatus;
+
+  @Column({ name: 'transaction_hash', nullable: true })
+  transactionHash: string | null;
+
+  @Column({ name: 'destination_tx_hash', nullable: true })
+  destinationTxHash: string | null;
+
+  @Column({ name: 'quote_requested_at', type: 'timestamptz', nullable: true })
+  quoteRequestedAt: Date | null;
+
+  @Column({ name: 'start_time', type: 'timestamptz' })
+  startTime: Date;
+
+  @Column({ name: 'destination_confirmed_at', type: 'timestamptz', nullable: true })
+  destinationConfirmedAt: Date | null;
+
+  @Column({ name: 'completion_time', type: 'timestamptz', nullable: true })
+  completionTime: Date | null;
+
+  @Column({ name: 'duration_ms', type: 'bigint', nullable: true })
+  durationMs: number | null;
+
+  @Column({ name: 'amount', type: 'decimal', precision: 30, scale: 10, nullable: true })
+  amount: number | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/src/bridge-benchmark/migrations/1700000000000-CreateBridgeBenchmarks.ts
+++ b/src/bridge-benchmark/migrations/1700000000000-CreateBridgeBenchmarks.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateBridgeBenchmarks1700000000000 implements MigrationInterface {
+  name = 'CreateBridgeBenchmarks1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "bridge_benchmarks_source_chain_type_enum" AS ENUM ('evm', 'stellar')
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "bridge_benchmarks_destination_chain_type_enum" AS ENUM ('evm', 'stellar')
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "bridge_benchmarks_status_enum" AS ENUM ('pending', 'submitted', 'confirmed', 'failed')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "bridge_benchmarks" (
+        "id"                        UUID                DEFAULT gen_random_uuid() NOT NULL,
+        "bridge_name"               VARCHAR             NOT NULL,
+        "source_chain"              VARCHAR             NOT NULL,
+        "destination_chain"         VARCHAR             NOT NULL,
+        "token"                     VARCHAR             NOT NULL,
+        "source_chain_type"         "bridge_benchmarks_source_chain_type_enum"      NOT NULL DEFAULT 'evm',
+        "destination_chain_type"    "bridge_benchmarks_destination_chain_type_enum" NOT NULL DEFAULT 'evm',
+        "status"                    "bridge_benchmarks_status_enum"                 NOT NULL DEFAULT 'pending',
+        "transaction_hash"          VARCHAR,
+        "destination_tx_hash"       VARCHAR,
+        "quote_requested_at"        TIMESTAMPTZ,
+        "start_time"                TIMESTAMPTZ         NOT NULL,
+        "destination_confirmed_at"  TIMESTAMPTZ,
+        "completion_time"           TIMESTAMPTZ,
+        "duration_ms"               BIGINT,
+        "amount"                    DECIMAL(30, 10),
+        "created_at"                TIMESTAMPTZ         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_bridge_benchmarks" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_bridge_benchmarks_route"
+        ON "bridge_benchmarks" ("bridge_name", "source_chain", "destination_chain")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_bridge_benchmarks_status"
+        ON "bridge_benchmarks" ("status")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_bridge_benchmarks_completion_time"
+        ON "bridge_benchmarks" ("completion_time" DESC)
+        WHERE "completion_time" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_bridge_benchmarks_completion_time"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_bridge_benchmarks_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_bridge_benchmarks_route"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "bridge_benchmarks"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "bridge_benchmarks_status_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "bridge_benchmarks_destination_chain_type_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "bridge_benchmarks_source_chain_type_enum"`);
+  }
+}


### PR DESCRIPTION
Summary

  - Adds BridgeBenchmark entity to track the full bridge transaction lifecycle (quote requested → submitted →       
  destination confirmed)
  - Stores start/completion timestamps and auto-calculates durationMs on confirmation
  - Computes rolling averages over the last 50 transactions per route for the ranking engine
  - Exposes GET /api/v1/bridges/speed-metrics with filterable, aggregated speed metrics
  - Supports both EVM and Stellar chain types

  Endpoints

  - POST /api/v1/bridges/benchmarks — initiate benchmark
  - PATCH /api/v1/bridges/benchmarks/:id/confirm — record destination confirmation
  - PATCH /api/v1/bridges/benchmarks/:id/status — update transaction status
  - GET /api/v1/bridges/speed-metrics — public speed metrics
  
  closes #50 