### PR TITLE
feat: Soroban route simulation cache and Stellar trustline auto-setup

### DIFF
--- a/src/cache/simulations/stellar/index.ts
+++ b/src/cache/simulations/stellar/index.ts
@@ -1,0 +1,9 @@
+export {
+  StellarRouteSimulationCache,
+  buildSimulationKey,
+} from './stellar-route-simulation-cache';
+export type {
+  SimulationKeyInput,
+  SimulationCacheEntry,
+  SimulationCacheConfig,
+} from './stellar-route-simulation-cache';

--- a/src/cache/simulations/stellar/stellar-route-simulation-cache.spec.ts
+++ b/src/cache/simulations/stellar/stellar-route-simulation-cache.spec.ts
@@ -1,0 +1,133 @@
+import {
+  StellarRouteSimulationCache,
+  buildSimulationKey,
+  type SimulationKeyInput,
+} from './stellar-route-simulation-cache';
+
+interface DummyResult {
+  destinationAmount: string;
+  pathHops: number;
+}
+
+const KEY_A: SimulationKeyInput = {
+  sourceAsset: 'XLM:native',
+  destinationAsset: 'USDC:GA…',
+  sourceAmount: '1000000',
+  network: 'testnet',
+};
+const RESULT_A: DummyResult = { destinationAmount: '950000', pathHops: 2 };
+
+const KEY_B: SimulationKeyInput = {
+  sourceAsset: 'XLM:native',
+  destinationAsset: 'USDC:GA…',
+  sourceAmount: '2000000',
+  network: 'testnet',
+};
+const RESULT_B: DummyResult = { destinationAmount: '1899000', pathHops: 2 };
+
+describe('buildSimulationKey', () => {
+  it('is deterministic for identical inputs', () => {
+    expect(buildSimulationKey(KEY_A)).toBe(buildSimulationKey(KEY_A));
+  });
+
+  it('discriminates on every input field', () => {
+    const base = buildSimulationKey(KEY_A);
+    expect(buildSimulationKey({ ...KEY_A, sourceAmount: '999' })).not.toBe(base);
+    expect(buildSimulationKey({ ...KEY_A, network: 'mainnet' })).not.toBe(base);
+    expect(buildSimulationKey({ ...KEY_A, sourceAsset: 'XLM:other' })).not.toBe(base);
+    expect(buildSimulationKey({ ...KEY_A, destinationAsset: 'EURC:GA…' })).not.toBe(base);
+  });
+});
+
+describe('StellarRouteSimulationCache', () => {
+  let cache: StellarRouteSimulationCache<DummyResult>;
+
+  beforeEach(() => {
+    cache = new StellarRouteSimulationCache<DummyResult>({
+      maxEntries: 3,
+      ttlMs: 1_000,
+      cleanupIntervalMs: 60_000,
+    });
+  });
+
+  afterEach(() => cache.destroy());
+
+  it('stores and retrieves a result', () => {
+    cache.set(KEY_A, RESULT_A, 1_000);
+    expect(cache.get(KEY_A, 1_000)).toEqual(RESULT_A);
+    expect(cache.has(KEY_A, 1_000)).toBe(true);
+    expect(cache.size).toBe(1);
+  });
+
+  it('returns null on a miss', () => {
+    expect(cache.get(KEY_A, 1_000)).toBeNull();
+    expect(cache.has(KEY_A, 1_000)).toBe(false);
+  });
+
+  it('returns null and prunes the entry once TTL expires', () => {
+    cache.set(KEY_A, RESULT_A, 1_000);
+    expect(cache.get(KEY_A, 1_900)).toEqual(RESULT_A);
+    expect(cache.get(KEY_A, 2_001)).toBeNull();
+    expect(cache.size).toBe(0);
+  });
+
+  it('evicts the oldest entry when at capacity', () => {
+    cache.set({ ...KEY_A, sourceAmount: '1' }, RESULT_A, 1_000);
+    cache.set({ ...KEY_A, sourceAmount: '2' }, RESULT_A, 1_001);
+    cache.set({ ...KEY_A, sourceAmount: '3' }, RESULT_A, 1_002);
+    cache.set({ ...KEY_A, sourceAmount: '4' }, RESULT_A, 1_003);
+    expect(cache.size).toBe(3);
+    expect(cache.has({ ...KEY_A, sourceAmount: '1' }, 1_003)).toBe(false);
+    expect(cache.has({ ...KEY_A, sourceAmount: '4' }, 1_003)).toBe(true);
+  });
+
+  it('replacing an existing key does not trigger eviction', () => {
+    cache.set({ ...KEY_A, sourceAmount: '1' }, RESULT_A, 1_000);
+    cache.set({ ...KEY_A, sourceAmount: '2' }, RESULT_B, 1_001);
+    cache.set({ ...KEY_A, sourceAmount: '3' }, RESULT_A, 1_002);
+    cache.set({ ...KEY_A, sourceAmount: '2' }, RESULT_A, 1_003); // replace
+    expect(cache.size).toBe(3);
+    expect(cache.has({ ...KEY_A, sourceAmount: '1' }, 1_003)).toBe(true);
+  });
+
+  describe('invalidation', () => {
+    beforeEach(() => {
+      cache.set(KEY_A, RESULT_A, 1_000);
+      cache.set(KEY_B, RESULT_B, 1_001);
+      cache.set(
+        { sourceAsset: 'XLM:native', destinationAsset: 'EURC:GA…', sourceAmount: '500', network: 'mainnet' },
+        { destinationAmount: '49', pathHops: 1 },
+        1_002,
+      );
+    });
+
+    it('invalidate(key) removes only that entry', () => {
+      expect(cache.invalidate(KEY_A)).toBe(true);
+      expect(cache.size).toBe(2);
+      expect(cache.invalidate(KEY_A)).toBe(false);
+    });
+
+    it('invalidateNetwork removes every entry on the network', () => {
+      const removed = cache.invalidateNetwork('testnet');
+      expect(removed).toBe(2);
+      expect(cache.size).toBe(1);
+    });
+
+    it('invalidateAsset removes entries touching the asset on either side', () => {
+      const removed = cache.invalidateAsset('USDC:GA…');
+      expect(removed).toBe(2);
+      expect(cache.size).toBe(1);
+    });
+
+    it('invalidateBy supports arbitrary predicates', () => {
+      const removed = cache.invalidateBy((entry) => entry.input.sourceAmount === '1000000');
+      expect(removed).toBe(1);
+      expect(cache.size).toBe(2);
+    });
+
+    it('clear() drops everything', () => {
+      cache.clear();
+      expect(cache.size).toBe(0);
+    });
+  });
+});

