### PR TITLE
: implement Soroban wallet auto-reconnect system (#354)

### DIFF
--- a/PR_354.md
+++ b/PR_354.md
@@ -1,0 +1,24 @@
+## Issue #354: Implement Soroban Wallet Auto-Reconnect System
+
+**PR Title:** 
+`feat: implement Soroban wallet auto-reconnect system (#354)`
+
+**PR Description:**
+```markdown
+## Description
+Closes #354.
+
+This PR implements a robust auto-reconnect system for Stellar/Soroban wallets (such as Freighter) within the `@bridgewise/wallet` package. It preserves disconnected wallet sessions persistently in browser storage and automatically restores them transparently during application initialization, preventing workflow interruptions in bridge operations.
+
+## Changes Made
+- Created `StellarReconnectManager` to serialize, store, and clear active Stellar wallet sessions (adapter type, address, chain ID) in `localStorage` under `bridgewise-stellar-session`.
+- Implemented a 7-day expiration guard to ignore and clean up outdated session states.
+- Extended `WalletManager` with connection persistence hooks in `connect()` and `disconnect()`.
+- Exposed `autoReconnectStellar()` as a public method and integrated an initialization trigger in the `WalletManager` constructor when `autoReconnect` option is enabled.
+- Added comprehensive unit and integration regression tests in `StellarReconnect.test.ts` verifying connection persistence, auto-reconnection, expiration pruning, and graceful missing-extension recovery.
+
+## Acceptance Criteria Met
+- [x] Persist session state of Stellar/Soroban wallets.
+- [x] Reconnect wallets automatically on initialization.
+- [x] Regression and unit tests verify protection and connection restoration logic.
+```

--- a/packages/wallet/src/WalletManager.ts
+++ b/packages/wallet/src/WalletManager.ts
@@ -18,6 +18,7 @@ import type {
   WalletTransaction,
   WalletType,
 } from './types';
+import { StellarReconnectManager } from './adapters/stellar';
 
 /**
  * Wallet manager configuration
@@ -39,6 +40,8 @@ export interface WalletManagerOptions {
   onAccountChange?: (account: WalletAccount | null, walletId: string) => void;
   /** Callback when network changes */
   onNetworkChange?: (chainId: ChainId, network: NetworkType, walletId: string) => void;
+  /** Automatically reconnect Stellar wallet sessions on initialization */
+  autoReconnect?: boolean;
 }
 
 /**
@@ -77,6 +80,15 @@ export class WalletManager {
       for (const adapter of options.adapters) {
         this.registerAdapter(adapter);
       }
+    }
+
+    // Auto-reconnect Stellar sessions if configured
+    if (options.autoReconnect) {
+      setTimeout(() => {
+        this.autoReconnectStellar().catch((err) => {
+          this.options.onError?.(err);
+        });
+      }, 0);
     }
   }
 
@@ -209,6 +221,11 @@ export class WalletManager {
     // Set as active wallet
     this.activeWalletId = adapterId;
 
+    // Persist session if it is a Stellar wallet adapter
+    if (adapter.networkType === 'stellar') {
+      StellarReconnectManager.saveSession(adapterId, account);
+    }
+
     this.emit('connect', { walletId: adapterId, account });
     this.options.onConnect?.(account, adapterId);
 
@@ -230,6 +247,11 @@ export class WalletManager {
 
     this.connections.delete(adapterId);
 
+    // Clear persisted session if it is a Stellar wallet adapter
+    if (adapter.networkType === 'stellar') {
+      StellarReconnectManager.clearSession();
+    }
+
     // If this was the active wallet, switch to another
     if (this.activeWalletId === adapterId) {
       const remaining = Array.from(this.connections.keys());
@@ -248,6 +270,14 @@ export class WalletManager {
       this.disconnect(id)
     );
     await Promise.all(disconnectPromises);
+  }
+
+  /**
+   * Automatically reconnect any previously connected Stellar/Soroban wallet session
+   */
+  async autoReconnectStellar(): Promise<WalletAccount | null> {
+    const reconnectManager = new StellarReconnectManager(this);
+    return reconnectManager.tryReconnect();
   }
 
   // ─── Active Account ────────────────────────────────────────────────────────

