### PR TITLE
feat(wallets/stellar): detect Soroban wallet capabilities

### DIFF
--- a/src/wallets/capabilities/stellar/__tests__/detector.spec.ts
+++ b/src/wallets/capabilities/stellar/__tests__/detector.spec.ts
@@ -1,0 +1,61 @@
+import { detectSorobanWalletCapabilities } from '../detector';
+import type { WalletAdapter, WalletAccount } from '../../../../packages/wallet/src';
+
+class MockAdapter implements WalletAdapter {
+  readonly id = 'mock-wallet';
+  readonly name = 'Mock Wallet';
+  readonly type = 'freighter' as const;
+  readonly networkType = 'stellar' as const;
+  readonly isAvailable = true;
+  readonly icon = undefined;
+  readonly supportedChains = [] as any;
+
+  private account: WalletAccount | null = null;
+
+  async connect(): Promise<WalletAccount> {
+    this.account = { address: 'GABC', publicKey: 'GABC', chainId: 'stellar:public', network: 'stellar' };
+    return this.account;
+  }
+  async disconnect(): Promise<void> {
+    this.account = null;
+  }
+  async getAccount(): Promise<WalletAccount | null> {
+    return this.account;
+  }
+  async getBalance(): Promise<any> {
+    return {};
+  }
+  async getAllBalances(): Promise<any[]> {
+    return [];
+  }
+  async switchNetwork(): Promise<void> {}
+  async sign(): Promise<string> {
+    return 'signed';
+  }
+  async sendTransaction(): Promise<string> {
+    return 'txhash';
+  }
+  on(): void {}
+  off(): void {}
+}
+
+describe('detectSorobanWalletCapabilities', () => {
+  it('detects capabilities for a connected adapter', async () => {
+    const adapter = new MockAdapter();
+    await adapter.connect();
+
+    const caps = await detectSorobanWalletCapabilities(adapter as unknown as WalletAdapter);
+
+    expect(caps.walletId).toBe('mock-wallet');
+    expect(caps.supports.signTransaction).toBe(true);
+    expect(caps.supports.signData).toBe(true);
+    expect(caps.supports.isConnected).toBe(true);
+  });
+
+  it('handles disconnected adapter safely', async () => {
+    const adapter = new MockAdapter();
+    const caps = await detectSorobanWalletCapabilities(adapter as unknown as WalletAdapter);
+
+    expect(caps.supports.isConnected).toBe(false);
+  });
+});

--- a/src/wallets/capabilities/stellar/detector.ts
+++ b/src/wallets/capabilities/stellar/detector.ts
@@ -1,0 +1,72 @@
+import type { WalletAdapter, WalletAccount } from '../../../../packages/wallet/src';
+
+export interface SorobanWalletCapabilities {
+  walletId: string;
+  name?: string;
+  type?: string;
+  supports: {
+    signTransaction: boolean;
+    signData: boolean;
+    getNetwork: boolean;
+    isConnected: boolean;
+    sorobanRpc: boolean;
+  };
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Detect capabilities of a connected Soroban (Stellar) wallet adapter.
+ * The detector is conservative: it checks for presence of adapter methods
+ * and non-invasive read-only fields where available.
+ */
+export async function detectSorobanWalletCapabilities(
+  adapter: WalletAdapter
+): Promise<SorobanWalletCapabilities> {
+  const walletId = (adapter as any).id || adapter.id || 'unknown';
+  const name = (adapter as any).name || adapter.name;
+  const type = (adapter as any).type || adapter.type;
+
+  const supportsSignTransaction = typeof adapter.sendTransaction === 'function';
+  const supportsSignData = typeof adapter.sign === 'function';
+  const supportsGetNetwork = typeof (adapter as any).getFreighterNetwork === 'function';
+
+  // Conservative isConnected: try to call getAccount() but do not throw.
+  let isConnected = false;
+  try {
+    const account: WalletAccount | null = await adapter.getAccount();
+    isConnected = !!account;
+  } catch {
+    isConnected = false;
+  }
+
+  // Detect Soroban RPC support heuristically: Freighter/other adapters sometimes
+  // expose an RPC URL option or provider option. Check for commonly used fields.
+  const hasRpcUrl = !!((adapter as any).freighterOptions && (adapter as any).freighterOptions.rpcUrl);
+  const provider = (adapter as any).provider || null;
+  const providerHasRpc = !!(provider && typeof provider.request === 'function');
+
+  const sorobanRpc = hasRpcUrl || providerHasRpc;
+
+  const capabilities: SorobanWalletCapabilities = {
+    walletId,
+    name,
+    type,
+    supports: {
+      signTransaction: supportsSignTransaction,
+      signData: supportsSignData,
+      getNetwork: supportsGetNetwork,
+      isConnected,
+      sorobanRpc,
+    },
+    metadata: {
+      inferredFrom: {
+        hasFreighterRpcOption: hasRpcUrl,
+        providerExposesRequest: providerHasRpc,
+      },
+    },
+  };
+
+  return capabilities;
+}
+
+export default detectSorobanWalletCapabilities;


### PR DESCRIPTION
Summary

Add a conservative capability detector for Soroban (Stellar) wallets. The detector returns a small compatibility metadata object describing whether the adapter supports transaction signing, data signing, network queries, connection state and whether Soroban RPC access is available (heuristically).

What changed

- Added `src/wallets/capabilities/stellar/detector.ts` implementing `detectSorobanWalletCapabilities`.
- Added unit tests at `src/wallets/capabilities/stellar/__tests__/detector.spec.ts` covering connected and disconnected adapters.

Why

Wallet feature support varies between Soroban wallet providers. Exposing capability metadata enables the app to adapt behavior, show helpful UI, and avoid unsupported flows.

Testing performed

- Run the new test file directly with Jest: both tests pass locally (`detectSorobanWalletCapabilities` tests).
- No existing modules were modified; changes are isolated and covered by targeted tests.

Risks considered

- Detector is conservative and non-invasive: it does not call signing or send RPC requests. It only inspects available adapter methods and calls `getAccount()` for a safe connected check.
- No runtime-breaking changes to existing adapters were introduced.

Edge cases handled

- Safely handles adapters that throw from `getAccount()` by treating them as disconnected.
- Heuristically infers RPC capability via common fields (`freighterOptions.rpcUrl` / `provider.request`) but does not rely on them.

Closes #362
