### PR TITLE
feat: add slippage calculation and risk warning system

### DIFF
--- a/src/components/bridge/SlippageDisplay.tsx
+++ b/src/components/bridge/SlippageDisplay.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
+import { SlippageResult } from "@/hooks/useSlippage";
+
+interface SlippageDisplayProps {
+  slippage: SlippageResult;
+  outputSymbol?: string;
+  className?: string;
+}
+
+export function SlippageDisplay({
+  slippage,
+  outputSymbol = "",
+  className = "",
+}: SlippageDisplayProps) {
+  const { slippagePercent, minimumReceived, isHighSlippage, hasWarning } =
+    slippage;
+
+  const slippageColor = isHighSlippage
+    ? "text-red-500"
+    : slippagePercent > 0.5
+    ? "text-yellow-500"
+    : "text-green-500";
+
+  return (
+    <div className={`flex flex-col gap-2 text-sm ${className}`}>
+      {/* Slippage Row */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1 text-muted-foreground">
+          <span>Slippage</span>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="h-3.5 w-3.5 cursor-pointer" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p>
+                  Slippage is the difference between the expected and actual
+                  amount received. High slippage may result in receiving
+                  significantly less than expected. This can occur during high
+                  volatility or low liquidity conditions.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+
+        <span className={`font-medium ${slippageColor}`}>
+          {hasWarning && (
+            <span className="mr-1" aria-label="warning">
+              ⚠️
+            </span>
+          )}
+          {slippagePercent.toFixed(2)}%
+        </span>
+      </div>
+
+      {/* Minimum Received Row */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1 text-muted-foreground">
+          <span>Minimum received</span>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="h-3.5 w-3.5 cursor-pointer" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p>
+                  The minimum amount you are guaranteed to receive after
+                  accounting for slippage. If the actual output falls below this
+                  value, the transaction will revert.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+
+        <span className="font-medium text-foreground">
+          {minimumReceived} {outputSymbol}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/bridge/SlippageSection.tsx
+++ b/src/components/bridge/SlippageSection.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * SlippageSection — Drop this component into your bridge form wherever
+ * you display route details. It reacts automatically whenever
+ * `transferAmount` or `route` changes.
+ *
+ * Usage:
+ *   <SlippageSection
+ *     transferAmount={amount}
+ *     route={selectedRoute}
+ *     outputSymbol="USDC"
+ *   />
+ */
+
+import React from "react";
+import { useSlippage, SlippageRoute } from "@/hooks/useSlippage";
+import { SlippageDisplay } from "./SlippageDisplay";
+import { SlippageWarning } from "./SlippageWarning";
+
+interface SlippageSectionProps {
+  transferAmount: string;
+  route: SlippageRoute | null | undefined;
+  outputSymbol?: string;
+  /** Override the default 1% warning threshold */
+  warningThreshold?: number;
+  /** Override the default $10,000 low-liquidity threshold */
+  lowLiquidityThreshold?: number;
+  className?: string;
+}
+
+export function SlippageSection({
+  transferAmount,
+  route,
+  outputSymbol,
+  warningThreshold,
+  lowLiquidityThreshold,
+  className = "",
+}: SlippageSectionProps) {
+  const slippage = useSlippage(
+    route,
+    transferAmount,
+    warningThreshold,
+    lowLiquidityThreshold
+  );
+
+  if (!route || !transferAmount || Number(transferAmount) <= 0) return null;
+
+  return (
+    <div className={`flex flex-col gap-3 ${className}`}>
+      <SlippageWarning slippage={slippage} warningThreshold={warningThreshold} />
+      <SlippageDisplay slippage={slippage} outputSymbol={outputSymbol} />
+    </div>
+  );
+}

--- a/src/components/bridge/SlippageWarning.tsx
+++ b/src/components/bridge/SlippageWarning.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React from "react";
+import { AlertTriangle, Droplets } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { SlippageResult, SLIPPAGE_WARNING_THRESHOLD } from "@/hooks/useSlippage";
+
+interface SlippageWarningProps {
+  slippage: SlippageResult;
+  warningThreshold?: number;
+  className?: string;
+}
+
+export function SlippageWarning({
+  slippage,
+  warningThreshold = SLIPPAGE_WARNING_THRESHOLD,
+  className = "",
+}: SlippageWarningProps) {
+  const { isHighSlippage, isLowLiquidity, slippagePercent, hasWarning } =
+    slippage;
+
+  if (!hasWarning) return null;
+
+  return (
+    <div className={`flex flex-col gap-2 ${className}`}>
+      {/* High Slippage Warning */}
+      {isHighSlippage && (
+        <Alert variant="destructive" className="border-red-500/50 bg-red-500/10">
+          <AlertTriangle className="h-4 w-4 text-red-500" />
+          <AlertTitle className="text-red-500 font-semibold">
+            High Slippage Warning
+          </AlertTitle>
+          <AlertDescription className="text-red-400 text-sm">
+            Current slippage is{" "}
+            <span className="font-bold">{slippagePercent.toFixed(2)}%</span>,
+            which exceeds the {warningThreshold}% threshold. You may receive
+            significantly less than expected. Consider splitting your transaction
+            or waiting for better market conditions.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Low Liquidity Warning */}
+      {isLowLiquidity && (
+        <Alert
+          variant="destructive"
+          className="border-yellow-500/50 bg-yellow-500/10"
+        >
+          <Droplets className="h-4 w-4 text-yellow-500" />
+          <AlertTitle className="text-yellow-500 font-semibold">
+            Low Liquidity
+          </AlertTitle>
+          <AlertDescription className="text-yellow-400 text-sm">
+            This route has low liquidity depth. Large transactions may cause
+            higher slippage and price impact. Consider using a smaller amount or
+            an alternative route.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useSlippage.ts
+++ b/src/hooks/useSlippage.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+
+export interface SlippageRoute {
+  inputAmount: string;
+  outputAmount: string;
+  expectedOutput: string;
+  liquidityUSD?: number;
+}
+
+export interface SlippageResult {
+  slippagePercent: number;
+  minimumReceived: string;
+  isHighSlippage: boolean;
+  isLowLiquidity: boolean;
+  hasWarning: boolean;
+}
+
+export const SLIPPAGE_WARNING_THRESHOLD = 1; // 1%
+export const LOW_LIQUIDITY_THRESHOLD_USD = 10_000; // $10,000
+
+export function useSlippage(
+  route: SlippageRoute | null | undefined,
+  transferAmount: string,
+  warningThreshold: number = SLIPPAGE_WARNING_THRESHOLD,
+  lowLiquidityThreshold: number = LOW_LIQUIDITY_THRESHOLD_USD
+): SlippageResult {
+  return useMemo(() => {
+    const defaultResult: SlippageResult = {
+      slippagePercent: 0,
+      minimumReceived: "0",
+      isHighSlippage: false,
+      isLowLiquidity: false,
+      hasWarning: false,
+    };
+
+    if (!route || !transferAmount || Number(transferAmount) <= 0) {
+      return defaultResult;
+    }
+
+    const expected = parseFloat(route.expectedOutput);
+    const actual = parseFloat(route.outputAmount);
+
+    if (isNaN(expected) || isNaN(actual) || expected <= 0) {
+      return defaultResult;
+    }
+
+    const slippagePercent = ((expected - actual) / expected) * 100;
+    const minimumReceived = actual.toFixed(6);
+
+    const isHighSlippage = slippagePercent > warningThreshold;
+    const isLowLiquidity =
+      route.liquidityUSD !== undefined &&
+      route.liquidityUSD < lowLiquidityThreshold;
+
+    return {
+      slippagePercent: Math.max(0, slippagePercent),
+      minimumReceived,
+      isHighSlippage,
+      isLowLiquidity,
+      hasWarning: isHighSlippage || isLowLiquidity,
+    };
+  }, [route, transferAmount, warningThreshold, lowLiquidityThreshold]);
+}


### PR DESCRIPTION
Summary

  - Added useSlippage hook that recalculates slippage on transfer amount and route changes
  - Built SlippageDisplay component showing slippage %, minimum received amount, and tooltips
  - Built SlippageWarning component with alerts for high slippage (>1%) and low liquidity (<$10k)
  - Added SlippageSection as a single drop-in composite component for easy integration
  
  closes #53 