### PR TITLE
Feat/stellar

### DIFF
--- a/src/scoring/routes/stellar/index.ts
+++ b/src/scoring/routes/stellar/index.ts
@@ -1,0 +1,119 @@
+/**
+ * Dynamic scoring helpers for Stellar routes.
+ *
+ * This module computes a network-aware score from real-time route telemetry
+ * such as latency, failure pressure, liquidity availability, and route health.
+ * Stellar route scoring is intentionally conservative when live metrics are
+ * unavailable: it falls back to a neutral score rather than biasing ranking.
+ */
+
+export interface StellarNetworkMetrics {
+  latencyMs?: number;          // Observed request latency for this route
+  failureRate?: number;        // Observed failure rate (0-1)
+  liquidityUsd?: number;       // Available liquidity in USD for route execution
+  availability?: number;       // Current route availability (0-1)
+  activeRouteCount?: number;   // Number of competing active routes on the same path
+}
+
+export interface StellarRouteNetworkFrame {
+  networkMetrics?: StellarNetworkMetrics;
+  successRate?: number;
+}
+
+interface NetworkMetricConfig {
+  value?: number;
+  pool: number[];
+  lowerIsBetter: boolean;
+  weight: number;
+}
+
+export function calculateStellarNetworkScore(
+  route: StellarRouteNetworkFrame,
+  allRoutes: StellarRouteNetworkFrame[]
+): number {
+  const network = route.networkMetrics;
+  if (!network) {
+    return 0.5;
+  }
+
+  const routesWithNetwork = allRoutes.map(r => r.networkMetrics ?? {});
+
+  const failureRate = network.failureRate ?? (route.successRate != null ? 1 - route.successRate : undefined);
+  const failurePool = allRoutes
+    .map(r => r.networkMetrics?.failureRate ?? (r.successRate != null ? 1 - r.successRate : undefined))
+    .filter(isFiniteNumber);
+
+  const config: NetworkMetricConfig[] = [
+    {
+      value: network.latencyMs,
+      pool: allRoutes.map(r => r.networkMetrics?.latencyMs).filter(isFiniteNumber),
+      lowerIsBetter: true,
+      weight: 0.35,
+    },
+    {
+      value: failureRate,
+      pool: failurePool,
+      lowerIsBetter: true,
+      weight: 0.25,
+    },
+    {
+      value: network.availability,
+      pool: allRoutes.map(r => r.networkMetrics?.availability).filter(isFiniteNumber),
+      lowerIsBetter: false,
+      weight: 0.2,
+    },
+    {
+      value: network.liquidityUsd,
+      pool: allRoutes.map(r => r.networkMetrics?.liquidityUsd).filter(isFiniteNumber),
+      lowerIsBetter: false,
+      weight: 0.15,
+    },
+    {
+      value: network.activeRouteCount,
+      pool: allRoutes.map(r => r.networkMetrics?.activeRouteCount).filter(isFiniteNumber),
+      lowerIsBetter: true,
+      weight: 0.05,
+    },
+  ];
+
+  const scoredMetrics = config
+    .map(metric => ({
+      ...metric,
+      normalized: normalizeNetworkMetric(metric.value, metric.pool, metric.lowerIsBetter),
+    }))
+    .filter(metric => metric.normalized !== null);
+
+  if (scoredMetrics.length === 0) {
+    return 0.5;
+  }
+
+  const totalWeight = scoredMetrics.reduce((sum, metric) => sum + metric.weight, 0);
+  if (totalWeight === 0) {
+    return 0.5;
+  }
+
+  return scoredMetrics.reduce((score, metric) => score + metric.normalized * metric.weight, 0) / totalWeight;
+}
+
+function normalizeNetworkMetric(
+  value: number | undefined,
+  pool: number[],
+  lowerIsBetter: boolean
+): number | null {
+  if (!isFiniteNumber(value) || pool.length === 0) {
+    return null;
+  }
+
+  const min = Math.min(...pool);
+  const max = Math.max(...pool);
+  if (min === max) {
+    return 0.5;
+  }
+
+  const normalized = (value - min) / (max - min);
+  return lowerIsBetter ? 1 - normalized : normalized;
+}
+
+function isFiniteNumber(value: number | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/src/services/__tests__/route-ranker.spec.ts
+++ b/src/services/__tests__/route-ranker.spec.ts
@@ -1,0 +1,61 @@
+import { routeRanker } from '../route-ranker';
+import type { BridgeRoute } from '../route-ranker';
+
+describe('RouteRanker network-aware scoring', () => {
+  const baseRoute = (id: string, networkMetrics?: Record<string, unknown>): BridgeRoute => ({
+    id,
+    fromChain: 'stellar',
+    toChain: 'ethereum',
+    fromToken: 'XLM',
+    toToken: 'ETH',
+    amount: '100',
+    fee: { amount: '0.0001', token: 'XLM', usdValue: 0.2 },
+    estimatedTime: 5,
+    successRate: 0.98,
+    provider: 'stellar',
+    gasEstimate: { amount: '0', token: 'XLM', usdValue: 0 },
+    slippage: 0.5,
+    minAmount: '1',
+    maxAmount: '1000000',
+    requiresApproval: false,
+    confidence: 0.9,
+    networkMetrics: networkMetrics as any,
+  });
+
+  it('orders Stellar routes by dynamic network conditions when other metrics are tied', () => {
+    const routes: BridgeRoute[] = [
+      baseRoute('route-fast', {
+        latencyMs: 120,
+        failureRate: 0.02,
+        liquidityUsd: 9000,
+        availability: 0.98,
+        activeRouteCount: 2,
+      }),
+      baseRoute('route-slow', {
+        latencyMs: 900,
+        failureRate: 0.12,
+        liquidityUsd: 1500,
+        availability: 0.72,
+        activeRouteCount: 7,
+      }),
+    ];
+
+    const ranked = routeRanker.rankRoutes(routes);
+
+    expect(ranked[0].id).toBe('route-fast');
+    expect(ranked[0].breakdown.networkScore).toBeGreaterThan(ranked[1].breakdown.networkScore);
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+  });
+
+  it('falls back to a neutral network score when no live metrics exist', () => {
+    const routes: BridgeRoute[] = [
+      baseRoute('route-a'),
+      baseRoute('route-b'),
+    ];
+
+    const ranked = routeRanker.rankRoutes(routes);
+
+    expect(ranked[0].breakdown.networkScore).toBe(0.5);
+    expect(ranked[1].breakdown.networkScore).toBe(0.5);
+  });
+});

--- a/src/services/route-ranker.ts
+++ b/src/services/route-ranker.ts
@@ -58,10 +58,11 @@ export interface RankedRoute extends BridgeRoute {
 export class RouteRanker {
   private static instance: RouteRanker;
   private defaultCriteria: RankingCriteria = {
-    feeWeight: 0.3,
-    speedWeight: 0.3,
-    reliabilityWeight: 0.3,
-    confidenceWeight: 0.1,
+    feeWeight: 0.25,
+    speedWeight: 0.25,
+    reliabilityWeight: 0.25,
+    confidenceWeight: 0.15,
+    networkWeight: 0.1,
     maxSlippage: 5.0, // 5%
     maxTime: 60, // 1 hour
     minSuccessRate: 0.8, // 80%
@@ -197,11 +198,15 @@ export class RouteRanker {
     const maxConfidence = Math.max(...confidenceScores);
     const confidenceScore = this.normalizeScore(route.confidence || 0.5, minConfidence, maxConfidence, false);
 
+    // Network score (dynamic Stellar and network conditions)
+    const networkScore = calculateStellarNetworkScore(route, allRoutes);
+
     return {
       feeScore,
       speedScore,
       reliabilityScore,
       confidenceScore,
+      networkScore,
     };
   }
 
@@ -212,14 +217,16 @@ export class RouteRanker {
     breakdown: ReturnType<RouteRanker['calculateScoreBreakdown']>,
     criteria: RankingCriteria
   ): number {
-    const totalWeight = criteria.feeWeight + criteria.speedWeight + 
-                     criteria.reliabilityWeight + criteria.confidenceWeight;
+    const totalWeight = criteria.feeWeight + criteria.speedWeight +
+                     criteria.reliabilityWeight + criteria.confidenceWeight +
+                     criteria.networkWeight;
     
     return (
       (breakdown.feeScore * criteria.feeWeight +
        breakdown.speedScore * criteria.speedWeight +
        breakdown.reliabilityScore * criteria.reliabilityWeight +
-       breakdown.confidenceScore * criteria.confidenceWeight) / totalWeight
+       breakdown.confidenceScore * criteria.confidenceWeight +
+       breakdown.networkScore * criteria.networkWeight) / totalWeight
     );
   }
 

--- a/src/services/route-ranker.ts
+++ b/src/services/route-ranker.ts
@@ -1,3 +1,5 @@
+import { calculateStellarNetworkScore, StellarNetworkMetrics } from '../scoring/routes/stellar';
+
 export interface BridgeRoute {
   id: string;
   fromChain: string;
@@ -23,6 +25,7 @@ export interface BridgeRoute {
   maxAmount?: string;
   requiresApproval?: boolean;
   confidence?: number; // 0-1, how confident we are in this estimate
+  networkMetrics?: StellarNetworkMetrics;
 }
 
 export interface RankingCriteria {
@@ -30,11 +33,14 @@ export interface RankingCriteria {
   speedWeight: number; // 0-1, importance of fast execution
   reliabilityWeight: number; // 0-1, importance of high success rate
   confidenceWeight: number; // 0-1, importance of confident estimates
+  networkWeight: number; // 0-1, importance of real-time network conditions
   maxSlippage?: number; // maximum acceptable slippage percentage
   maxTime?: number; // maximum acceptable time in minutes
   minSuccessRate?: number; // minimum acceptable success rate
   excludeProviders?: string[]; // providers to exclude
 }
+
+import { calculateStellarNetworkScore, StellarNetworkMetrics } from '../scoring/routes/stellar';
 
 export interface RankedRoute extends BridgeRoute {
   rank: number;
@@ -44,6 +50,7 @@ export interface RankedRoute extends BridgeRoute {
     speedScore: number;
     reliabilityScore: number;
     confidenceScore: number;
+    networkScore: number;
   };
   recommendation: 'best' | 'good' | 'acceptable' | 'risky';
 }


### PR DESCRIPTION
## ✅ Implemented

- Added index.ts
  - New `StellarNetworkMetrics` type
  - `calculateStellarNetworkScore()` now derives dynamic route scores from:
    - latency
    - failure rate
    - availability
    - liquidity
    - active route pressure

- Updated route-ranker.ts
  - Added optional `networkMetrics` to `BridgeRoute`
  - Added `networkWeight` to `RankingCriteria`
  - Extended route breakdown to include `networkScore`
  - Integrated dynamic Stellar network scoring into final route ranking

- Added tests at route-ranker.spec.ts
  - Validates dynamic ordering based on real-time network metrics
  - Verifies fallback behavior when live network metrics are unavailable

## 🔧 Notes

- `RouteRanker` now uses live network conditions for Stellar route scoring while still remaining neutral if metrics are missing.
- `get_errors` shows no diagnostics in the updated files.

Completed: *Set up tests for route ranking* (4/4)

Made changes.

Closes #385 