### PR TITLE
Implement Secure Secrets Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,21 @@ dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+build.log
+build_output.log
 
-# local env files
-.env*.local
+# local env files - NEVER commit secrets
 .env
+.env.local
+.env.*.local
+.env.development
+.env.staging
+.env.production
+
+# Keep example files but ignore actual env files
+!.env.example
+!.env.*.example
 
 # vercel
 .vercel
@@ -36,3 +47,11 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 libs/bridge-core/node_modules
+
+# Secret files
+*.key
+*.p12
+*.pfx
+secrets/
+credentials/
+*.secret

--- a/apps/api/src/common/logger/audit-logger.service.ts
+++ b/apps/api/src/common/logger/audit-logger.service.ts
@@ -20,6 +20,17 @@ export interface AuditLogEntry {
 @Injectable()
 export class AuditLoggerService {
   private readonly logger = new Logger('AuditLogger');
+  private readonly secretPatterns = [
+    /api[_-]?key/i,
+    /api[_-]?secret/i,
+    /password/i,
+    /token/i,
+    /private[_-]?key/i,
+    /secret/i,
+    /auth[_-]?token/i,
+    /bearer/i,
+    /credential/i,
+  ];
 
   logRouteSelection(data: {
     requestId?: string;
@@ -34,14 +45,14 @@ export class AuditLoggerService {
       eventType: AuditEventType.ROUTE_SELECTION,
       timestamp: new Date().toISOString(),
       requestId: data.requestId,
-      metadata: {
+      metadata: this.sanitizeMetadata({
         sourceChain: data.sourceChain,
         destinationChain: data.destinationChain,
         amount: this.sanitizeAmount(data.amount),
         selectedAdapter: data.selectedAdapter,
         routeScore: data.routeScore,
         alternativeCount: data.alternativeCount,
-      },
+      }),
     };
     this.logger.log(JSON.stringify(entry));
   }
@@ -59,14 +70,14 @@ export class AuditLoggerService {
       eventType: AuditEventType.ROUTE_EXECUTION,
       timestamp: new Date().toISOString(),
       requestId: data.requestId,
-      metadata: {
+      metadata: this.sanitizeMetadata({
         transactionId: data.transactionId,
         adapter: data.adapter,
         sourceChain: data.sourceChain,
         destinationChain: data.destinationChain,
         status: data.status,
         executionTimeMs: data.executionTimeMs,
-      },
+      }),
     };
     this.logger.log(JSON.stringify(entry));
   }
@@ -81,11 +92,11 @@ export class AuditLoggerService {
       eventType: AuditEventType.TRANSACTION_CREATED,
       timestamp: new Date().toISOString(),
       requestId: data.requestId,
-      metadata: {
+      metadata: this.sanitizeMetadata({
         transactionId: data.transactionId,
         type: data.type,
         totalSteps: data.totalSteps,
-      },
+      }),
     };
     this.logger.log(JSON.stringify(entry));
   }
@@ -101,12 +112,12 @@ export class AuditLoggerService {
       eventType: AuditEventType.TRANSACTION_UPDATED,
       timestamp: new Date().toISOString(),
       requestId: data.requestId,
-      metadata: {
+      metadata: this.sanitizeMetadata({
         transactionId: data.transactionId,
         previousStatus: data.previousStatus,
         newStatus: data.newStatus,
         currentStep: data.currentStep,
-      },
+      }),
     };
     this.logger.log(JSON.stringify(entry));
   }
@@ -123,13 +134,13 @@ export class AuditLoggerService {
       eventType: AuditEventType.FEE_ESTIMATION,
       timestamp: new Date().toISOString(),
       requestId: data.requestId,
-      metadata: {
+      metadata: this.sanitizeMetadata({
         adapter: data.adapter,
         sourceChain: data.sourceChain,
         destinationChain: data.destinationChain,
         estimatedFee: this.sanitizeAmount(data.estimatedFee),
         responseTimeMs: data.responseTimeMs,
-      },
+      }),
     };
     this.logger.log(JSON.stringify(entry));
   }
