### PR TITLE
feat(stellar-bridge-provider): implement provider priority manager

### DIFF
--- a/packages/bridge-providers/__tests__/bridge-provider-manager.spec.ts
+++ b/packages/bridge-providers/__tests__/bridge-provider-manager.spec.ts
@@ -1,0 +1,87 @@
+import { BridgeProviderManager, ProviderMetrics, BridgeProvider, BridgeParams } from '../index';
+
+describe('BridgeProviderManager', () => {
+  let manager: BridgeProviderManager;
+  const makeProvider = (name: string, available = true): BridgeProvider => ({
+    name,
+    getRoutes: async () => [],
+    isAvailable: () => available,
+    getSupportedChains: () => ['stellar'],
+    getSupportedTokens: () => ['USDC'],
+  });
+
+  beforeEach(() => {
+    manager = BridgeProviderManager.getInstance();
+    manager.unregisterProvider('stellar-a');
+    manager.unregisterProvider('stellar-b');
+    manager.unregisterProvider('stellar-c');
+  });
+
+  it('computes provider priority from reliability, availability, latency, and failure metrics', () => {
+    manager.registerProvider(makeProvider('stellar-a'));
+    manager.registerProvider(makeProvider('stellar-b'));
+
+    manager.updateProviderMetrics('stellar-a', {
+      reliability: 0.97,
+      availability: 0.98,
+      latencyMs: 120,
+      failureRate: 0.02,
+    });
+
+    manager.updateProviderMetrics('stellar-b', {
+      reliability: 0.80,
+      availability: 0.85,
+      latencyMs: 450,
+      failureRate: 0.08,
+    });
+
+    const priorityA = manager.getProviderPriority('stellar-a');
+    const priorityB = manager.getProviderPriority('stellar-b');
+
+    expect(priorityA).toBeGreaterThan(priorityB);
+    expect(priorityA).toBeGreaterThan(0.5);
+    expect(priorityB).toBeLessThan(0.8);
+  });
+
+  it('orders providers by dynamic priority and drops unavailable providers when collecting routes', async () => {
+    const availableProvider = makeProvider('stellar-a', true);
+    const unavailableProvider = makeProvider('stellar-b', false);
+
+    manager.registerProvider(availableProvider);
+    manager.registerProvider(unavailableProvider);
+
+    manager.updateProviderMetrics('stellar-a', {
+      reliability: 0.99,
+      availability: 0.99,
+      latencyMs: 100,
+      failureRate: 0.01,
+    });
+
+    manager.updateProviderMetrics('stellar-b', {
+      reliability: 0.95,
+      availability: 0.96,
+      latencyMs: 200,
+      failureRate: 0.04,
+    });
+
+    const providersByPriority = manager.getProvidersByPriority();
+
+    expect(providersByPriority[0].provider.name).toBe('stellar-a');
+    expect(providersByPriority.some((entry) => entry.provider.name === 'stellar-b')).toBe(true);
+
+    const routes = await manager.getAllRoutes({
+      fromChain: 'stellar',
+      toChain: 'ethereum',
+      fromToken: 'USDC',
+      toToken: 'ETH',
+      amount: '1000',
+    });
+
+    expect(routes).toEqual([]);
+  });
+
+  it('returns default neutral priority when metrics are missing', () => {
+    manager.registerProvider(makeProvider('stellar-a'));
+    expect(manager.getProviderPriority('stellar-a')).toBe(0.5);
+  });
+});

--- a/packages/bridge-providers/index.ts
+++ b/packages/bridge-providers/index.ts
@@ -8,6 +8,20 @@ export interface BridgeProvider {
   getSupportedTokens(): string[];
 }
 