--- a/packages/wallet/src/adapters/stellar/index.ts
+++ b/packages/wallet/src/adapters/stellar/index.ts
@@ -6,3 +6,6 @@ export type { StellarAdapterOptions } from './StellarBaseAdapter';
 
 export { FreighterAdapter } from './FreighterAdapter';
 export type { FreighterAdapterOptions } from './FreighterAdapter';
+
+export { StellarReconnectManager } from './reconnect/StellarReconnectManager';
+export type { StellarSession } from './reconnect/StellarReconnectManager';

--- a/packages/wallet/src/adapters/stellar/reconnect/StellarReconnectManager.ts
+++ b/packages/wallet/src/adapters/stellar/reconnect/StellarReconnectManager.ts
@@ -1,0 +1,108 @@
+/**
+ * Stellar Reconnect Manager
+ * Handles persisting Stellar wallet sessions and restoring them automatically
+ */
+
+import type { WalletManager } from '../../../WalletManager';
+import type { WalletAccount } from '../../../types';
+
+/**
+ * Persisted session data format
+ */
+export interface StellarSession {
+  /** The connected adapter identifier (e.g. 'freighter') */
+  adapterId: string;
+  /** The public key or account address */
+  address: string;
+  /** Connected chain ID (e.g. 'stellar:public') */
+  chainId: string;
+  /** Timestamp when session was connected */
+  connectedAt: number;
+}
+
+export class StellarReconnectManager {
+  private static readonly SESSION_KEY = 'bridgewise-stellar-session';
+  private manager: WalletManager;
+
+  constructor(manager: WalletManager) {
+    this.manager = manager;
+  }
+
+  /**
+   * Save the Stellar session state to localStorage
+   */
+  static saveSession(adapterId: string, account: WalletAccount): void {
+    if (typeof window === 'undefined') return;
+
+    const session: StellarSession = {
+      adapterId,
+      address: account.address,
+      chainId: account.chainId,
+      connectedAt: Date.now(),
+    };
+
+    try {
+      window.localStorage.setItem(this.SESSION_KEY, JSON.stringify(session));
+    } catch (error) {
+      console.error('Failed to save Stellar wallet session:', error);
+    }
+  }
+
+  /**
+   * Clear the persisted Stellar session state
+   */
+  static clearSession(): void {
+    if (typeof window === 'undefined') return;
+
+    try {
+      window.localStorage.removeItem(this.SESSION_KEY);
+    } catch (error) {
+      console.error('Failed to clear Stellar wallet session:', error);
+    }
+  }
+
+  /**
+   * Get the persisted Stellar session
+   */
+  static getSession(): StellarSession | null {
+    if (typeof window === 'undefined') return null;
+
+    try {
+      const data = window.localStorage.getItem(this.SESSION_KEY);
+      if (!data) return null;
+      return JSON.parse(data) as StellarSession;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Automatically reconnect the persisted Stellar session
+   */
+  async tryReconnect(): Promise<WalletAccount | null> {
+    const session = StellarReconnectManager.getSession();
+    if (!session) return null;
+
+    // Reject and prune sessions older than 7 days
+    const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
+    if (Date.now() - session.connectedAt > ONE_WEEK) {
+      StellarReconnectManager.clearSession();
+      return null;
+    }
+
+    try {
+      const adapter = this.manager.getAdapter(session.adapterId);
+      if (!adapter || !adapter.isAvailable) {
+        return null;
+      }
+
+      // Automatically reconnect the adapter using the persisted chainId
+      const account = await this.manager.connect(session.adapterId, session.chainId);
+      return account;
+    } catch (error) {
+      console.warn(`Failed to auto-reconnect Stellar wallet (${session.adapterId}):`, error);
+      StellarReconnectManager.clearSession();
+      return null;
+    }
+  }
+}

--- a/packages/wallet/src/adapters/stellar/reconnect/__tests__/StellarReconnect.test.ts
+++ b/packages/wallet/src/adapters/stellar/reconnect/__tests__/StellarReconnect.test.ts
@@ -1,0 +1,195 @@
+import { WalletManager } from '../../../../WalletManager';
+import { StellarReconnectManager } from '../StellarReconnectManager';
+import { StellarBaseAdapter } from '../../StellarBaseAdapter';
+import type { WalletAccount, StellarProvider, ChainId } from '../../../../types';
+
+// Mock Stellar Adapter for testing reconnect
+class MockStellarAdapter extends StellarBaseAdapter {
+  readonly id = 'mock-stellar';
+  readonly name = 'Mock Stellar';
+  readonly type = 'custom' as const;
+  readonly icon = undefined;
+
+  public providerMock: any;
+  public mockIsAvailable = true;
+
+  constructor() {
+    super({ defaultNetwork: 'public' });
+  }
+
+  get isAvailable(): boolean {
+    return this.mockIsAvailable;
+  }
+
+  protected getProvider(): StellarProvider | null {
+    return this.providerMock || null;
+  }
+}
+
+describe('Soroban Wallet Auto-Reconnect System', () => {
+  let manager: WalletManager;
+  let adapter: MockStellarAdapter;
+  let mockProvider: jest.Mocked<any>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    // Mock localStorage
+    const store: Record<string, string> = {};
+    const mockLocalStorage = {
+      getItem: jest.fn((key: string) => store[key] || null),
+      setItem: jest.fn((key: string, val: any) => {
+        store[key] = val.toString();
+      }),
+      removeItem: jest.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: jest.fn(() => {
+        for (const k of Object.keys(store)) {
+          delete store[k];
+        }
+      }),
+    };
+    Object.defineProperty(global, 'localStorage', {
+      value: mockLocalStorage,
+      writable: true,
+      configurable: true,
+    });
+
+    mockProvider = {
+      publicKey: jest.fn().mockResolvedValue('GBMOCKACCOUNT1234567890'),
+      signTransaction: jest.fn(),
+      signData: jest.fn(),
+      getNetwork: jest.fn().mockResolvedValue('Public Global Stellar Network ; September 2015'),
+      isConnected: jest.fn().mockReturnValue(true),
+    };
+
+    adapter = new MockStellarAdapter();
+    adapter.providerMock = mockProvider;
+
+    manager = new WalletManager({
+      adapters: [adapter],
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('Session Persistence', () => {
+    it('should save session state to localStorage on successful connect', async () => {
+      const account = await manager.connect('mock-stellar');
+
+      expect(global.localStorage.setItem).toHaveBeenCalledWith(
+        'bridgewise-stellar-session',
+        expect.any(String)
+      );
+
+      const savedSession = StellarReconnectManager.getSession();
+      expect(savedSession).not.toBeNull();
+      expect(savedSession?.adapterId).toBe('mock-stellar');
+      expect(savedSession?.address).toBe(account.address);
+      expect(savedSession?.chainId).toBe('stellar:public');
+    });
+
+    it('should clear session state from localStorage on disconnect', async () => {
+      await manager.connect('mock-stellar');
+      await manager.disconnect('mock-stellar');
+
+      expect(global.localStorage.removeItem).toHaveBeenCalledWith('bridgewise-stellar-session');
+      expect(StellarReconnectManager.getSession()).toBeNull();
+    });
+  });
+
+  describe('Auto-Reconnect Restoration', () => {
+    it('should successfully restore an active persisted session', async () => {
+      // Setup stored session
+      const accountMock: WalletAccount = {
+        address: 'GBMOCKACCOUNT1234567890',
+        publicKey: 'GBMOCKACCOUNT1234567890',
+        chainId: 'stellar:public',
+        network: 'stellar',
+      };
+      StellarReconnectManager.saveSession('mock-stellar', accountMock);
+
+      // Trigger auto-reconnect
+      const account = await manager.autoReconnectStellar();
+
+      expect(account).not.toBeNull();
+      expect(account?.address).toBe('GBMOCKACCOUNT1234567890');
+      expect(manager.getActiveAccount()?.address).toBe('GBMOCKACCOUNT1234567890');
+      expect(manager.getActiveWallet()?.id).toBe('mock-stellar');
+    });
+
+    it('should not reconnect and should clear session if it is older than 7 days', async () => {
+      const accountMock: WalletAccount = {
+        address: 'GBMOCKACCOUNT1234567890',
+        publicKey: 'GBMOCKACCOUNT1234567890',
+        chainId: 'stellar:public',
+        network: 'stellar',
+      };
+
+      // Persist session
+      StellarReconnectManager.saveSession('mock-stellar', accountMock);
+
+      // Backdate the session to 8 days ago
+      const session = StellarReconnectManager.getSession()!;
+      session.connectedAt = Date.now() - (8 * 24 * 60 * 60 * 1000);
+      window.localStorage.setItem('bridgewise-stellar-session', JSON.stringify(session));
+
+      // Trigger auto-reconnect
+      const account = await manager.autoReconnectStellar();
+
+      expect(account).toBeNull();
+      expect(manager.getActiveAccount()).toBeNull();
+      expect(StellarReconnectManager.getSession()).toBeNull(); // Cleared
+    });
+
+    it('should fail gracefully and clear session if adapter is unavailable', async () => {
+      const accountMock: WalletAccount = {
+        address: 'GBMOCKACCOUNT1234567890',
+        publicKey: 'GBMOCKACCOUNT1234567890',
+        chainId: 'stellar:public',
+        network: 'stellar',
+      };
+      StellarReconnectManager.saveSession('mock-stellar', accountMock);
+
+      // Make adapter unavailable
+      adapter.mockIsAvailable = false;
+
+      const account = await manager.autoReconnectStellar();
+
+      expect(account).toBeNull();
+      expect(manager.getActiveAccount()).toBeNull();
+    });
+
+    it('should trigger reconnect on manager creation if autoReconnect option is active', async () => {
+      const accountMock: WalletAccount = {
+        address: 'GBMOCKACCOUNT1234567890',
+        publicKey: 'GBMOCKACCOUNT1234567890',
+        chainId: 'stellar:public',
+        network: 'stellar',
+      };
+      StellarReconnectManager.saveSession('mock-stellar', accountMock);
+
+      const onConnectSpy = jest.fn();
+
+      const newManager = new WalletManager({
+        adapters: [adapter],
+        autoReconnect: true,
+        onConnect: onConnectSpy,
+      });
+
+      // Run microtasks/timeouts
+      jest.runAllTimers();
+
+      // Flush microtask queue to resolve all nested promises
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+
+      expect(newManager.getActiveAccount()?.address).toBe('GBMOCKACCOUNT1234567890');
+    });
+  });
+});

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -78,6 +78,8 @@ export { StellarBaseAdapter } from './adapters/stellar';
 export type { StellarAdapterOptions } from './adapters/stellar';
 export { FreighterAdapter } from './adapters/stellar';
 export type { FreighterAdapterOptions } from './adapters/stellar';
+export { StellarReconnectManager } from './adapters/stellar';
+export type { StellarSession } from './adapters/stellar';
 
 // Wallet Manager
 export { WalletManager } from './WalletManager';


### PR DESCRIPTION
Closes #354.
This PR implements a robust auto-reconnect system for Stellar/Soroban wallets (such as Freighter) within the `@bridgewise/wallet` package. It preserves disconnected wallet sessions persistently in browser storage and automatically restores them transparently during application initialization, preventing workflow interruptions in bridge operations.
## Changes Made
- Created `StellarReconnectManager` to serialize, store, and clear active Stellar wallet sessions (adapter type, address, chain ID) in `localStorage` under `bridgewise-stellar-session`.
- Implemented a 7-day expiration guard to ignore and clean up outdated session states.
- Extended `WalletManager` with connection persistence hooks in `connect()` and `disconnect()`.
- Exposed `autoReconnectStellar()` as a public method and integrated an initialization trigger in the `WalletManager` constructor when `autoReconnect` option is enabled.
- Added comprehensive unit and integration regression tests in `StellarReconnect.test.ts` verifying connection persistence, auto-reconnection, expiration pruning, and graceful missing-extension recovery.
## Acceptance Criteria Met
- [x] Persist session state of Stellar/Soroban wallets.
- [x] Reconnect wallets automatically on initialization.
- [x] Regression and unit tests verify protection and connection restoration logic.