@@ -146,13 +157,13 @@ export class AuditLoggerService {
       eventType: AuditEventType.BRIDGE_TRANSFER,
       timestamp: new Date().toISOString(),
       requestId: data.requestId,
-      metadata: {
+      metadata: this.sanitizeMetadata({
         transactionId: data.transactionId,
         adapter: data.adapter,
         txHash: data.txHash ? this.sanitizeTxHash(data.txHash) : undefined,
         status: data.status,
         errorCode: data.errorCode,
-      },
+      }),
     };
     this.logger.log(JSON.stringify(entry));
   }
@@ -171,5 +182,52 @@ export class AuditLoggerService {
       return `${hash.slice(0, 8)}...${hash.slice(-8)}`;
     }
     return hash;
+  }
+
+  private sanitizeMetadata(metadata: Record<string, any>): Record<string, any> {
+    const sanitized: Record<string, any> = {};
+    
+    for (const [key, value] of Object.entries(metadata)) {
+      // Check if key matches secret patterns
+      const isSecretKey = this.secretPatterns.some(pattern => pattern.test(key));
+      
+      if (isSecretKey) {
+        // Redact secret values
+        sanitized[key] = '[REDACTED]';
+      } else if (typeof value === 'string' && value.length > 0) {
+        // Check if value looks like a secret (long hex strings, etc.)
+        if (this.looksLikeSecret(value)) {
+          sanitized[key] = this.redactSensitiveValue(value);
+        } else {
+          sanitized[key] = value;
+        }
+      } else if (typeof value === 'object' && value !== null) {
+        // Recursively sanitize nested objects
+        sanitized[key] = this.sanitizeMetadata(value);
+      } else {
+        sanitized[key] = value;
+      }
+    }
+    
+    return sanitized;
+  }
+
+  private looksLikeSecret(value: string): boolean {
+    // Check for common secret patterns
+    const hexPattern = /^[a-f0-9]{32,}$/i; // 32+ char hex strings (likely keys)
+    const bearerPattern = /^bearer\s+/i;
+    const basicPattern = /^basic\s+/i;
+    
+    return hexPattern.test(value) || 
+           bearerPattern.test(value) || 
+           basicPattern.test(value);
+  }
+
+  private redactSensitiveValue(value: string): string {
+    if (value.length <= 8) {
+      return '[REDACTED]';
+    }
+    // Show first 4 and last 4 characters
+    return `${value.slice(0, 4)}...${value.slice(-4)}`;
   }
 }

--- a/apps/api/src/config/config.service.ts
+++ b/apps/api/src/config/config.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { AppConfig, Environment } from './config.interface';
 import { ApiKeyVaultService } from '../security/api-key-vault.service';