+export interface ProviderMetrics {
+  reliability?: number; // 0-1
+  availability?: number; // 0-1
+  latencyMs?: number;
+  failureRate?: number; // 0-1
+}
+
+export interface ProviderPriorityConfig {
+  reliabilityWeight?: number;
+  availabilityWeight?: number;
+  latencyWeight?: number;
+  failureWeight?: number;
+}
+
 export interface BridgeParams {
   fromChain: string;
   toChain: string;
@@ -21,6 +35,13 @@ export interface BridgeParams {
 export class BridgeProviderManager {
   private static instance: BridgeProviderManager;
   private providers: Map<string, BridgeProvider> = new Map();
+  private providerMetrics: Map<string, ProviderMetrics> = new Map();
+  private providerPriorityConfig: Required<ProviderPriorityConfig> = {
+    reliabilityWeight: 0.4,
+    availabilityWeight: 0.3,
+    latencyWeight: 0.2,
+    failureWeight: 0.1,
+  };
 
   private constructor() {}
 
@@ -39,24 +60,101 @@ export class BridgeProviderManager {
   }
 
   /**
+   * Update priority metrics for a provider
+   */
+  updateProviderMetrics(providerName: string, metrics: ProviderMetrics) {
+    if (!this.providers.has(providerName)) {
+      throw new Error(`Provider ${providerName} not found`);
+    }
+
+    this.providerMetrics.set(providerName, {
+      ...this.providerMetrics.get(providerName),
+      ...metrics,
+    });
+  }
+
+  /**
+   * Get the current computed priority for a provider
+   */
+  getProviderPriority(providerName: string): number {
+    const metrics = this.providerMetrics.get(providerName);
+    if (!metrics) {
+      return 0.5;
+    }
+
+    const reliabilityScore = this.toScore(metrics.reliability, false);
+    const availabilityScore = this.toScore(metrics.availability, false);
+    const latencyScore = this.toScore(metrics.latencyMs, true);
+    const failureScore = this.toScore(metrics.failureRate, true);
+
+    const totalWeight =
+      this.providerPriorityConfig.reliabilityWeight +
+      this.providerPriorityConfig.availabilityWeight +
+      this.providerPriorityConfig.latencyWeight +
+      this.providerPriorityConfig.failureWeight;
+
+    return (
+      reliabilityScore * this.providerPriorityConfig.reliabilityWeight +
+      availabilityScore * this.providerPriorityConfig.availabilityWeight +
+      latencyScore * this.providerPriorityConfig.latencyWeight +
+      failureScore * this.providerPriorityConfig.failureWeight
+    ) / totalWeight;
+  }
+
+  /**
+   * Get a list of providers ordered by their current priority.
+   */
+  getProvidersByPriority() {
+    return Array.from(this.providers.values())
+      .map((provider) => ({
+        provider,
+        priority: this.getProviderPriority(provider.name),
+      }))
+      .sort((left, right) => right.priority - left.priority);
+  }
+
+  /**
+   * Normalize a single priority metric to a 0-1 score.
+   */
+  private toScore(value: number | undefined, lowerIsBetter: boolean): number {
+    if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) {
+      return 0.5;
+    }
+
+    const normalizedValue = lowerIsBetter
+      ? value <= 1
+        ? Math.min(1, Math.max(0, value))
+        : Math.min(1, Math.max(0, value / 1000))
+      : Math.min(1, Math.max(0, value));
+
+    if (!lowerIsBetter) {
+      return normalizedValue;
+    }
+
+    return 1 - normalizedValue;
+  }
+
+  /**
    * Unregister a bridge provider
    */
   unregisterProvider(name: string) {
     this.providers.delete(name);
+    this.providerMetrics.delete(name);
   }
 
   /**
    * Get all available routes from all providers
    */
   async getAllRoutes(params: BridgeParams): Promise<BridgeRoute[]> {
-    const availableProviders = Array.from(this.providers.values())
-      .filter(provider => provider.isAvailable());
+    const availableProviders = this.getProvidersByPriority()
+      .map((entry) => entry.provider)
+      .filter((provider) => provider.isAvailable());
 
-    const routePromises = availableProviders.map(provider => 
-      provider.getRoutes(params).catch(error => {
+    const routePromises = availableProviders.map((provider) =>
+      provider.getRoutes(params).catch((error) => {
         console.error(`Provider ${provider.name} failed:`, error);
         return [] as BridgeRoute[];
-      })
+      }),
     );
 
     const allRoutes = await Promise.all(routePromises);
@@ -71,7 +169,15 @@ export class BridgeProviderManager {
     criteria?: import('../../src/services/route-ranker').RankingCriteria
   ): Promise<RankedRoute[]> {
     const allRoutes = await this.getAllRoutes(params);
-    return routeRanker.rankRoutes(allRoutes, criteria);
+    const rankedRoutes = routeRanker.rankRoutes(allRoutes, criteria);
+
+    return rankedRoutes.sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+
+      return this.getProviderPriority(b.provider) - this.getProviderPriority(a.provider);
+    });
   }
 
   /**
@@ -135,18 +241,20 @@ export class BridgeProviderManager {
       available: boolean;
       supportedChains: number;
       supportedTokens: number;
+      priority: number;
     }>;
   } {
-    const providers = Array.from(this.providers.values()).map(provider => ({
+    const providers = Array.from(this.providers.values()).map((provider) => ({
       name: provider.name,
       available: provider.isAvailable(),
       supportedChains: provider.getSupportedChains().length,
       supportedTokens: provider.getSupportedTokens().length,
+      priority: this.getProviderPriority(provider.name),
     }));
 
     return {
       totalProviders: providers.length,
-      availableProviders: providers.filter(p => p.available).length,
+      availableProviders: providers.filter((p) => p.available).length,
       providers,
     };
   }


### PR DESCRIPTION
Summary:
- Adds provider metrics and dynamic priority scoring for Stellar bridge providers.
- Ensures routes from higher-priority providers are preferred when scores are tied.
- Adds unit tests covering priority computation, provider ordering, and default neutral scoring.

What changed:
- Added ProviderMetrics and ProviderPriorityConfig interfaces.
- Implemented provider metrics updates and priority computation.
- Prioritized provider route collection and tie-breaking in ranked routes.
- Extended provider stats with computed priority values.

Why:
- Stellar providers were treated equally despite reliability differences.
- This change enables more dependable provider selection using live metrics.

Testing performed:
- npx jest packages/bridge-providers/__tests__/bridge-provider-manager.spec.ts --runInBand

Risks considered:
- Only provider ordering logic was changed; existing route scoring remains unchanged.
- Default neutral priority is preserved when metrics are missing.

Closes #373