### PR TITLE
feat: Soroban recommendation cache, Stellar metrics exporter, Soroban sandbox

### DIFF
--- a/src/cache/recommendations/stellar/index.ts
+++ b/src/cache/recommendations/stellar/index.ts
@@ -1,0 +1,131 @@
+/**
+ * Soroban route recommendation cache (#390).
+ *
+ * Recommendations are expensive to compute: they involve fee estimation,
+ * liquidity probing, and ranking across multiple providers. Re-running the
+ * full pipeline for every UI render or API hit wastes compute. This module
+ * exposes a small in-memory cache with TTL expiry and targeted invalidation.
+ *
+ * Cache keys are derived from the recommendation request shape so semantically
+ * equivalent requests share a single cache slot.
+ */
+
+export interface SorobanRouteRecommendation {
+  routeId: string;
+  fromAsset: string;
+  toAsset: string;
+  estimatedFee: string;
+  estimatedTime: number;
+  provider: string;
+  score: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SorobanRecommendationRequest {
+  fromAsset: string;
+  toAsset: string;
+  amount: string;
+  /** Optional sender address — different addresses can have different liquidity/path preferences. */
+  sender?: string;
+}
+
+interface CacheEntry {
+  recommendations: SorobanRouteRecommendation[];
+  expiresAt: number;
+  storedAt: number;
+}
+
+export interface SorobanRecommendationCacheOptions {
+  /** TTL in milliseconds. Default: 30 seconds. */
+  ttlMs?: number;
+  /** Maximum number of entries before LRU eviction. Default: 500. */
+  maxEntries?: number;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+const DEFAULT_MAX_ENTRIES = 500;
+
+export class SorobanRecommendationCache {
+  private store = new Map<string, CacheEntry>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(options: SorobanRecommendationCacheOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  }
+
+  /**
+   * Build a stable cache key for a recommendation request.
+   * Keys are case-insensitive on asset codes and ignore amount casing whitespace.
+   */
+  static keyFor(req: SorobanRecommendationRequest): string {
+    const sender = req.sender ?? "";
+    return [
+      req.fromAsset.trim().toUpperCase(),
+      req.toAsset.trim().toUpperCase(),
+      req.amount.trim(),
+      sender.trim(),
+    ].join("|");
+  }
+
+  get(req: SorobanRecommendationRequest): SorobanRouteRecommendation[] | null {
+    const key = SorobanRecommendationCache.keyFor(req);
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    // LRU bump: re-set so the entry moves to the tail of insertion order.
+    this.store.delete(key);
+    this.store.set(key, entry);
+    return entry.recommendations;
+  }
+
+  set(req: SorobanRecommendationRequest, recommendations: SorobanRouteRecommendation[]): void {
+    const key = SorobanRecommendationCache.keyFor(req);
+    if (this.store.size >= this.maxEntries && !this.store.has(key)) {
+      const oldestKey = this.store.keys().next().value;
+      if (oldestKey !== undefined) this.store.delete(oldestKey);
+    }
+    this.store.set(key, {
+      recommendations,
+      expiresAt: Date.now() + this.ttlMs,
+      storedAt: Date.now(),
+    });
+  }
+
+  /** Drop a single request's cached recommendations. */
+  invalidate(req: SorobanRecommendationRequest): boolean {
+    return this.store.delete(SorobanRecommendationCache.keyFor(req));
+  }
+
+  /** Drop every cached entry that includes the given asset on either side of the route. */
+  invalidateByAsset(asset: string): number {
+    const needle = asset.trim().toUpperCase();
+    let removed = 0;
+    for (const key of this.store.keys()) {
+      const [from, to] = key.split("|");
+      if (from === needle || to === needle) {
+        this.store.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /** Drop every cached entry. */
+  clear(): void {
+    this.store.clear();
+  }
+
+  /** Number of live (non-expired) entries. Expired entries are pruned in-place. */
+  size(): number {
+    const now = Date.now();
+    for (const [key, entry] of this.store) {
+      if (entry.expiresAt <= now) this.store.delete(key);
+    }
+    return this.store.size;
+  }
+}

--- a/src/exporters/metrics/stellar/index.ts
+++ b/src/exporters/metrics/stellar/index.ts
@@ -1,0 +1,261 @@
+/**
+ * Stellar cross-chain metrics exporter (#391).
+ *
+ * Collects per-route bridge metrics and serialises them in Prometheus text
+ * exposition format so external observability stacks (Prometheus, Grafana,
+ * VictoriaMetrics, etc.) can scrape them via the standard `/metrics` endpoint.
+ *
+ * The exporter is intentionally provider-agnostic: callers feed it events
+ * (`recordTransaction`, `recordLatency`, etc.) and it tracks counters,
+ * gauges, and histograms.
+ */
+
+export type MetricLabels = Record<string, string>;
+
+interface Counter {
+  type: "counter";
+  help: string;
+  values: Map<string, number>;
+}
+
+interface Gauge {
+  type: "gauge";
+  help: string;
+  values: Map<string, number>;
+}
+
+interface Histogram {
+  type: "histogram";
+  help: string;
+  buckets: number[];
+  observations: Map<string, { bucketCounts: number[]; sum: number; count: number }>;
+}
+
+type Metric = Counter | Gauge | Histogram;
+
+const DEFAULT_LATENCY_BUCKETS_MS = [50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 30_000];
+
+function serialiseLabels(labels: MetricLabels): string {
+  const entries = Object.entries(labels);
+  if (entries.length === 0) return "";
+  return entries
+    .map(([k, v]) => `${k}="${String(v).replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`)
+    .join(",");
+}
+
+function labelKey(labels: MetricLabels): string {
+  return Object.keys(labels)
+    .sort()
+    .map((k) => `${k}=${labels[k]}`)
+    .join("|");
+}
+
+export class StellarMetricsExporter {
+  private readonly metrics = new Map<string, Metric>();
+  private readonly namespace: string;
+
+  constructor(namespace = "bridgewise_stellar") {
+    this.namespace = namespace;
+    this.registerDefaults();
+  }
+
+  private registerDefaults(): void {
+    this.registerCounter("transactions_total", "Total Stellar bridge transactions, partitioned by outcome");
+    this.registerCounter("transaction_failures_total", "Total failed Stellar bridge transactions");
+    this.registerGauge("active_routes", "Currently active Stellar bridge routes");
+    this.registerGauge("liquidity_usd", "Available liquidity per route in USD");
+    this.registerHistogram("transaction_latency_ms", "Stellar bridge transaction latency in milliseconds", DEFAULT_LATENCY_BUCKETS_MS);
+    this.registerHistogram("fee_usd", "Fee per transaction in USD", [0.01, 0.05, 0.1, 0.25, 0.5, 1, 5, 10, 50]);
+  }
+
+  // ── Metric registration ──────────────────────────────────────────────────
+
+  private registerCounter(name: string, help: string): void {
+    this.metrics.set(name, { type: "counter", help, values: new Map() });
+  }
+
+  private registerGauge(name: string, help: string): void {
+    this.metrics.set(name, { type: "gauge", help, values: new Map() });
+  }
+
+  private registerHistogram(name: string, help: string, buckets: number[]): void {
+    this.metrics.set(name, {
+      type: "histogram",
+      help,
+      buckets: [...buckets].sort((a, b) => a - b),
+      observations: new Map(),
+    });
+  }
+
+  // ── Recording API ────────────────────────────────────────────────────────
+
+  recordTransaction(labels: { route: string; status: "success" | "failure" | "timeout" }): void {
+    this.incrementCounter("transactions_total", labels);
+    if (labels.status !== "success") {
+      this.incrementCounter("transaction_failures_total", { route: labels.route, reason: labels.status });
+    }
+  }
+
+  recordLatency(labels: { route: string }, latencyMs: number): void {
+    this.observeHistogram("transaction_latency_ms", labels, latencyMs);
+  }
+
+  recordFee(labels: { route: string; asset: string }, feeUsd: number): void {
+    this.observeHistogram("fee_usd", labels, feeUsd);
+  }
+
+  setActiveRoutes(count: number, labels: MetricLabels = {}): void {
+    this.setGauge("active_routes", labels, count);
+  }
+
+  setLiquidity(labels: { route: string }, liquidityUsd: number): void {
+    this.setGauge("liquidity_usd", labels, liquidityUsd);
+  }
+
+  // ── Low-level mutators ───────────────────────────────────────────────────
+
+  private incrementCounter(name: string, labels: MetricLabels, by = 1): void {
+    const metric = this.metrics.get(name);
+    if (!metric || metric.type !== "counter") throw new Error(`Unknown counter: ${name}`);
+    const key = labelKey(labels);
+    metric.values.set(key, (metric.values.get(key) ?? 0) + by);
+  }
+
+  private setGauge(name: string, labels: MetricLabels, value: number): void {
+    const metric = this.metrics.get(name);
+    if (!metric || metric.type !== "gauge") throw new Error(`Unknown gauge: ${name}`);
+    metric.values.set(labelKey(labels), value);
+  }
+
+  private observeHistogram(name: string, labels: MetricLabels, value: number): void {
+    const metric = this.metrics.get(name);
+    if (!metric || metric.type !== "histogram") throw new Error(`Unknown histogram: ${name}`);
+    const key = labelKey(labels);
+    let entry = metric.observations.get(key);
+    if (!entry) {
+      entry = { bucketCounts: new Array(metric.buckets.length).fill(0), sum: 0, count: 0 };
+      metric.observations.set(key, entry);
+    }
+    entry.sum += value;
+    entry.count += 1;
+    for (let i = 0; i < metric.buckets.length; i += 1) {
+      if (value <= metric.buckets[i]) entry.bucketCounts[i] += 1;
+    }
+  }
+
+  /** Reset all metrics. Intended for tests; production callers should not need this. */
+  reset(): void {
+    for (const metric of this.metrics.values()) {
+      if (metric.type === "counter" || metric.type === "gauge") {
+        metric.values.clear();
+      } else {
+        metric.observations.clear();
+      }
+    }
+  }
+
+  // ── Serialisation ────────────────────────────────────────────────────────
+
+  /**
+   * Render the current metric snapshot as Prometheus text exposition (v0.0.4).
+   * Suitable for serving from a `GET /metrics` HTTP endpoint with content type
+   * `text/plain; version=0.0.4`.
+   */
+  toPrometheus(): string {
+    const lines: string[] = [];
+    for (const [name, metric] of this.metrics) {
+      const fullName = `${this.namespace}_${name}`;
+      lines.push(`# HELP ${fullName} ${metric.help}`);
+      lines.push(`# TYPE ${fullName} ${metric.type}`);
+
+      if (metric.type === "counter" || metric.type === "gauge") {
+        if (metric.values.size === 0) {
+          lines.push(`${fullName} 0`);
+        } else {
+          for (const [labelStr, value] of metric.values) {
+            const labels = labelStr ? `{${this.formatLabelKey(labelStr)}}` : "";
+            lines.push(`${fullName}${labels} ${value}`);
+          }
+        }
+      } else {
+        // histogram
+        for (const [labelStr, obs] of metric.observations) {
+          const baseLabels = labelStr ? this.formatLabelKey(labelStr) : "";
+          for (let i = 0; i < metric.buckets.length; i += 1) {
+            const leLabel = `le="${metric.buckets[i]}"`;
+            const labels = baseLabels ? `{${baseLabels},${leLabel}}` : `{${leLabel}}`;
+            lines.push(`${fullName}_bucket${labels} ${obs.bucketCounts[i]}`);
+          }
+          const infLabel = `le="+Inf"`;
+          const labelsInf = baseLabels ? `{${baseLabels},${infLabel}}` : `{${infLabel}}`;
+          lines.push(`${fullName}_bucket${labelsInf} ${obs.count}`);
+          const sumLabels = baseLabels ? `{${baseLabels}}` : "";
+          lines.push(`${fullName}_sum${sumLabels} ${obs.sum}`);
+          lines.push(`${fullName}_count${sumLabels} ${obs.count}`);
+        }
+      }
+    }
+    return lines.join("\n") + "\n";
+  }
+
+  /**
+   * Render the current metric snapshot as plain JSON. Useful for systems
+   * that don't speak Prometheus (e.g. OpenTelemetry collectors, custom
+   * ingesters, debugging endpoints).
+   */
+  toJSON(): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const [name, metric] of this.metrics) {
+      const fullName = `${this.namespace}_${name}`;
+      if (metric.type === "counter" || metric.type === "gauge") {
+        out[fullName] = {
+          type: metric.type,
+          help: metric.help,
+          values: Array.from(metric.values, ([labels, value]) => ({
+            labels: this.parseLabelKey(labels),
+            value,
+          })),
+        };
+      } else {
+        out[fullName] = {
+          type: metric.type,
+          help: metric.help,
+          buckets: metric.buckets,
+          observations: Array.from(metric.observations, ([labels, obs]) => ({
+            labels: this.parseLabelKey(labels),
+            bucketCounts: obs.bucketCounts,
+            sum: obs.sum,
+            count: obs.count,
+          })),
+        };
+      }
+    }
+    return out;
+  }
+
+  private formatLabelKey(labelStr: string): string {
+    const parts = labelStr.split("|").filter(Boolean);
+    return parts
+      .map((p) => {
+        const idx = p.indexOf("=");
+        const k = p.slice(0, idx);
+        const v = p.slice(idx + 1);
+        return `${k}="${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+      })
+      .join(",");
+  }
+
+  private parseLabelKey(labelStr: string): MetricLabels {
+    if (!labelStr) return {};
+    const out: MetricLabels = {};
+    for (const p of labelStr.split("|")) {
+      if (!p) continue;
+      const idx = p.indexOf("=");
+      out[p.slice(0, idx)] = p.slice(idx + 1);
+    }
+    return out;
+  }
+}
+
+/** Singleton instance for the common case where one exporter is shared app-wide. */
+export const stellarMetrics = new StellarMetricsExporter();

--- a/test/sandbox/stellar/index.ts
+++ b/test/sandbox/stellar/index.ts
@@ -1,0 +1,274 @@
+/**
+ * Soroban integration sandbox environment (#392).
+ *
+ * Provides an isolated, in-memory mock of the parts of the Stellar/Soroban
+ * stack that bridge integration tests typically touch: accounts with balances,
+ * contract calls with scripted responses, transaction submission with
+ * configurable outcomes (success/failure/timeout), and an event log so tests
+ * can assert what was invoked.
+ *
+ * No network access. No real keypairs. No real ledger. Tests can spin up a
+ * sandbox per case, mutate state freely, and discard it when done.
+ *
+ * Usage:
+ *   import { SorobanSandbox, SandboxScenario } from "../../test/sandbox/stellar";
+ *
+ *   const sandbox = new SorobanSandbox();
+ *   sandbox.createAccount("GABC...", { XLM: "1000.0000000" });
+ *   sandbox.registerContract("CD...", { call_swap: () => ({ ok: true }) });
+ *   sandbox.submitTransaction({ source: "GABC...", op: "call", ... });
+ *   expect(sandbox.events()).toContainEqual({ kind: "tx", status: "success", ... });
+ */
+
+export type AssetCode = string;
+export type AccountId = string;
+export type ContractId = string;
+
+export interface AccountState {
+  accountId: AccountId;
+  balances: Record<AssetCode, string>;
+  sequence: bigint;
+  flags: { authRequired: boolean; authRevocable: boolean };
+}
+
+export type ContractMethod = (args: unknown[]) => unknown;
+
+export interface MockContract {
+  contractId: ContractId;
+  methods: Record<string, ContractMethod>;
+}
+
+export type SandboxScenario = "success" | "failure" | "timeout" | "random";
+
+export interface SandboxTransaction {
+  source: AccountId;
+  op: "payment" | "call" | "create_account";
+  /** For payment ops: { destination, asset, amount }. For calls: { contractId, method, args }. */
+  payload: Record<string, unknown>;
+}
+
+export type SandboxEvent =
+  | { kind: "tx"; status: "success" | "failure" | "timeout"; tx: SandboxTransaction; result?: unknown; error?: string; timestamp: number }
+  | { kind: "balance_change"; account: AccountId; asset: AssetCode; before: string; after: string; timestamp: number }
+  | { kind: "contract_call"; contractId: ContractId; method: string; args: unknown[]; result: unknown; timestamp: number };
+
+export interface SorobanSandboxOptions {
+  /** Default scenario applied when `submitTransaction` doesn't specify one. */
+  defaultScenario?: SandboxScenario;
+  /** When true, mutations to balances/state are echoed to the event log. Default: true. */
+  emitBalanceEvents?: boolean;
+  /** Seed for deterministic `random` scenarios. */
+  seed?: number;
+}
+
+export class SorobanSandbox {
+  private readonly accounts = new Map<AccountId, AccountState>();
+  private readonly contracts = new Map<ContractId, MockContract>();
+  private readonly eventLog: SandboxEvent[] = [];
+  private readonly options: Required<SorobanSandboxOptions>;
+  private rngState: number;
+
+  constructor(options: SorobanSandboxOptions = {}) {
+    this.options = {
+      defaultScenario: options.defaultScenario ?? "success",
+      emitBalanceEvents: options.emitBalanceEvents ?? true,
+      seed: options.seed ?? 1,
+    };
+    this.rngState = this.options.seed;
+  }
+
+  // ── Account management ───────────────────────────────────────────────────
+
+  createAccount(accountId: AccountId, balances: Record<AssetCode, string> = { XLM: "0" }): AccountState {
+    if (this.accounts.has(accountId)) {
+      throw new Error(`Account already exists: ${accountId}`);
+    }
+    const state: AccountState = {
+      accountId,
+      balances: { ...balances },
+      sequence: 0n,
+      flags: { authRequired: false, authRevocable: false },
+    };
+    this.accounts.set(accountId, state);
+    return state;
+  }
+
+  getAccount(accountId: AccountId): AccountState | undefined {
+    return this.accounts.get(accountId);
+  }
+
+  setBalance(accountId: AccountId, asset: AssetCode, amount: string): void {
+    const account = this.accounts.get(accountId);
+    if (!account) throw new Error(`Unknown account: ${accountId}`);
+    const before = account.balances[asset] ?? "0";
+    account.balances[asset] = amount;
+    if (this.options.emitBalanceEvents) {
+      this.eventLog.push({
+        kind: "balance_change",
+        account: accountId,
+        asset,
+        before,
+        after: amount,
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  // ── Contract management ──────────────────────────────────────────────────
+
+  registerContract(contractId: ContractId, methods: Record<string, ContractMethod>): void {
+    this.contracts.set(contractId, { contractId, methods });
+  }
+
+  invokeContract(contractId: ContractId, method: string, args: unknown[] = []): unknown {
+    const contract = this.contracts.get(contractId);
+    if (!contract) throw new Error(`Unknown contract: ${contractId}`);
+    const fn = contract.methods[method];
+    if (!fn) throw new Error(`Unknown method ${method} on contract ${contractId}`);
+    const result = fn(args);
+    this.eventLog.push({
+      kind: "contract_call",
+      contractId,
+      method,
+      args,
+      result,
+      timestamp: Date.now(),
+    });
+    return result;
+  }
+
+  // ── Transaction submission ───────────────────────────────────────────────
+
+  /**
+   * Submit a transaction. The `scenario` decides the outcome — overriding the
+   * sandbox default — so individual tests can simulate success, failure, or
+   * timeout without touching shared state.
+   */
+  submitTransaction(tx: SandboxTransaction, scenario?: SandboxScenario): SandboxEvent {
+    const account = this.accounts.get(tx.source);
+    if (!account) {
+      const event: SandboxEvent = {
+        kind: "tx",
+        status: "failure",
+        tx,
+        error: `Source account not found: ${tx.source}`,
+        timestamp: Date.now(),
+      };
+      this.eventLog.push(event);
+      return event;
+    }
+
+    const resolved = this.resolveScenario(scenario ?? this.options.defaultScenario);
+
+    if (resolved === "timeout") {
+      const event: SandboxEvent = { kind: "tx", status: "timeout", tx, timestamp: Date.now() };
+      this.eventLog.push(event);
+      return event;
+    }
+    if (resolved === "failure") {
+      const event: SandboxEvent = {
+        kind: "tx",
+        status: "failure",
+        tx,
+        error: "Simulated failure",
+        timestamp: Date.now(),
+      };
+      this.eventLog.push(event);
+      return event;
+    }
+
+    // Success: dispatch on op
+    let result: unknown;
+    try {
+      if (tx.op === "call") {
+        const { contractId, method, args } = tx.payload as { contractId: ContractId; method: string; args?: unknown[] };
+        result = this.invokeContract(contractId, method, args ?? []);
+      } else if (tx.op === "payment") {
+        result = this.applyPayment(tx);
+      } else if (tx.op === "create_account") {
+        const { destination, starting_balance } = tx.payload as { destination: AccountId; starting_balance: string };
+        this.createAccount(destination, { XLM: starting_balance });
+        result = { destination };
+      }
+      account.sequence += 1n;
+    } catch (err) {
+      const event: SandboxEvent = {
+        kind: "tx",
+        status: "failure",
+        tx,
+        error: (err as Error).message,
+        timestamp: Date.now(),
+      };
+      this.eventLog.push(event);
+      return event;
+    }
+
+    const event: SandboxEvent = {
+      kind: "tx",
+      status: "success",
+      tx,
+      result,
+      timestamp: Date.now(),
+    };
+    this.eventLog.push(event);
+    return event;
+  }
+
+  private applyPayment(tx: SandboxTransaction): { source: AccountId; destination: AccountId; asset: AssetCode; amount: string } {
+    const { destination, asset, amount } = tx.payload as { destination: AccountId; asset: AssetCode; amount: string };
+    const src = this.accounts.get(tx.source);
+    const dst = this.accounts.get(destination);
+    if (!src) throw new Error(`Source account not found: ${tx.source}`);
+    if (!dst) throw new Error(`Destination account not found: ${destination}`);
+
+    const srcBalanceNum = Number(src.balances[asset] ?? "0");
+    const amountNum = Number(amount);
+    if (Number.isNaN(srcBalanceNum) || Number.isNaN(amountNum)) {
+      throw new Error(`Invalid numeric balance/amount for asset ${asset}`);
+    }
+    if (srcBalanceNum < amountNum) {
+      throw new Error(`Insufficient balance: ${src.balances[asset] ?? "0"} < ${amount}`);
+    }
+    const newSrc = (srcBalanceNum - amountNum).toString();
+    const newDst = ((Number(dst.balances[asset] ?? "0")) + amountNum).toString();
+    this.setBalance(tx.source, asset, newSrc);
+    this.setBalance(destination, asset, newDst);
+    return { source: tx.source, destination, asset, amount };
+  }
+
+  private resolveScenario(scenario: SandboxScenario): Exclude<SandboxScenario, "random"> {
+    if (scenario !== "random") return scenario;
+    // Deterministic LCG so tests stay reproducible across runs given the same seed
+    this.rngState = (this.rngState * 1664525 + 1013904223) >>> 0;
+    const r = this.rngState / 0xffffffff;
+    if (r < 0.6) return "success";
+    if (r < 0.85) return "failure";
+    return "timeout";
+  }
+
+  // ── Introspection ────────────────────────────────────────────────────────
+
+  events(): readonly SandboxEvent[] {
+    return this.eventLog;
+  }
+
+  clearEvents(): void {
+    this.eventLog.length = 0;
+  }
+
+  /** Reset balances, contracts, and event log. Useful between test cases. */
+  reset(): void {
+    this.accounts.clear();
+    this.contracts.clear();
+    this.eventLog.length = 0;
+    this.rngState = this.options.seed;
+  }
+}
+
+/** Convenience factory: build a sandbox pre-seeded with two funded accounts. */
+export function createDefaultSandbox(): SorobanSandbox {
+  const sandbox = new SorobanSandbox();
+  sandbox.createAccount("GSANDBOX_ALICE", { XLM: "10000.0000000", USDC: "1000.0000000" });
+  sandbox.createAccount("GSANDBOX_BOB", { XLM: "10000.0000000", USDC: "1000.0000000" });
+  return sandbox;
+}


### PR DESCRIPTION
## Summary


- Closes #390 — Add `SorobanRecommendationCache` at `src/cache/recommendations/stellar/index.ts`: in-memory cache for Soroban route recommendations with configurable TTL (default 30s), LRU eviction at capacity (default 500), stable key derivation from request shape, per-request `invalidate()`, and bulk `invalidateByAsset()` for when liquidity for a given asset changes.

- Closes #391 — Add `StellarMetricsExporter` at `src/exporters/metrics/stellar/index.ts`: provider-agnostic metrics collector with counters, gauges, and histograms. Built-in metrics: `transactions_total`, `transaction_failures_total`, `transaction_latency_ms`, `fee_usd`, `active_routes`, `liquidity_usd`. Emits Prometheus text exposition format via `toPrometheus()` (ready to serve from `GET /metrics` with `Content-Type: text/plain; version=0.0.4`) and JSON via `toJSON()` for non-Prometheus consumers. Exports a `stellarMetrics` singleton.

- Closes #392 — Add `SorobanSandbox` at `test/sandbox/stellar/index.ts`: in-memory mock of accounts, contracts, balances, and transactions. Tests can `createAccount`, `registerContract`, and `submitTransaction` with scenario overrides (`success` / `failure` / `timeout` / deterministic `random` with seedable LCG). Event log lets tests assert exactly what was invoked. Includes `createDefaultSandbox()` factory pre-seeded with two funded accounts.
- Closes #266 
## Test plan

- [ ] Cache: write, read, expire after TTL, evict LRU at capacity, `invalidateByAsset` removes entries on either side of a route
- [ ] Exporter: record a few transactions/latencies/fees, scrape via `toPrometheus()` — output is parseable by `promtool check metrics`
- [ ] Sandbox: payment op decrements source / increments destination balance; insufficient balance fails the tx; `random` scenario is deterministic given the seed; event log captures every state transition