+import { validateEnvironment } from './config.validation';
 
 @Injectable()
 export class ConfigService implements OnModuleInit {
@@ -9,6 +10,8 @@ export class ConfigService implements OnModuleInit {
   private vaultInitialized = false;
 
   constructor(private readonly apiKeyVault: ApiKeyVaultService) {
+    // Validate environment variables on startup
+    validateEnvironment(process.env);
     this.config = this.createConfig();
     this.validateConfig();
   }
@@ -17,6 +20,11 @@ export class ConfigService implements OnModuleInit {
     // Initialize vault with keys from environment
     this.initializeVault();
     this.vaultInitialized = true;
+    
+    // Verify vault is properly initialized in production
+    if (this.isProduction) {
+      this.verifyVaultInitialization();
+    }
   }
 
   private initializeVault(): void {
@@ -45,6 +53,27 @@ export class ConfigService implements OnModuleInit {
       this.logger.error(`Failed to initialize vault: ${error.message}`);
       // Continue anyway - vault is optional for development
     }
+  }
+
+  private verifyVaultInitialization(): void {
+    const requiredKeys = ['api-key-main', 'db-password'];
+    const missingKeys: string[] = [];
+
+    for (const keyId of requiredKeys) {
+      try {
+        this.apiKeyVault.retrieveKey(keyId);
+      } catch (error) {
+        missingKeys.push(keyId);
+      }
+    }
+
+    if (missingKeys.length > 0) {
+      throw new Error(
+        `Vault initialization failed in production. Missing keys: ${missingKeys.join(', ')}`,
+      );
+    }
+
+    this.logger.log('Vault verified and all required secrets are accessible');
   }
 
   private createConfig(): AppConfig {

--- a/apps/api/src/config/config.validation.ts
+++ b/apps/api/src/config/config.validation.ts
@@ -4,6 +4,7 @@ export interface EnvValidationSchema {
     type: 'string' | 'number' | 'boolean' | 'url' | 'email';
     default?: string | number | boolean;
     description?: string;
+    secret?: boolean;
   };
 }
 
@@ -46,6 +47,7 @@ export const ENV_VALIDATION_SCHEMA: EnvValidationSchema = {
     required: true,
     type: 'string',
     description: 'Database password',
+    secret: true,
   },
   DB_NAME: {
     required: true,
@@ -62,11 +64,13 @@ export const ENV_VALIDATION_SCHEMA: EnvValidationSchema = {
     required: true,
     type: 'string',
     description: 'External API key',
+    secret: true,
   },
   API_SECRET: {
     required: false,
     type: 'string',
     description: 'External API secret',
+    secret: true,
   },
   API_BASE_URL: {
     required: false,
@@ -79,6 +83,12 @@ export const ENV_VALIDATION_SCHEMA: EnvValidationSchema = {
     type: 'number',
     default: 30000,
     description: 'API request timeout in milliseconds',
+  },
+  VAULT_ENCRYPTION_KEY: {
+    required: false,
+    type: 'string',
+    description: 'Encryption key for vault (32-byte hex string)',
+    secret: true,
   },
   RPC_ETHEREUM: {
     required: true,
@@ -135,6 +145,7 @@ export function validateEnvironment(
   env: Record<string, string | undefined>,
 ): void {
   const errors: string[] = [];
+  const warnings: string[] = [];
 
   for (const [key, schema] of Object.entries(ENV_VALIDATION_SCHEMA)) {
     const value = env[key];
@@ -155,10 +166,33 @@ export function validateEnvironment(
         `Invalid type for ${key}: expected ${schema.type}, got ${typeof value}`,
       );
     }
+
+    // Check for secret fields with placeholder values
+    if (schema.secret && value) {
+      const placeholderPatterns = [
+        'your_',
+        'YOUR_',
+        'generate-',
+        'placeholder',
+        'REPLACE',
+      ];
+      const isPlaceholder = placeholderPatterns.some((pattern) =>
+        value.toLowerCase().includes(pattern.toLowerCase()),
+      );
+      if (isPlaceholder) {
+        warnings.push(
+          `Secret field ${key} contains a placeholder value. This should be replaced with a real secret in production.`,
+        );
+      }
+    }
   }
 
   if (errors.length > 0) {
     throw new Error(`Environment validation failed:\n${errors.join('\n')}`);
+  }
+
+  if (warnings.length > 0) {
+    console.warn(`Environment validation warnings:\n${warnings.join('\n')}`);
   }
 }
 

--- a/test/e2e/bridge-flow.e2e-spec.ts
+++ b/test/e2e/bridge-flow.e2e-spec.ts
@@ -1,0 +1,298 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '../apps/api/src/config/config.module';
+import { ConfigService } from '../apps/api/src/config/config.service';
+import { SecurityModule } from '../apps/api/src/security/security.module';
+import { TransactionsModule } from '../apps/api/src/transactions/transactions.module';
+import { Transaction } from '../apps/api/src/transactions/entities/transaction.entity';
+import { WalletModule } from '../apps/api/src/wallet/wallet.module';
+import { WalletSession } from '../apps/api/src/wallet/entities/wallet-session.entity';
+
+describe('Bridge Flow E2E', () => {
+  let app: INestApplication;
+  let configService: ConfigService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule,
+        SecurityModule,
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [Transaction, WalletSession],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([Transaction, WalletSession]),
+        TransactionsModule,
+        WalletModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    configService = moduleFixture.get<ConfigService>(ConfigService);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('Full Bridge Flow - Stellar Payment', () => {
+    let transactionId: string;
+
+    it('should create a Stellar payment transaction', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/transactions')
+        .send({
+          type: 'stellar-payment',
+          metadata: {
+            sourceAccount: 'GCXMWUAUF37IWOABB3GNXFZB7TBBBHL3IJKUSJUWVEKM3CXEGTHUMDSD',
+            destinationAccount: 'GBRPYHIL2CI3WHZSRJQEMQ5CPQIS2TCCQ7OXJGGUFR7XUWVEPSWR47U',
+            amount: '100',
+            asset: 'native',
+            memo: 'Cross-chain transfer',
+          },
+          totalSteps: 3,
+        })
+        .expect(201);
+
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.type).toBe('stellar-payment');
+      expect(response.body.status).toBe('pending');
+      expect(response.body.currentStep).toBe(0);
+      expect(response.body.totalSteps).toBe(3);
+      
+      transactionId = response.body.id;
+    });
+
+    it('should retrieve the created transaction', async () => {
+      const response = await request(app.getHttpServer())
+        .get(`/transactions/${transactionId}`)
+        .expect(200);
+
+      expect(response.body.id).toBe(transactionId);
+      expect(response.body.type).toBe('stellar-payment');
+      expect(response.body.metadata).toHaveProperty('sourceAccount');
+      expect(response.body.metadata).toHaveProperty('destinationAccount');
+    });
+
+    it('should advance transaction to step 1', async () => {
+      const response = await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({
+          signature: 'TAQCSRX2RIDJNHFYFZXPGXWRWQUXNZKICH57C4YKHUYATFLBMUUPAA2DWS5PDVLXP6GQ6SDFGJJWMKHW',
+        })
+        .expect(200);
+
+      expect(response.body.currentStep).toBe(1);
+      expect(response.body.status).toBe('in-progress');
+    });
+
+    it('should advance transaction to step 2', async () => {
+      const response = await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({
+          fee: '1.5',
+        })
+        .expect(200);
+
+      expect(response.body.currentStep).toBe(2);
+      expect(response.body.status).toBe('in-progress');
+    });
+
+    it('should complete the transaction on final step', async () => {
+      const response = await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({
+          txHash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        })
+        .expect(200);
+
+      expect(response.body.currentStep).toBe(3);
+      expect(response.body.status).toBe('completed');
+      expect(response.body).toHaveProperty('completedAt');
+    });
+  });
+
+  describe('Full Bridge Flow - Hop Protocol', () => {
+    let transactionId: string;
+
+    it('should create a Hop bridge transaction', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/transactions')
+        .send({
+          type: 'hop-bridge',
+          metadata: {
+            token: 'USDC',
+            amount: '500',
+            sourceChain: 'ethereum',
+            destinationChain: 'polygon',
+            recipient: '0x742d35Cc6634C0532925a3b844Bc328e8f94D5dC',
+            deadline: 1000000000,
+            amountOutMin: '490',
+          },
+          totalSteps: 4,
+        })
+        .expect(201);
+
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.type).toBe('hop-bridge');
+      expect(response.body.status).toBe('pending');
+      
+      transactionId = response.body.id;
+    });
+
+    it('should advance through all Hop bridge steps', async () => {
+      // Step 1: Fee estimation
+      await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({ fee: '2.5', gasLimit: '200000' })
+        .expect(200);
+
+      // Step 2: Approval
+      await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({ approvalTxHash: '0xabc123...' })
+        .expect(200);
+
+      // Step 3: Bridge transaction
+      await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({ bridgeTxHash: '0xdef456...' })
+        .expect(200);
+
+      // Step 4: Completion
+      const response = await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({ finalTxHash: '0xghi789...' })
+        .expect(200);
+
+      expect(response.body.status).toBe('completed');
+      expect(response.body.currentStep).toBe(4);
+    });
+  });
+
+  describe('Full Bridge Flow - LayerZero', () => {
+    let transactionId: string;
+
+    it('should create a LayerZero transaction', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/transactions')
+        .send({
+          type: 'layerzero-omnichain',
+          metadata: {
+            token: 'USDT',
+            amount: '1000',
+            sourceChainId: 101,
+            destinationChainId: 102,
+            recipient: '0x9e4c14403d7d2a8f5bD10b2c7c1e0d0e0d0e0d0e',
+          },
+          totalSteps: 3,
+        })
+        .expect(201);
+
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.type).toBe('layerzero-omnichain');
+      
+      transactionId = response.body.id;
+    });
+
+    it('should complete LayerZero transaction flow', async () => {
+      // Step 1: Quote
+      await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({ quote: { fee: '3.0', estimatedTime: 300 } })
+        .expect(200);
+
+      // Step 2: Send
+      await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({ sendTxHash: '0xlayerzero123' })
+        .expect(200);
+
+      // Step 3: Receive
+      const response = await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}/advance`)
+        .send({ receiveTxHash: '0xlayerzero456' })
+        .expect(200);
+
+      expect(response.body.status).toBe('completed');
+    });
+  });
+
+  describe('Error Handling - Invalid Transaction', () => {
+    it('should return 404 for non-existent transaction', async () => {
+      await request(app.getHttpServer())
+        .get('/transactions/invalid-id')
+        .expect(404);
+    });
+
+    it('should return 400 for invalid transaction creation', async () => {
+      await request(app.getHttpServer())
+        .post('/transactions')
+        .send({
+          type: 'invalid-type',
+          metadata: {},
+        })
+        .expect(400);
+    });
+
+    it('should handle transaction failure', async () => {
+      const createResponse = await request(app.getHttpServer())
+        .post('/transactions')
+        .send({
+          type: 'stellar-payment',
+          metadata: {
+            sourceAccount: 'GCXMWUAUF37IWOABB3GNXFZB7TBBBHL3IJKUSJUWVEKM3CXEGTHUMDSD',
+            destinationAccount: 'GBRPYHIL2CI3WHZSRJQEMQ5CPQIS2TCCQ7OXJGGUFR7XUWVEPSWR47U',
+            amount: '100',
+          },
+          totalSteps: 3,
+        })
+        .expect(201);
+
+      const transactionId = createResponse.body.id;
+
+      await request(app.getHttpServer())
+        .put(`/transactions/${transactionId}`)
+        .send({
+          status: 'failed',
+          error: 'Insufficient funds',
+        })
+        .expect(200);
+
+      const response = await request(app.getHttpServer())
+        .get(`/transactions/${transactionId}`)
+        .expect(200);
+
+      expect(response.body.status).toBe('failed');
+      expect(response.body.error).toBe('Insufficient funds');
+    });
+  });
+
+  describe('Configuration and Security', () => {
+    it('should have config service available', () => {
+      expect(configService).toBeDefined();
+      expect(configService.isDevelopment).toBe(true);
+    });
+
+    it('should not expose secrets in config', () => {
+      const config = configService.all;
+      
+      // These should be empty strings, not actual secrets
+      expect(config.api.apiKey).toBe('');
+      expect(config.api.apiSecret).toBe('');
+      expect(config.database.password).toBe('');
+    });
+
+    it('should retrieve secrets via vault methods only', () => {
+      // Vault methods should work (even with test data)
+      expect(typeof configService.getApiKey).toBe('function');
+      expect(typeof configService.getApiSecret).toBe('function');
+      expect(typeof configService.getDatabasePassword).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
summary or pr 

Task 1: E2E Tests for Full Bridge Flow
Created test/e2e/bridge-flow.e2e-spec.ts with comprehensive tests:

Stellar Payment Flow: Tests transaction creation, retrieval, step advancement through 3 steps, and completion
Hop Protocol Flow: Tests 4-step bridge transaction (fee estimation, approval, bridge, completion)
LayerZero Flow: Tests 3-step omnichain transaction (quote, send, receive)
Error Handling: Tests non-existent transactions, invalid creation, and failure scenarios
Security Verification: Tests that config service doesn't expose secrets and vault methods work correctly
Task 2: Secret Protection
Environment Variable Validation
Added secret flag to EnvValidationSchema interface for API_KEY, API_SECRET, DB_PASSWORD, VAULT_ENCRYPTION_KEY
Added placeholder detection to warn when secrets contain placeholder values like "your_api_key_here"
Integrated validateEnvironment call in ConfigService constructor
Startup Validation
Added verifyVaultInitialization method that runs in production
Verifies required vault keys (api-key-main, db-password) are accessible
Throws error if vault initialization fails in production
Git Protection
Updated .gitignore to block all actual env files (.env, .env.development, .env.staging, .env.production)
Kept example files (.env.example, .env.*.example) for reference
Added patterns for secret files (*.key, *.p12, *.pfx, secrets/, credentials/, *.secret)
Added build.log and build_output.log to prevent accidental secret logging
Log Sanitization
Enhanced AuditLoggerService with secret pattern detection (api_key, password, token, private_key, secret, auth_token, bearer, credential)
Added sanitizeMetadata method that recursively redacts secrets from log metadata
Added looksLikeSecret method to detect hex strings (32+ chars), bearer tokens, basic auth
Added redactSensitiveValue method to show only first/last 4 characters
Applied sanitization to all log methods (route selection, execution, transaction, fee estimation, bridge transfer)

closes #287 
closes #288 