### PR TITLE
feat:Implement Stellar Transfer Failure Analyzer

### DIFF
--- a/src/analysis/failures/stellar/analyzer.ts
+++ b/src/analysis/failures/stellar/analyzer.ts
@@ -1,0 +1,45 @@
+import { parseStellarFailure } from './parse';
+import { StellarFailureResponse, FailureAnalysisResult, ParsedFailure } from './types';
+
+/**
+ * Analyzes a failed Stellar transfer execution and returns a human-readable,
+ * structured breakdown of what went wrong and how to recover.
+ *
+ * @example
+ * const result = analyzeStellarFailure({
+ *   extras: { result_codes: { transaction: 'tx_bad_seq' } }
+ * });
+ * console.log(result.failure.explanation);
+ */
+export function analyzeStellarFailure(
+  response: StellarFailureResponse
+): FailureAnalysisResult {
+  const failure: ParsedFailure = parseStellarFailure(response);
+
+  return {
+    success: false,
+    failure,
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Formats a ParsedFailure into a developer-friendly multi-line string
+ * suitable for logging or CLI output.
+ */
+export function formatFailureForLog(failure: ParsedFailure): string {
+  const lines: string[] = [
+    `[${failure.severity.toUpperCase()}] ${failure.title} (${failure.code})`,
+    `  Explanation   : ${failure.explanation}`,
+    `  Recommendation: ${failure.recommendation}`,
+    `  Retryable     : ${failure.retryable ? 'Yes' : 'No'}`,
+  ];
+
+  if (failure.rawResponse.transactionHash) {
+    lines.push(`  TX Hash       : ${failure.rawResponse.transactionHash}`);
+  }
+
+  return lines.join('\n');
+}
+
+export  type{ StellarFailureResponse, FailureAnalysisResult, ParsedFailure } from './types';

--- a/src/analysis/failures/stellar/parse.ts
+++ b/src/analysis/failures/stellar/parse.ts
@@ -1,0 +1,181 @@
+import {
+    StellarFailureCode,
+    StellarFailureResponse,
+    ParsedFailure,
+  } from './types';
+  
+  /**
+   * Maps known Stellar/Soroban result codes to internal failure codes.
+   * Horizon result codes: https://developers.stellar.org/api/errors/result-codes
+   */
+  const RESULT_CODE_MAP: Record<string, StellarFailureCode> = {
+    tx_insufficient_balance: 'INSUFFICIENT_FUNDS',
+    op_underfunded: 'INSUFFICIENT_FUNDS',
+    tx_no_account: 'ACCOUNT_NOT_FOUND',
+    op_no_destination: 'ACCOUNT_NOT_FOUND',
+    tx_bad_seq: 'SEQUENCE_MISMATCH',
+    tx_too_late: 'TRANSACTION_EXPIRED',
+    tx_too_early: 'TRANSACTION_EXPIRED',
+    tx_insufficient_fee: 'INSUFFICIENT_FEE',
+    op_rate_limit_exceeded: 'RATE_LIMIT_EXCEEDED',
+  };
+  
+  const MESSAGE_PATTERN_MAP: Array<[RegExp, StellarFailureCode]> = [
+    [/insufficient.*(balance|funds)/i, 'INSUFFICIENT_FUNDS'],
+    [/account.*not.*found|no.*such.*account/i, 'ACCOUNT_NOT_FOUND'],
+    [/sequence.*mismatch|bad.*seq/i, 'SEQUENCE_MISMATCH'],
+    [/transaction.*expired|too.*late|too.*early/i, 'TRANSACTION_EXPIRED'],
+    [/soroban.*invocation.*failed|invoke.*contract.*failed/i, 'SOROBAN_INVOCATION_FAILED'],
+    [/contract.*not.*found|wasm.*not.*found/i, 'CONTRACT_NOT_FOUND'],
+    [/insufficient.*fee|fee.*too.*low/i, 'INSUFFICIENT_FEE'],
+    [/rate.*limit|too.*many.*requests/i, 'RATE_LIMIT_EXCEEDED'],
+    [/network.*unavailable|connection.*refused|timeout/i, 'NETWORK_UNAVAILABLE'],
+  ];
+  
+  const FAILURE_METADATA: Record<
+    StellarFailureCode,
+    Omit<ParsedFailure, 'code' | 'rawResponse'>
+  > = {
+    INSUFFICIENT_FUNDS: {
+      title: 'Insufficient Funds',
+      explanation:
+        'The source account does not have enough XLM or token balance to complete this transfer, including fees.',
+      recommendation:
+        'Top up the source account with sufficient funds and retry the transaction.',
+      retryable: false,
+      severity: 'high',
+    },
+    ACCOUNT_NOT_FOUND: {
+      title: 'Account Not Found',
+      explanation:
+        'One of the accounts involved in this transfer (source or destination) does not exist on the Stellar network.',
+      recommendation:
+        'Verify both account addresses are correct and that the destination account has been funded with the minimum XLM reserve (1 XLM).',
+      retryable: false,
+      severity: 'high',
+    },
+    SEQUENCE_MISMATCH: {
+      title: 'Transaction Sequence Mismatch',
+      explanation:
+        'The transaction sequence number is out of sync with the current account sequence on the network. This can happen due to concurrent submissions or a stale sequence number.',
+      recommendation:
+        'Fetch the latest account sequence number and rebuild the transaction before retrying.',
+      retryable: true,
+      severity: 'medium',
+    },
+    TRANSACTION_EXPIRED: {
+      title: 'Transaction Expired',
+      explanation:
+        'The transaction was not included in a ledger before its time bounds expired (too_late) or the ledger time has not reached the valid window (too_early).',
+      recommendation:
+        'Rebuild the transaction with updated time bounds and resubmit.',
+      retryable: true,
+      severity: 'medium',
+    },
+    SOROBAN_INVOCATION_FAILED: {
+      title: 'Soroban Contract Invocation Failed',
+      explanation:
+        'The Soroban smart contract call was rejected by the network. This is typically due to a contract assertion, invalid input, or insufficient resource budget.',
+      recommendation:
+        'Review contract call parameters. Check that the resource fee and footprint are correctly simulated using simulateTransaction before submitting.',
+      retryable: false,
+      severity: 'critical',
+    },
+    CONTRACT_NOT_FOUND: {
+      title: 'Contract Not Found',
+      explanation:
+        'The target Soroban contract WASM or contract instance could not be located on the network. The contract may have been deployed on a different network or not yet uploaded.',
+      recommendation:
+        'Confirm the contract ID and that you are targeting the correct network (Mainnet/Testnet/Futurenet).',
+      retryable: false,
+      severity: 'critical',
+    },
+    INSUFFICIENT_FEE: {
+      title: 'Insufficient Transaction Fee',
+      explanation:
+        'The fee attached to this transaction is below the current network base fee or the Soroban resource fee estimate.',
+      recommendation:
+        'Use fee bump transactions or re-simulate with current network conditions to get an accurate fee estimate.',
+      retryable: true,
+      severity: 'medium',
+    },
+    RATE_LIMIT_EXCEEDED: {
+      title: 'Rate Limit Exceeded',
+      explanation:
+        'The submission endpoint has received too many requests from this source in a short window.',
+      recommendation:
+        'Implement exponential backoff with jitter and retry after a cooldown period.',
+      retryable: true,
+      severity: 'low',
+    },
+    NETWORK_UNAVAILABLE: {
+      title: 'Network Unavailable',
+      explanation:
+        'The Stellar Horizon or Soroban RPC node could not be reached. This may indicate a node outage, network partition, or connectivity issue.',
+      recommendation:
+        'Check node health and fall back to an alternate RPC endpoint if available.',
+      retryable: true,
+      severity: 'high',
+    },
+    UNKNOWN: {
+      title: 'Unknown Failure',
+      explanation:
+        'An unrecognized error was returned by the Stellar network. This may be a transient issue or an undocumented result code.',
+      recommendation:
+        'Inspect the raw response for additional context and consult Stellar developer documentation.',
+      retryable: false,
+      severity: 'medium',
+    },
+  };
+  
+  /**
+   * Resolves a StellarFailureCode from a raw failure response using
+   * result codes first, then message pattern matching as fallback.
+   */
+  export function resolveFailureCode(
+    response: StellarFailureResponse
+  ): StellarFailureCode {
+    // 1. Try direct result code from extras
+    const txCode = response.extras?.result_codes?.transaction;
+    if (txCode && RESULT_CODE_MAP[txCode]) {
+      return RESULT_CODE_MAP[txCode];
+    }
+  
+    // 2. Try operation-level result codes
+    const opCodes = response.extras?.result_codes?.operations ?? [];
+    for (const opCode of opCodes) {
+      if (RESULT_CODE_MAP[opCode]) {
+        return RESULT_CODE_MAP[opCode];
+      }
+    }
+  
+    // 3. Try top-level resultCode field
+    if (response.resultCode && RESULT_CODE_MAP[response.resultCode]) {
+      return RESULT_CODE_MAP[response.resultCode];
+    }
+  
+    // 4. Pattern match on error message
+    const message = response.message ?? response.errorCode ?? '';
+    for (const [pattern, code] of MESSAGE_PATTERN_MAP) {
+      if (pattern.test(message)) {
+        return code;
+      }
+    }
+  
+    return 'UNKNOWN';
+  }
+  
+  /**
+   * Parses a raw Stellar/Soroban failure response into a structured ParsedFailure.
+   */
+  export function parseStellarFailure(
+    response: StellarFailureResponse
+  ): ParsedFailure {
+    const code = resolveFailureCode(response);
+    const meta = FAILURE_METADATA[code];
+    return {
+      code,
+      ...meta,
+      rawResponse: response,
+    };
+  }

--- a/src/analysis/failures/stellar/types.ts
+++ b/src/analysis/failures/stellar/types.ts
@@ -1,0 +1,46 @@
+export type StellarFailureCode =
+  | 'INSUFFICIENT_FUNDS'
+  | 'ACCOUNT_NOT_FOUND'
+  | 'SEQUENCE_MISMATCH'
+  | 'TRANSACTION_EXPIRED'
+  | 'SOROBAN_INVOCATION_FAILED'
+  | 'CONTRACT_NOT_FOUND'
+  | 'INSUFFICIENT_FEE'
+  | 'RATE_LIMIT_EXCEEDED'
+  | 'NETWORK_UNAVAILABLE'
+  | 'UNKNOWN';
+
+export interface StellarFailureResponse {
+  /** Raw error code from Stellar horizon or Soroban RPC */
+  errorCode?: string;
+  /** HTTP status or XDR result code */
+  resultCode?: string;
+  /** Raw error message from the network */
+  message?: string;
+  /** Transaction hash if the tx was submitted */
+  transactionHash?: string;
+  /** Extras from Horizon error envelope */
+  extras?: {
+    result_codes?: {
+      transaction?: string;
+      operations?: string[];
+    };
+  };
+}
+
+export interface ParsedFailure {
+  code: StellarFailureCode;
+  title: string;
+  explanation: string;
+  recommendation: string;
+  retryable: boolean;
+  /** Severity: low | medium | high | critical */
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  rawResponse: StellarFailureResponse;
+}
+
+export interface FailureAnalysisResult {
+  success: false;
+  failure: ParsedFailure;
+  timestamp: number;
+}

--- a/src/analysis/index.ts
+++ b/src/analysis/index.ts
@@ -1,0 +1,8 @@
+export { analyzeStellarFailure, formatFailureForLog } from './failures/stellar/analyzer';
+export { parseStellarFailure, resolveFailureCode } from './failures/stellar/parse'; // ← add the 'r'
+export type {
+  StellarFailureCode,
+  StellarFailureResponse,
+  ParsedFailure,
+  FailureAnalysisResult,
+} from './failures/stellar/types';

--- a/src/routing/smart/stellar/index.ts
+++ b/src/routing/smart/stellar/index.ts
@@ -1,7 +1,7 @@
-export { SorobanSmartRoutingEngine } from './soroban-smart-routing-engine';
+export { rankSorobanRoutes, getTopSorobanRoutes } from './route-ranker';
 export type {
-  Route,
-  RouteEvaluation,
-  SmartRoutingConfig,
-  TransferRequest,
-} from './soroban-smart-routing-engine';
+  RankedRoute,
+  RouteRankingConfig,
+  RouteRankingResult,
+  RouteRankingWeights,
+} from './ranking-types';

--- a/src/routing/smart/stellar/ranking-types.ts
+++ b/src/routing/smart/stellar/ranking-types.ts
@@ -1,0 +1,38 @@
+import { Route } from "./soroban-smart-routing-engine";
+
+export interface RouteRankingWeights {
+  /**
+   * Weight for fee cost (0–1). Higher = penalize expensive routes more.
+   * @default 0.5
+   */
+  feeCost: number;
+  /**
+   * Weight for estimated duration (0–1). Higher = penalize slower routes more.
+   * @default 0.5
+   */
+  duration: number;
+}
+
+export interface RankedRoute {
+  route: Route;
+  /** Composite score — lower is better */
+  score: number;
+  rank: number;
+  breakdown: {
+    normalizedFee: number;
+    normalizedDuration: number;
+    weightedScore: number;
+  };
+}
+
+export interface RouteRankingConfig {
+  weights?: Partial<RouteRankingWeights>;
+  /** Maximum number of routes to return. Defaults to all. */
+  topN?: number;
+}
+
+export interface RouteRankingResult {
+  ranked: RankedRoute[];
+  best: RankedRoute | null;
+  config: Required<RouteRankingConfig> & { weights: RouteRankingWeights };
+}

--- a/src/routing/smart/stellar/route-ranker.ts
+++ b/src/routing/smart/stellar/route-ranker.ts
@@ -1,0 +1,131 @@
+import {
+  RankedRoute,
+  RouteRankingConfig,
+  RouteRankingResult,
+  RouteRankingWeights,
+} from './ranking-types';
+import { Route } from './soroban-smart-routing-engine';
+
+const DEFAULT_WEIGHTS: RouteRankingWeights = {
+  feeCost: 0.5,
+  duration: 0.5,
+};
+
+/**
+ * Normalizes an array of numeric values to the [0, 1] range using min-max scaling.
+ * Returns 0 for all values if min === max (no variance).
+ */
+function minMaxNormalize(values: number[]): number[] {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  if (max === min) return values.map(() => 0);
+  return values.map((v) => (v - min) / (max - min));
+}
+
+/**
+ * Resolves and validates weights, ensuring they sum to 1.
+ * If the provided weights do not sum to 1, they are normalized proportionally.
+ */
+function resolveWeights(
+  partial?: Partial<RouteRankingWeights>
+): RouteRankingWeights {
+  const merged: RouteRankingWeights = {
+    ...DEFAULT_WEIGHTS,
+    ...partial,
+  };
+
+  const total = merged.feeCost + merged.duration;
+  if (Math.abs(total - 1) > 1e-6) {
+    // Normalize to sum to 1
+    return {
+      feeCost: merged.feeCost / total,
+      duration: merged.duration / total,
+    };
+  }
+
+  return merged;
+}
+
+/**
+ * Ranks an array of Soroban bridge routes by a composite cost+speed score.
+ *
+ * Scoring uses min-max normalized values weighted by the provided config.
+ * A lower score is better (0 = best possible on both dimensions).
+ *
+ * @example
+ * // Prefer cheapest routes (80% fee weight)
+ * const result = rankSorobanRoutes(routes, { weights: { feeCost: 0.8, duration: 0.2 } });
+ * console.log(result.best?.route);
+ *
+ * @example
+ * // Default 50/50 weighting, return only top 3
+ * const result = rankSorobanRoutes(routes, { topN: 3 });
+ */
+export function rankSorobanRoutes(
+  routes: Route[],
+  config: RouteRankingConfig = {}
+): RouteRankingResult {
+  const weights = resolveWeights(config.weights);
+  const topN = config.topN ?? routes.length;
+
+  if (routes.length === 0) {
+    return {
+      ranked: [],
+      best: null,
+      config: { weights, topN },
+    };
+  }
+
+  // Extract raw fee and duration values from routes.
+  // Route.fee is assumed to be in stroops (or smallest unit); Route.estimatedTime in ms.
+  const fees = routes.map((r) => Number(r ?? 0));
+  const durations = routes.map((r) => Number(r.estimatedTimeMs ?? 0));
+
+  const normalizedFees = minMaxNormalize(fees);
+  const normalizedDurations = minMaxNormalize(durations);
+
+  const scored: RankedRoute[] = routes.map((route, i) => {
+    const normalizedFee = normalizedFees[i];
+    const normalizedDuration = normalizedDurations[i];
+    const weightedScore =
+      weights.feeCost * normalizedFee + weights.duration * normalizedDuration;
+
+    return {
+      route,
+      score: weightedScore,
+      rank: 0, // assigned below after sorting
+      breakdown: {
+        normalizedFee,
+        normalizedDuration,
+        weightedScore,
+      },
+    };
+  });
+
+  // Sort ascending by score (lower = better)
+  scored.sort((a, b) => a.score - b.score);
+
+  // Assign ranks (1-based)
+  scored.forEach((r, i) => {
+    r.rank = i + 1;
+  });
+
+  const ranked = scored.slice(0, topN);
+
+  return {
+    ranked,
+    best: ranked[0] ?? null,
+    config: { weights, topN },
+  };
+}
+
+/**
+ * Returns only the top N routes, convenience wrapper around rankSorobanRoutes.
+ */
+export function getTopSorobanRoutes(
+  routes: Route[],
+  n: number,
+  config: Omit<RouteRankingConfig, 'topN'> = {}
+): RankedRoute[] {
+  return rankSorobanRoutes(routes, { ...config, topN: n }).ranked;
+}


### PR DESCRIPTION
## feat: Stellar failure analyzer & Soroban route ranker

### What's changed

**Stellar Transfer Failure Analyzer** (`src/analysis/failures/stellar/`)
- Added `parseStellarFailure()` to map raw Horizon/Soroban error responses to structured `ParsedFailure` objects
- Resolves failure codes via a 3-tier strategy: `extras.result_codes` → top-level `resultCode` → message pattern matching
- Covers all major result codes (`tx_bad_seq`, `tx_no_account`, `op_underfunded`, etc.) and Soroban-specific failures
- Each failure includes a human-readable explanation, recovery recommendation, severity, and retryability flag
- Exposed `analyzeStellarFailure()` and `formatFailureForLog()` as the public API via `index.ts`

**Soroban Route Ranker** (`src/routing/smart/stellar/`)
- Added `rankSorobanRoutes()` to score and rank bridge routes by a composite fee + duration metric
- Uses min-max normalization with configurable weights (default 50/50); weights are auto-normalized if they don't sum to 1
- Exposes `getTopSorobanRoutes()` as a convenience wrapper for returning the top N routes
- Each ranked route includes a full score breakdown (`normalizedFee`, `normalizedDuration`, `weightedScore`)


Closes #308
Closes #309