--- a/src/cache/simulations/stellar/stellar-route-simulation-cache.ts
+++ b/src/cache/simulations/stellar/stellar-route-simulation-cache.ts
@@ -1,0 +1,184 @@
+/**
+ * Stellar route simulation cache — Issue #364.
+ *
+ * Soroban route simulations (path-payment quotes, swap previews, fee
+ * projections) are deterministic for a short window: identical inputs return
+ * the same numbers until ledger state moves. This cache reuses those results
+ * across repeated queries to cut down on Horizon/Soroban-RPC round-trips.
+ *
+ * The shape mirrors the sibling `StellarReplayProtectionCache` in
+ * `src/cache/replay/stellar` — a Map-backed, TTL-bounded, LRU-evicting store
+ * with a background cleanup timer. Several invalidation strategies are
+ * supported so callers can flush narrowly (by route, by predicate) instead of
+ * blasting the whole cache.
+ */
+
+/** Inputs that fully describe a route simulation request. */
+export interface SimulationKeyInput {
+  sourceAsset: string;
+  destinationAsset: string;
+  /** Stroop amount serialised as a string to avoid bigint/number ambiguity. */
+  sourceAmount: string;
+  network: string;
+}
+
+export interface SimulationCacheEntry<T> {
+  key: string;
+  input: SimulationKeyInput;
+  result: T;
+  /** Ms since epoch when the entry was stored. */
+  cachedAt: number;
+}
+
+export interface SimulationCacheConfig {
+  maxEntries: number;
+  ttlMs: number;
+  cleanupIntervalMs: number;
+}
+
+const DEFAULT_CONFIG: SimulationCacheConfig = {
+  maxEntries: 1_000,
+  ttlMs: 30 * 1_000, // simulations go stale quickly — 30s
+  cleanupIntervalMs: 60 * 1_000,
+};
+
+/** Build the deterministic cache key for a simulation. Exported for tests. */
+export function buildSimulationKey(input: SimulationKeyInput): string {
+  return [
+    input.network,
+    input.sourceAsset,
+    input.destinationAsset,
+    input.sourceAmount,
+  ].join('|');
+}
+
+export class StellarRouteSimulationCache<T = unknown> {
+  private cache: Map<string, SimulationCacheEntry<T>> = new Map();
+  private readonly config: SimulationCacheConfig;
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(config: Partial<SimulationCacheConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.startCleanup();
+  }
+
+  /** Look up a cached simulation result; returns null on miss or expiry. */
+  get(input: SimulationKeyInput, now: number = Date.now()): T | null {
+    const key = buildSimulationKey(input);
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+    if (this.isExpired(entry, now)) {
+      this.cache.delete(key);
+      return null;
+    }
+    return entry.result;
+  }
+
+  /** Insert/replace a simulation result. Evicts the oldest entry if full. */
+  set(input: SimulationKeyInput, result: T, now: number = Date.now()): void {
+    const key = buildSimulationKey(input);
+    if (!this.cache.has(key) && this.cache.size >= this.config.maxEntries) {
+      this.evictOldest();
+    }
+    this.cache.set(key, { key, input, result, cachedAt: now });
+  }
+
+  /** True iff a fresh (non-expired) entry exists for this key. */
+  has(input: SimulationKeyInput, now: number = Date.now()): boolean {
+    const entry = this.cache.get(buildSimulationKey(input));
+    return entry !== undefined && !this.isExpired(entry, now);
+  }
+
+  // ── Invalidation strategies ────────────────────────────────────────────
+
+  /** Invalidate a specific (source, destination, amount, network) entry. */
+  invalidate(input: SimulationKeyInput): boolean {
+    return this.cache.delete(buildSimulationKey(input));
+  }
+
+  /** Invalidate every entry on the given network (e.g. on ledger reorg). */
+  invalidateNetwork(network: string): number {
+    let removed = 0;
+    for (const [key, entry] of this.cache) {
+      if (entry.input.network === network) {
+        this.cache.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /** Invalidate every entry touching the given asset (source or destination). */
+  invalidateAsset(asset: string): number {
+    let removed = 0;
+    for (const [key, entry] of this.cache) {
+      if (entry.input.sourceAsset === asset || entry.input.destinationAsset === asset) {
+        this.cache.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /** Invalidate every entry for which the predicate returns true. */
+  invalidateBy(predicate: (entry: SimulationCacheEntry<T>) => boolean): number {
+    let removed = 0;
+    for (const [key, entry] of this.cache) {
+      if (predicate(entry)) {
+        this.cache.delete(key);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /** Drop every entry. */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /** Stop the background cleanup timer. */
+  destroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────────
+
+  private isExpired(entry: SimulationCacheEntry<T>, now: number): boolean {
+    return now - entry.cachedAt > this.config.ttlMs;
+  }
+
+  private evictOldest(): void {
+    let oldestKey: string | null = null;
+    let oldestTime = Infinity;
+    for (const [key, entry] of this.cache) {
+      if (entry.cachedAt < oldestTime) {
+        oldestTime = entry.cachedAt;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey) this.cache.delete(oldestKey);
+  }
+
+  private startCleanup(): void {
+    this.cleanupTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [key, entry] of this.cache) {
+        if (this.isExpired(entry, now)) {
+          this.cache.delete(key);
+        }
+      }
+    }, this.config.cleanupIntervalMs);
+    // Don't hold the event loop open just for the cleanup timer.
+    if (typeof (this.cleanupTimer as { unref?: () => void }).unref === 'function') {
+      (this.cleanupTimer as { unref: () => void }).unref();
+    }
+  }
+}

--- a/src/wallets/trustlines/stellar/index.ts
+++ b/src/wallets/trustlines/stellar/index.ts
@@ -1,0 +1,17 @@
+export {
+  detectMissingTrustlines,
+  buildTrustlineSetupPlan,
+  executeSetupPlan,
+  isSameAsset,
+  isNativeAsset,
+} from './stellar-trustline-auto-setup';
+export type {
+  StellarAsset,
+  ExistingTrustline,
+  TrustlineSetupOperation,
+  TrustlineSetupPlan,
+  TrustlineSetupStatus,
+  TrustlineSetupResult,
+  TrustlineOperationSubmitter,
+  BuildPlanOptions,
+} from './stellar-trustline-auto-setup';

--- a/src/wallets/trustlines/stellar/stellar-trustline-auto-setup.spec.ts
+++ b/src/wallets/trustlines/stellar/stellar-trustline-auto-setup.spec.ts
@@ -1,0 +1,113 @@
+import {
+  detectMissingTrustlines,
+  buildTrustlineSetupPlan,
+  executeSetupPlan,
+  isSameAsset,
+  isNativeAsset,
+  type StellarAsset,
+  type ExistingTrustline,
+  type TrustlineSetupOperation,
+} from './stellar-trustline-auto-setup';
+
+const USDC: StellarAsset = { code: 'USDC', issuer: 'GA_USDC_ISSUER' };
+const EURC: StellarAsset = { code: 'EURC', issuer: 'GA_EURC_ISSUER' };
+const XLM: StellarAsset = { code: 'XLM' };
+
+function trust(asset: StellarAsset, limit: string | null = null): ExistingTrustline {
+  return { asset, limit };
+}
+
+const ACCOUNT = 'GA_ACCOUNT';
+
+describe('isSameAsset / isNativeAsset', () => {
+  it('compares non-native assets by code and issuer', () => {
+    expect(isSameAsset(USDC, { code: 'USDC', issuer: 'GA_USDC_ISSUER' })).toBe(true);
+    expect(isSameAsset(USDC, { code: 'USDC', issuer: 'GA_OTHER' })).toBe(false);
+    expect(isSameAsset(USDC, EURC)).toBe(false);
+  });
+
+  it('treats XLM as native regardless of issuer (and ignores any issuer field)', () => {
+    expect(isSameAsset(XLM, { code: 'XLM' })).toBe(true);
+    expect(isNativeAsset(XLM)).toBe(true);
+    expect(isNativeAsset(USDC)).toBe(false);
+  });
+});
+
+describe('detectMissingTrustlines', () => {
+  it('returns the empty list when every required asset is already trusted', () => {
+    expect(detectMissingTrustlines([trust(USDC), trust(EURC)], [USDC, EURC])).toEqual([]);
+  });
+
+  it('lists every required asset the account does not yet trust', () => {
+    expect(detectMissingTrustlines([trust(USDC)], [USDC, EURC])).toEqual([EURC]);
+  });
+
+  it('excludes the native XLM asset — every account has it implicitly', () => {
+    expect(detectMissingTrustlines([], [XLM, USDC])).toEqual([USDC]);
+  });
+
+  it('de-duplicates required assets so a repeat does not appear twice', () => {
+    expect(detectMissingTrustlines([], [USDC, USDC])).toEqual([USDC]);
+  });
+
+  it('treats USDC issued by different issuers as distinct assets', () => {
+    const fake = { code: 'USDC', issuer: 'GA_FAKE_USDC_ISSUER' };
+    expect(detectMissingTrustlines([trust(USDC)], [fake])).toEqual([fake]);
+  });
+});
+
+describe('buildTrustlineSetupPlan', () => {
+  it('builds a plan with one change_trust op per missing asset', () => {
+    const plan = buildTrustlineSetupPlan(ACCOUNT, [], [USDC, EURC]);
+    expect(plan.account).toBe(ACCOUNT);
+    expect(plan.missing).toEqual([USDC, EURC]);
+    expect(plan.operations).toEqual<TrustlineSetupOperation[]>([
+      { type: 'change_trust', asset: USDC },
+      { type: 'change_trust', asset: EURC },
+    ]);
+  });
+
+  it('is a no-op (empty plan) when everything is already trusted', () => {
+    const plan = buildTrustlineSetupPlan(ACCOUNT, [trust(USDC)], [USDC]);
+    expect(plan.missing).toEqual([]);
+    expect(plan.operations).toEqual([]);
+  });
+
+  it('applies a caller-supplied trust limit to every op', () => {
+    const plan = buildTrustlineSetupPlan(ACCOUNT, [], [USDC], { limit: '100000' });
+    expect(plan.operations[0]).toEqual({ type: 'change_trust', asset: USDC, limit: '100000' });
+  });
+});
+
+describe('executeSetupPlan', () => {
+  it('returns noop without invoking the submitter for an empty plan', async () => {
+    const submit = jest.fn();
+    const plan = buildTrustlineSetupPlan(ACCOUNT, [trust(USDC)], [USDC]);
+    const result = await executeSetupPlan(plan, submit);
+    expect(submit).not.toHaveBeenCalled();
+    expect(result.status).toBe('noop');
+    expect(result.submitted).toBe(false);
+  });
+
+  it('submits one op per missing trustline and reports success', async () => {
+    const submit = jest.fn().mockResolvedValue(undefined);
+    const plan = buildTrustlineSetupPlan(ACCOUNT, [], [USDC, EURC]);
+    const result = await executeSetupPlan(plan, submit);
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe('submitted');
+    expect(result.submitted).toBe(true);
+    expect(result.operationResults.map((r) => r.ok)).toEqual([true, true]);
+  });
+
+  it('continues past a failing op and reports the error', async () => {
+    const submit = jest.fn<Promise<void>, [TrustlineSetupOperation, string]>().mockImplementation(async (op) => {
+      if (op.asset.code === 'USDC') throw new Error('reject');
+    });
+    const plan = buildTrustlineSetupPlan(ACCOUNT, [], [USDC, EURC]);
+    const result = await executeSetupPlan(plan, submit);
+    expect(result.status).toBe('failed');
+    expect(result.submitted).toBe(true); // EURC still submitted
+    expect(result.operationResults[0]).toMatchObject({ ok: false, error: 'reject' });
+    expect(result.operationResults[1].ok).toBe(true);
+  });
+});

--- a/src/wallets/trustlines/stellar/stellar-trustline-auto-setup.ts
+++ b/src/wallets/trustlines/stellar/stellar-trustline-auto-setup.ts
@@ -1,0 +1,162 @@
+/**
+ * Stellar trustline auto-setup — Issue #365.
+ *
+ * Users routinely fail Stellar transfers when their account is missing a
+ * trustline for a non-native asset (USDC, EURC, custom SACs). This module
+ * detects the gap and produces a setup plan the wallet layer can execute —
+ * either by signing each `changeTrust` op locally or by handing the plan to
+ * the UI to walk the user through.
+ *
+ * The detection and planning logic is pure (no SDK, no network calls) so it
+ * can be unit-tested without a live account. `executeSetupPlan` accepts an
+ * injectable submitter so the caller picks the transport (Freighter, xBull,
+ * Soroban CLI, etc.).
+ */
+
+/** Canonical identifier for a Stellar asset. */
+export interface StellarAsset {
+  /** Asset code (e.g. "USDC"), or "XLM" for the native asset. */
+  code: string;
+  /** Issuer account; absent for the native XLM asset. */
+  issuer?: string;
+}
+
+/** Existing trustline state on an account. */
+export interface ExistingTrustline {
+  asset: StellarAsset;
+  /** Optional human-readable balance. Not consulted by detection. */
+  balance?: string;
+  /** Trustline limit — `null` when unlimited (the SDK's default). */
+  limit?: string | null;
+}
+
+/** A single change-trust operation the wallet needs to execute. */
+export interface TrustlineSetupOperation {
+  type: 'change_trust';
+  asset: StellarAsset;
+  /** New limit. Defaults to the SDK's max when omitted. */
+  limit?: string;
+}
+
+/** The full plan: every missing trustline + ready-to-sign operations. */
+export interface TrustlineSetupPlan {
+  account: string;
+  missing: StellarAsset[];
+  operations: TrustlineSetupOperation[];
+}
+
+export type TrustlineSetupStatus = 'noop' | 'pending' | 'submitted' | 'failed';
+
+export interface TrustlineSetupResult {
+  status: TrustlineSetupStatus;
+  /** True when at least one trustline op was submitted. */
+  submitted: boolean;
+  /** Submission result for each op (one per `plan.operations` entry). */
+  operationResults: Array<{ asset: StellarAsset; ok: boolean; error?: string }>;
+}
+
+/** A function that signs and submits one trustline op to the network. */
+export type TrustlineOperationSubmitter = (
+  op: TrustlineSetupOperation,
+  account: string,
+) => Promise<void>;
+
+/**
+ * Return true when two assets reference the same on-chain trustline. The
+ * native XLM asset never needs a trustline.
+ */
+export function isSameAsset(a: StellarAsset, b: StellarAsset): boolean {
+  if (a.code !== b.code) return false;
+  // Native assets have no issuer.
+  if (a.code === 'XLM') return true;
+  return (a.issuer ?? '') === (b.issuer ?? '');
+}
+
+/** Native XLM never needs an explicit trustline. */
+export function isNativeAsset(asset: StellarAsset): boolean {
+  return asset.code === 'XLM' && !asset.issuer;
+}
+
+/**
+ * Diff the account's existing trustlines against a list of required assets
+ * and return only the assets that are missing. Native XLM is excluded
+ * because every account has it implicitly.
+ */
+export function detectMissingTrustlines(
+  existing: ExistingTrustline[],
+  required: StellarAsset[],
+): StellarAsset[] {
+  const missing: StellarAsset[] = [];
+  for (const asset of required) {
+    if (isNativeAsset(asset)) continue;
+    const present = existing.some((t) => isSameAsset(t.asset, asset));
+    if (!present && !missing.some((m) => isSameAsset(m, asset))) {
+      missing.push(asset);
+    }
+  }
+  return missing;
+}
+
+export interface BuildPlanOptions {
+  /** Optional trust limit to apply to every change-trust op. */
+  limit?: string;
+}
+
+/**
+ * Build the trustline setup plan for an account given its current trustlines
+ * and the assets it needs to transact. Idempotent — assets already trusted
+ * are omitted from the operations list.
+ */
+export function buildTrustlineSetupPlan(
+  account: string,
+  existing: ExistingTrustline[],
+  required: StellarAsset[],
+  options: BuildPlanOptions = {},
+): TrustlineSetupPlan {
+  const missing = detectMissingTrustlines(existing, required);
+  const operations: TrustlineSetupOperation[] = missing.map((asset) => ({
+    type: 'change_trust',
+    asset,
+    ...(options.limit !== undefined ? { limit: options.limit } : {}),
+  }));
+  return { account, missing, operations };
+}
+
+/**
+ * Execute every op in the plan via the injected submitter. Operations are
+ * submitted in order so a later failure does not leave the account in a state
+ * that depends on a later one having succeeded.
+ */
+export async function executeSetupPlan(
+  plan: TrustlineSetupPlan,
+  submit: TrustlineOperationSubmitter,
+): Promise<TrustlineSetupResult> {
+  if (plan.operations.length === 0) {
+    return { status: 'noop', submitted: false, operationResults: [] };
+  }
+
+  const operationResults: TrustlineSetupResult['operationResults'] = [];
+  let anyFailure = false;
+  let anySubmitted = false;
+
+  for (const op of plan.operations) {
+    try {
+      await submit(op, plan.account);
+      operationResults.push({ asset: op.asset, ok: true });
+      anySubmitted = true;
+    } catch (err) {
+      anyFailure = true;
+      operationResults.push({
+        asset: op.asset,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return {
+    status: anyFailure ? 'failed' : 'submitted',
+    submitted: anySubmitted,
+    operationResults,
+  };
+}


### PR DESCRIPTION
## Summary

Two assigned issues bundled into one PR. Both deliver a focused, fully unit-tested module matching the existing `src/.../stellar/` layout (the simulation cache mirrors the shape of `src/cache/replay/stellar/StellarReplayProtectionCache`).

- **#364 — Soroban route simulation cache** (`src/cache/simulations/stellar/`): `StellarRouteSimulationCache<T>` — a Map-backed, TTL-bounded, LRU-evicting cache for route simulation results. The deterministic `buildSimulationKey` derives a stable key from `{ network, sourceAsset, destinationAsset, sourceAmount }` so repeat callers reuse the result. Four invalidation strategies are exposed so callers can flush narrowly: `invalidate(input)`, `invalidateNetwork(network)`, `invalidateAsset(asset)`, `invalidateBy(predicate)`. A background cleanup timer is `unref`'d so it never holds the event loop open.
- **#365 — Stellar trustline auto-setup** (`src/wallets/trustlines/stellar/`): `detectMissingTrustlines(existing, required)` returns the diff between the account's current trustlines and the ones a transfer needs (native XLM is implicit and excluded). `buildTrustlineSetupPlan(account, existing, required, { limit? })` packages that into a ready-to-execute plan with one `change_trust` op per missing asset. `executeSetupPlan(plan, submit)` runs the plan against an **injectable submitter** so the wallet layer (Freighter, xBull, CLI, UI walk-through, …) picks the transport — and a failing op does not abort the rest of the plan.

## Test plan

- [x] `jest src/cache/simulations/stellar src/wallets/trustlines/stellar` — **25 / 25 new tests pass** (12 for the simulation cache, 13 for the trustline module).
- [x] `tsc --noEmit` is clean for the new files.

## Out of scope

The full repo `jest` shows 75 / 113 suites failing on a clean `main` (40 individual test failures, all in pre-existing files this PR does not touch — `apps/api/src/config/env-schema.spec.ts`, `test/integration/api.test.ts`, `packages/adapters/stellar/src/cache/assets/stellar/assetCache.test.ts`, `packages/utils/src/__tests__/ranker.spec.ts`, etc.). My modules and their specs are among the 38 passing suites; the rest is pre-existing breakage to be tracked separately.

Closes #364
Closes #365