### PR TITLE
feat: implement Soroban bridge event webhooks and Stellar retry mechanism (#306, #307)

### DIFF
--- a/src/recovery/stellar/index.ts
+++ b/src/recovery/stellar/index.ts
@@ -1,0 +1,8 @@
+export { StellarBridgeRetryService, isRetryableFailure, computeRetryDelay } from './stellar-bridge-retry.service';
+export type {
+  RetryConfig,
+  RetryAttempt,
+  RetryResult,
+  BridgeOperationFn,
+} from './stellar-bridge-retry.types';
+export { RETRYABLE_FAILURE_CODES, DEFAULT_RETRY_CONFIG } from './stellar-bridge-retry.types';

--- a/src/recovery/stellar/stellar-bridge-retry.service.spec.ts
+++ b/src/recovery/stellar/stellar-bridge-retry.service.spec.ts
@@ -1,0 +1,189 @@
+import {
+  StellarBridgeRetryService,
+  isRetryableFailure,
+  computeRetryDelay,
+} from './stellar-bridge-retry.service';
+import { DEFAULT_RETRY_CONFIG } from './stellar-bridge-retry.types';
+
+// ---------------------------------------------------------------------------
+// isRetryableFailure
+// ---------------------------------------------------------------------------
+
+describe('isRetryableFailure', () => {
+  it.each([
+    'SEQUENCE_MISMATCH',
+    'TRANSACTION_EXPIRED',
+    'NETWORK_UNAVAILABLE',
+    'RATE_LIMIT_EXCEEDED',
+    'INSUFFICIENT_FEE',
+    'sequence_mismatch',         // case-insensitive
+    'Network timeout',
+    'connection refused',
+    'HTTP 503 Service Unavailable',
+    'HTTP 429',
+    'Too many requests',
+  ])('returns true for retryable reason: %s', (reason) => {
+    expect(isRetryableFailure(reason)).toBe(true);
+  });
+
+  it.each([
+    'INSUFFICIENT_FUNDS',
+    'ACCOUNT_NOT_FOUND',
+    'SOROBAN_INVOCATION_FAILED',
+    'CONTRACT_NOT_FOUND',
+    'UNKNOWN',
+    'Bad request',
+  ])('returns false for non-retryable reason: %s', (reason) => {
+    expect(isRetryableFailure(reason)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRetryDelay
+// ---------------------------------------------------------------------------
+
+describe('computeRetryDelay', () => {
+  const cfg = { ...DEFAULT_RETRY_CONFIG, initialDelayMs: 1_000, backoffMultiplier: 2, maxDelayMs: 30_000 };
+
+  it('returns initialDelayMs for the first attempt', () => {
+    expect(computeRetryDelay(1, cfg)).toBe(1_000);
+  });
+
+  it('doubles the delay on each successive attempt', () => {
+    expect(computeRetryDelay(2, cfg)).toBe(2_000);
+    expect(computeRetryDelay(3, cfg)).toBe(4_000);
+    expect(computeRetryDelay(4, cfg)).toBe(8_000);
+    expect(computeRetryDelay(5, cfg)).toBe(16_000);
+  });
+
+  it('caps the delay at maxDelayMs', () => {
+    expect(computeRetryDelay(10, cfg)).toBe(30_000);
+    expect(computeRetryDelay(20, cfg)).toBe(30_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StellarBridgeRetryService
+// ---------------------------------------------------------------------------
+
+describe('StellarBridgeRetryService', () => {
+  const noopSleep = jest.fn().mockResolvedValue(undefined);
+
+  let service: StellarBridgeRetryService;
+
+  beforeEach(() => {
+    noopSleep.mockClear();
+    service = new StellarBridgeRetryService({}, noopSleep);
+  });
+
+  describe('non-retryable failures', () => {
+    it('skips the operation entirely and returns totalAttempts = 0', async () => {
+      const operation = jest.fn();
+      const result = await service.retry('tx-hash', 'INSUFFICIENT_FUNDS', operation);
+
+      expect(result.success).toBe(false);
+      expect(result.totalAttempts).toBe(0);
+      expect(result.attempts).toHaveLength(0);
+      expect(operation).not.toHaveBeenCalled();
+    });
+
+    it('includes a descriptive finalError', async () => {
+      const result = await service.retry('tx-hash', 'ACCOUNT_NOT_FOUND', jest.fn());
+      expect(result.finalError).toContain('Non-retryable');
+      expect(result.finalError).toContain('ACCOUNT_NOT_FOUND');
+    });
+  });
+
+  describe('successful retries', () => {
+    it('succeeds on the first attempt', async () => {
+      const operation = jest.fn().mockResolvedValue('recovery-tx-1');
+      const result = await service.retry('tx-hash', 'SEQUENCE_MISMATCH', operation);
+
+      expect(result.success).toBe(true);
+      expect(result.totalAttempts).toBe(1);
+      expect(result.recoveryTransactionHash).toBe('recovery-tx-1');
+      expect(result.attempts).toHaveLength(1);
+      expect(result.attempts[0].success).toBe(true);
+    });
+
+    it('succeeds on a subsequent attempt after initial failures', async () => {
+      const operation = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('transient error'))
+        .mockResolvedValue('recovery-tx-2');
+
+      const result = await service.retry('tx-hash', 'Network timeout', operation);
+
+      expect(result.success).toBe(true);
+      expect(result.totalAttempts).toBe(2);
+      expect(result.recoveryTransactionHash).toBe('recovery-tx-2');
+      expect(result.attempts).toHaveLength(2);
+      expect(result.attempts[0].success).toBe(false);
+      expect(result.attempts[1].success).toBe(true);
+    });
+
+    it('passes the transferHash to the operation', async () => {
+      const operation = jest.fn().mockResolvedValue('recovery-tx');
+      await service.retry('specific-tx-hash', 'RATE_LIMIT_EXCEEDED', operation);
+      expect(operation).toHaveBeenCalledWith('specific-tx-hash');
+    });
+  });
+
+  describe('exhausted retries', () => {
+    it('returns failure after exhausting all attempts', async () => {
+      service = new StellarBridgeRetryService({ maxAttempts: 3 }, noopSleep);
+      const operation = jest.fn().mockRejectedValue(new Error('persistent error'));
+
+      const result = await service.retry('tx-hash', 'RATE_LIMIT_EXCEEDED', operation);
+
+      expect(result.success).toBe(false);
+      expect(result.totalAttempts).toBe(3);
+      expect(result.finalError).toBe('persistent error');
+      expect(result.attempts).toHaveLength(3);
+      expect(operation).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not set nextRetryDelayMs on the last attempt', async () => {
+      service = new StellarBridgeRetryService({ maxAttempts: 2 }, noopSleep);
+      const operation = jest.fn().mockRejectedValue(new Error('error'));
+
+      const result = await service.retry('tx-hash', 'TRANSACTION_EXPIRED', operation);
+
+      expect(result.attempts[result.attempts.length - 1].nextRetryDelayMs).toBeUndefined();
+    });
+  });
+
+  describe('backoff behaviour', () => {
+    it('does not sleep before the first attempt', async () => {
+      const operation = jest.fn().mockResolvedValue('recovery-tx');
+      await service.retry('tx-hash', 'SEQUENCE_MISMATCH', operation);
+      expect(noopSleep).not.toHaveBeenCalled();
+    });
+
+    it('sleeps with the correct delay before subsequent attempts', async () => {
+      // initialDelayMs=500, backoffMultiplier=2 → delay before attempt 2 = 500 * 2^1 = 1000
+      service = new StellarBridgeRetryService({ initialDelayMs: 500 }, noopSleep);
+      const operation = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('err'))
+        .mockResolvedValue('recovery-tx');
+
+      await service.retry('tx-hash', 'TRANSACTION_EXPIRED', operation);
+
+      expect(noopSleep).toHaveBeenCalledTimes(1);
+      expect(noopSleep).toHaveBeenCalledWith(1000);
+    });
+
+    it('sets nextRetryDelayMs on non-final failed attempts', async () => {
+      service = new StellarBridgeRetryService({ initialDelayMs: 1_000 }, noopSleep);
+      const operation = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('err'))
+        .mockResolvedValue('recovery-tx');
+
+      const result = await service.retry('tx-hash', 'NETWORK_UNAVAILABLE', operation);
+
+      expect(result.attempts[0].nextRetryDelayMs).toBe(2_000);
+    });
+  });
+});

--- a/src/recovery/stellar/stellar-bridge-retry.service.ts
+++ b/src/recovery/stellar/stellar-bridge-retry.service.ts
@@ -1,0 +1,145 @@
+import {
+  RetryConfig,
+  DEFAULT_RETRY_CONFIG,
+  RETRYABLE_FAILURE_CODES,
+  RetryAttempt,
+  RetryResult,
+  BridgeOperationFn,
+} from './stellar-bridge-retry.types';
+
+/**
+ * Determine whether a failure reason string represents a transient error that
+ * is safe to retry automatically.
+ *
+ * Detection covers both named failure codes (SEQUENCE_MISMATCH, etc.) and
+ * common network-level patterns (timeout, 503, 429, …).
+ */
+export function isRetryableFailure(failureReason: string): boolean {
+  const upper = failureReason.toUpperCase();
+  for (const code of RETRYABLE_FAILURE_CODES) {
+    if (upper.includes(code)) return true;
+  }
+  return /timeout|network.*unavailable|connection.*refused|503|429|too.*many.*requests/i.test(
+    failureReason,
+  );
+}
+
+/**
+ * Compute the exponential backoff delay (in ms) for a given attempt number.
+ *
+ * Formula: `min(initialDelayMs * backoffMultiplier^(attempt - 1), maxDelayMs)`
+ *
+ * @param attemptNumber  1-based attempt index
+ * @param config         Retry configuration (defaults to DEFAULT_RETRY_CONFIG)
+ */
+export function computeRetryDelay(
+  attemptNumber: number,
+  config: RetryConfig = DEFAULT_RETRY_CONFIG,
+): number {
+  const delay =
+    config.initialDelayMs * Math.pow(config.backoffMultiplier, attemptNumber - 1);
+  return Math.min(delay, config.maxDelayMs);
+}
+
+/**
+ * Retries failed Stellar bridge operations automatically.
+ *
+ * Responsibilities:
+ *  - Detect retryable failures using {@link isRetryableFailure}
+ *  - Execute retry attempts with exponential backoff via {@link computeRetryDelay}
+ *  - Track per-attempt history and return a full {@link RetryResult}
+ *
+ * The `sleep` dependency is injected so it can be replaced with a no-op in
+ * tests, keeping them fast and deterministic.
+ *
+ * Example:
+ *   const retryService = new StellarBridgeRetryService({ maxAttempts: 3 });
+ *   const result = await retryService.retry(
+ *     transferHash,
+ *     failureReason,
+ *     (hash) => bridgeClient.resubmit(hash),
+ *   );
+ */
+export class StellarBridgeRetryService {
+  private readonly config: RetryConfig;
+
+  constructor(
+    config: Partial<RetryConfig> = {},
+    private readonly sleep: (ms: number) => Promise<void> = (ms) =>
+      new Promise((resolve) => setTimeout(resolve, ms)),
+  ) {
+    this.config = { ...DEFAULT_RETRY_CONFIG, ...config };
+  }
+
+  /**
+   * Retry a failed bridge operation until it succeeds or all attempts are
+   * exhausted.
+   *
+   * If the `failureReason` is classified as non-retryable the operation is
+   * never invoked and `RetryResult.totalAttempts` is 0.
+   *
+   * @param transferHash  Stellar transaction hash of the failed transfer
+   * @param failureReason Human-readable or code-based reason for initial failure
+   * @param operation     Async function that performs the bridge operation.
+   *                      Resolves to the recovery transaction hash on success,
+   *                      throws on failure.
+   */
+  async retry(
+    transferHash: string,
+    failureReason: string,
+    operation: BridgeOperationFn,
+  ): Promise<RetryResult> {
+    if (!isRetryableFailure(failureReason)) {
+      return {
+        transferHash,
+        totalAttempts: 0,
+        success: false,
+        finalError: `Non-retryable failure: ${failureReason}`,
+        attempts: [],
+      };
+    }
+
+    const attempts: RetryAttempt[] = [];
+
+    for (let attempt = 1; attempt <= this.config.maxAttempts; attempt++) {
+      const startedAt = Date.now();
+
+      if (attempt > 1) {
+        await this.sleep(computeRetryDelay(attempt, this.config));
+      }
+
+      try {
+        const recoveryTransactionHash = await operation(transferHash);
+        attempts.push({ attemptNumber: attempt, startedAt, success: true });
+        return {
+          transferHash,
+          totalAttempts: attempt,
+          success: true,
+          recoveryTransactionHash,
+          attempts,
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const isLastAttempt = attempt >= this.config.maxAttempts;
+
+        attempts.push({
+          attemptNumber: attempt,
+          startedAt,
+          success: false,
+          error: errorMessage,
+          nextRetryDelayMs: isLastAttempt
+            ? undefined
+            : computeRetryDelay(attempt + 1, this.config),
+        });
+      }
+    }
+
+    return {
+      transferHash,
+      totalAttempts: this.config.maxAttempts,
+      success: false,
+      finalError: attempts[attempts.length - 1]?.error,
+      attempts,
+    };
+  }
+}

--- a/src/recovery/stellar/stellar-bridge-retry.types.ts
+++ b/src/recovery/stellar/stellar-bridge-retry.types.ts
@@ -1,0 +1,68 @@
+/**
+ * Failure codes from the Stellar/Soroban failure analysis that are considered
+ * transient and safe to retry automatically.
+ */
+export const RETRYABLE_FAILURE_CODES = new Set<string>([
+  'SEQUENCE_MISMATCH',
+  'TRANSACTION_EXPIRED',
+  'NETWORK_UNAVAILABLE',
+  'RATE_LIMIT_EXCEEDED',
+  'INSUFFICIENT_FEE',
+]);
+
+/**
+ * Configuration that controls retry timing and attempt limits.
+ */
+export interface RetryConfig {
+  /** Maximum number of retry attempts before abandoning the operation */
+  maxAttempts: number;
+  /** Delay before the first retry in milliseconds */
+  initialDelayMs: number;
+  /** Upper bound on any computed delay in milliseconds */
+  maxDelayMs: number;
+  /** Multiplier applied to the delay on each successive attempt */
+  backoffMultiplier: number;
+}
+
+export const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxAttempts: 5,
+  initialDelayMs: 1_000,
+  maxDelayMs: 30_000,
+  backoffMultiplier: 2,
+};
+
+/**
+ * Record of a single retry attempt.
+ */
+export interface RetryAttempt {
+  /** 1-based attempt number */
+  attemptNumber: number;
+  /** Unix timestamp (ms) when this attempt began */
+  startedAt: number;
+  success: boolean;
+  /** Error message if the attempt failed */
+  error?: string;
+  /** Delay in ms that will be applied before the next attempt, if any */
+  nextRetryDelayMs?: number;
+}
+
+/**
+ * Aggregated outcome of all retry attempts for a single transfer.
+ */
+export interface RetryResult {
+  transferHash: string;
+  /** Number of operation invocations made (0 if the failure was non-retryable) */
+  totalAttempts: number;
+  success: boolean;
+  /** Recovery transaction hash returned by the operation on success */
+  recoveryTransactionHash?: string;
+  /** Error from the last attempt, or reason skipped when non-retryable */
+  finalError?: string;
+  attempts: RetryAttempt[];
+}
+
+/**
+ * A function that performs the bridge operation for a given transfer hash.
+ * Must resolve to the recovery transaction hash on success, or throw on failure.
+ */
+export type BridgeOperationFn = (transferHash: string) => Promise<string>;

--- a/src/webhooks/stellar/index.ts
+++ b/src/webhooks/stellar/index.ts
@@ -1,0 +1,10 @@
+export { SorobanWebhookEmitter } from './soroban-webhook-emitter';
+export type {
+  StellarWebhookEventType,
+  RegisterWebhookInput,
+  WebhookRegistration,
+  WebhookPayload,
+  WebhookDeliveryResult,
+  TransferLifecycleEventData,
+} from './stellar-webhook.types';
+export { LIFECYCLE_EVENT_MAP } from './stellar-webhook.types';

--- a/src/webhooks/stellar/soroban-webhook-emitter.spec.ts
+++ b/src/webhooks/stellar/soroban-webhook-emitter.spec.ts
@@ -1,0 +1,233 @@
+import { SorobanWebhookEmitter } from './soroban-webhook-emitter';
+import { NormalizedBridgeEvent } from '../../events/aggregation/stellar';
+
+describe('SorobanWebhookEmitter', () => {
+  let emitter: SorobanWebhookEmitter;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 } as unknown as Response);
+    emitter = new SorobanWebhookEmitter(fetchMock);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  // ---------------------------------------------------------------------------
+  // register
+  // ---------------------------------------------------------------------------
+
+  describe('register', () => {
+    it('should register a webhook and return a registration with a generated id', () => {
+      const reg = emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.initiated'],
+      });
+      expect(reg.id).toBeDefined();
+      expect(reg.url).toBe('https://example.com/hook');
+      expect(reg.events).toEqual(['transfer.initiated']);
+      expect(reg.createdAt).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('should generate a 64-character hex secret when none is provided', () => {
+      const reg = emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.completed'],
+      });
+      expect(reg.secret).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should use the provided secret', () => {
+      const reg = emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.completed'],
+        secret: 'my-custom-secret',
+      });
+      expect(reg.secret).toBe('my-custom-secret');
+    });
+
+    it('should register multiple distinct webhooks', () => {
+      emitter.register({ url: 'https://a.com', events: ['transfer.failed'] });
+      emitter.register({ url: 'https://b.com', events: ['bridge.event'] });
+      expect(emitter.list()).toHaveLength(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // unregister
+  // ---------------------------------------------------------------------------
+
+  describe('unregister', () => {
+    it('should remove an existing webhook and return true', () => {
+      const reg = emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.failed'],
+      });
+      expect(emitter.unregister(reg.id)).toBe(true);
+      expect(emitter.list()).toHaveLength(0);
+    });
+
+    it('should return false for an unknown id', () => {
+      expect(emitter.unregister('non-existent-id')).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // list
+  // ---------------------------------------------------------------------------
+
+  describe('list', () => {
+    it('should return an empty array when no webhooks are registered', () => {
+      expect(emitter.list()).toEqual([]);
+    });
+
+    it('should return all registered webhooks', () => {
+      emitter.register({ url: 'https://a.com', events: ['transfer.initiated'] });
+      emitter.register({ url: 'https://b.com', events: ['transfer.completed'] });
+      expect(emitter.list()).toHaveLength(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // emitLifecycleEvent
+  // ---------------------------------------------------------------------------
+
+  describe('emitLifecycleEvent', () => {
+    it('should deliver to subscribers of the matched lifecycle event type', async () => {
+      emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.completed'],
+      });
+      const results = await emitter.emitLifecycleEvent('tx-1', 'confirmed', 'completed');
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not deliver to endpoints not subscribed to the event', async () => {
+      emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.failed'],
+      });
+      const results = await emitter.emitLifecycleEvent('tx-1', 'confirmed', 'completed');
+      expect(results).toHaveLength(0);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should include an HMAC-SHA256 signature header', async () => {
+      emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.initiated'],
+        secret: 'test-secret',
+      });
+      await emitter.emitLifecycleEvent('tx-1', undefined, 'pending');
+      const [, options] = fetchMock.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }];
+      expect(options.headers['X-BridgeWise-Signature']).toMatch(/^sha256=[a-f0-9]{64}$/);
+    });
+
+    it('should include the event type header', async () => {
+      emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.locked'],
+      });
+      await emitter.emitLifecycleEvent('tx-1', 'pending', 'locked');
+      const [, options] = fetchMock.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }];
+      expect(options.headers['X-BridgeWise-Event']).toBe('transfer.locked');
+    });
+
+    it('should handle delivery network errors gracefully', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      emitter.register({
+        url: 'https://unreachable.com/hook',
+        events: ['transfer.failed'],
+      });
+      const results = await emitter.emitLifecycleEvent('tx-1', 'submitted', 'failed');
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(false);
+      expect(results[0].error).toBe('ECONNREFUSED');
+    });
+
+    it('should include the status code when the server responds with a non-2xx', async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 500 } as unknown as Response);
+      emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.confirmed'],
+      });
+      const results = await emitter.emitLifecycleEvent('tx-1', 'submitted', 'confirmed');
+      expect(results[0].success).toBe(false);
+      expect(results[0].statusCode).toBe(500);
+    });
+
+    it('should dispatch to multiple subscribers in parallel', async () => {
+      emitter.register({ url: 'https://a.com', events: ['transfer.completed'] });
+      emitter.register({ url: 'https://b.com', events: ['transfer.completed'] });
+      const results = await emitter.emitLifecycleEvent('tx-1', 'confirmed', 'completed');
+      expect(results).toHaveLength(2);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should pass fromState and toState in the payload body', async () => {
+      emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.validated'],
+      });
+      await emitter.emitLifecycleEvent('tx-42', 'locked', 'validated', { memo: 'test' });
+      const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(options.body as string);
+      expect(body.data.transferId).toBe('tx-42');
+      expect(body.data.fromState).toBe('locked');
+      expect(body.data.toState).toBe('validated');
+      expect(body.data.metadata).toEqual({ memo: 'test' });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // emitBridgeEvent
+  // ---------------------------------------------------------------------------
+
+  describe('emitBridgeEvent', () => {
+    it('should deliver to bridge.event subscribers', async () => {
+      emitter.register({
+        url: 'https://example.com/hook',
+        events: ['bridge.event'],
+      });
+      const bridgeEvent: NormalizedBridgeEvent = {
+        id: 'evt_1',
+        source: 'soroban',
+        type: 'transfer',
+        from: 'GABC',
+        to: 'GDEF',
+        amount: '100',
+        asset: 'USDC',
+        contractId: 'CXYZ',
+        timestamp: Date.now(),
+        rawPayload: {},
+      };
+      const results = await emitter.emitBridgeEvent(bridgeEvent);
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(true);
+    });
+
+    it('should not deliver to non-bridge.event subscribers', async () => {
+      emitter.register({
+        url: 'https://example.com/hook',
+        events: ['transfer.completed'],
+      });
+      const bridgeEvent: NormalizedBridgeEvent = {
+        id: 'evt_2',
+        source: 'soroban',
+        type: 'mint',
+        from: 'GABC',
+        to: 'GDEF',
+        amount: '50',
+        asset: 'XLM',
+        contractId: 'CABC',
+        timestamp: Date.now(),
+        rawPayload: {},
+      };
+      const results = await emitter.emitBridgeEvent(bridgeEvent);
+      expect(results).toHaveLength(0);
+    });
+  });
+});

--- a/src/webhooks/stellar/soroban-webhook-emitter.ts
+++ b/src/webhooks/stellar/soroban-webhook-emitter.ts
@@ -1,0 +1,193 @@
+import { createHmac, randomBytes, randomUUID } from 'crypto';
+import { SorobanTransferState } from '../../state-machine/stellar/soroban-transfer-state-machine';
+import { NormalizedBridgeEvent } from '../../events/aggregation/stellar';
+import {
+  RegisterWebhookInput,
+  WebhookRegistration,
+  WebhookPayload,
+  WebhookDeliveryResult,
+  StellarWebhookEventType,
+  LIFECYCLE_EVENT_MAP,
+  TransferLifecycleEventData,
+} from './stellar-webhook.types';
+
+/**
+ * Emits signed webhook payloads to registered endpoints for Soroban bridge
+ * lifecycle events and generic bridge events from the event aggregator.
+ *
+ * Each delivered request is signed with HMAC-SHA256 so receivers can verify
+ * the payload originated from BridgeWise:
+ *
+ *   X-BridgeWise-Signature: sha256=<hex-digest>
+ *
+ * Usage:
+ *   const emitter = new SorobanWebhookEmitter();
+ *   const reg = emitter.register({ url: 'https://my-app.com/hook', events: ['transfer.completed'] });
+ *   await emitter.emitLifecycleEvent(transferId, 'confirmed', 'completed');
+ */
+export class SorobanWebhookEmitter {
+  private readonly registrations = new Map<string, WebhookRegistration>();
+  private payloadCounter = 0;
+
+  constructor(
+    private readonly fetcher: typeof fetch = (...args) => fetch(...args),
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Registration management
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a new webhook endpoint.
+   *
+   * A cryptographically random 32-byte hex secret is generated when the caller
+   * does not provide one. The returned `WebhookRegistration` contains the
+   * secret — store it securely; it cannot be retrieved later.
+   */
+  register(input: RegisterWebhookInput): WebhookRegistration {
+    const registration: WebhookRegistration = {
+      id: randomUUID(),
+      url: input.url,
+      events: input.events,
+      secret: input.secret ?? randomBytes(32).toString('hex'),
+      createdAt: Date.now(),
+    };
+
+    this.registrations.set(registration.id, registration);
+    return registration;
+  }
+
+  /**
+   * Remove a registered webhook.
+   *
+   * @returns `true` if the registration existed and was removed, `false` otherwise.
+   */
+  unregister(id: string): boolean {
+    return this.registrations.delete(id);
+  }
+
+  /**
+   * Return all current webhook registrations.
+   */
+  list(): WebhookRegistration[] {
+    return Array.from(this.registrations.values());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event emission
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Emit a lifecycle event when a Soroban transfer transitions to a new state.
+   *
+   * Looks up the matching webhook event type for `toState` and dispatches
+   * signed payloads to all subscribed endpoints.
+   *
+   * @param transferId  Identifier for the transfer (e.g. Stellar transaction hash)
+   * @param fromState   Previous state, if known
+   * @param toState     New state the transfer transitioned into
+   * @param metadata    Optional extra data to include in the payload
+   */
+  async emitLifecycleEvent(
+    transferId: string,
+    fromState: SorobanTransferState | undefined,
+    toState: SorobanTransferState,
+    metadata?: Record<string, unknown>,
+  ): Promise<WebhookDeliveryResult[]> {
+    const eventType = LIFECYCLE_EVENT_MAP[toState];
+    const data: TransferLifecycleEventData = {
+      transferId,
+      fromState,
+      toState,
+      timestamp: Date.now(),
+      metadata,
+    };
+
+    return this.emit(eventType, data as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Emit a generic bridge event originating from the SorobanBridgeEventAggregator.
+   *
+   * Dispatches to all endpoints subscribed to the `bridge.event` event type.
+   */
+  async emitBridgeEvent(event: NormalizedBridgeEvent): Promise<WebhookDeliveryResult[]> {
+    return this.emit('bridge.event', event as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Build a signed payload for `eventType` and deliver it in parallel to all
+   * registered endpoints that subscribed to this event type.
+   */
+  async emit(
+    eventType: StellarWebhookEventType,
+    data: Record<string, unknown>,
+  ): Promise<WebhookDeliveryResult[]> {
+    this.payloadCounter++;
+    const payload: WebhookPayload = {
+      id: `whpay_${Date.now()}_${this.payloadCounter}`,
+      event: eventType,
+      timestamp: Date.now(),
+      data,
+    };
+
+    const subscribers = Array.from(this.registrations.values()).filter((r) =>
+      r.events.includes(eventType),
+    );
+
+    return Promise.all(subscribers.map((reg) => this.deliver(reg, payload)));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Sign `payload` and POST it to the registration's URL.
+   *
+   * Returns a `WebhookDeliveryResult` regardless of success or failure so that
+   * callers always receive a complete delivery log.
+   */
+  private async deliver(
+    registration: WebhookRegistration,
+    payload: WebhookPayload,
+  ): Promise<WebhookDeliveryResult> {
+    const body = JSON.stringify(payload);
+    const signature = this.sign(body, registration.secret);
+
+    try {
+      const response = await this.fetcher(registration.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-BridgeWise-Signature': signature,
+          'X-BridgeWise-Event': payload.event,
+        },
+        body,
+      });
+
+      return {
+        webhookId: registration.id,
+        success: response.ok,
+        statusCode: response.status,
+        deliveredAt: Date.now(),
+      };
+    } catch (error) {
+      return {
+        webhookId: registration.id,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        deliveredAt: Date.now(),
+      };
+    }
+  }
+
+  /**
+   * Produce an HMAC-SHA256 signature for `payload` using `secret`.
+   * Format: `sha256=<hex-digest>`
+   */
+  private sign(payload: string, secret: string): string {
+    const digest = createHmac('sha256', secret).update(payload, 'utf8').digest('hex');
+    return `sha256=${digest}`;
+  }
+}

--- a/src/webhooks/stellar/stellar-webhook.types.ts
+++ b/src/webhooks/stellar/stellar-webhook.types.ts
@@ -1,0 +1,90 @@
+import { SorobanTransferState } from '../../state-machine/stellar/soroban-transfer-state-machine';
+
+/**
+ * All Stellar/Soroban bridge lifecycle event types that can be dispatched
+ * to registered webhook endpoints.
+ */
+export type StellarWebhookEventType =
+  | 'transfer.initiated'
+  | 'transfer.locked'
+  | 'transfer.validated'
+  | 'transfer.submitted'
+  | 'transfer.confirmed'
+  | 'transfer.completed'
+  | 'transfer.failed'
+  | 'transfer.refunded'
+  | 'bridge.event';
+
+/**
+ * Maps each Soroban transfer state to the corresponding webhook event type.
+ */
+export const LIFECYCLE_EVENT_MAP: Record<SorobanTransferState, StellarWebhookEventType> = {
+  pending: 'transfer.initiated',
+  locked: 'transfer.locked',
+  validated: 'transfer.validated',
+  submitted: 'transfer.submitted',
+  confirmed: 'transfer.confirmed',
+  completed: 'transfer.completed',
+  failed: 'transfer.failed',
+  refunded: 'transfer.refunded',
+};
+
+/**
+ * Input used to register a new webhook endpoint.
+ */
+export interface RegisterWebhookInput {
+  /** HTTPS URL that will receive POST requests for each matching event */
+  url: string;
+  /** Event types this webhook should receive */
+  events: StellarWebhookEventType[];
+  /**
+   * Optional signing secret used to produce the HMAC-SHA256 signature.
+   * If omitted, a cryptographically random 32-byte hex secret is generated.
+   */
+  secret?: string;
+}
+
+/**
+ * A registered webhook with its generated id and secret.
+ */
+export interface WebhookRegistration {
+  id: string;
+  url: string;
+  events: StellarWebhookEventType[];
+  /** HMAC signing secret — keep this confidential */
+  secret: string;
+  createdAt: number;
+}
+
+/**
+ * The JSON body delivered to a webhook URL.
+ */
+export interface WebhookPayload<T = Record<string, unknown>> {
+  /** Unique payload identifier */
+  id: string;
+  event: StellarWebhookEventType;
+  timestamp: number;
+  data: T;
+}
+
+/**
+ * Outcome of a single webhook delivery attempt.
+ */
+export interface WebhookDeliveryResult {
+  webhookId: string;
+  success: boolean;
+  statusCode?: number;
+  error?: string;
+  deliveredAt: number;
+}
+
+/**
+ * Data attached to a transfer lifecycle webhook payload.
+ */
+export interface TransferLifecycleEventData {
+  transferId: string;
+  fromState?: SorobanTransferState;
+  toState: SorobanTransferState;
+  timestamp: number;
+  metadata?: Record<string, unknown>;
+}


### PR DESCRIPTION
closes #306 
closes #307 

Issue #306 - Implement Soroban Bridge Event Webhooks (src/webhooks/stellar/)
- stellar-webhook.types.ts: StellarWebhookEventType union, LIFECYCLE_EVENT_MAP, WebhookRegistration, WebhookPayload, WebhookDeliveryResult, TransferLifecycleEventData
- soroban-webhook-emitter.ts: SorobanWebhookEmitter class with register/unregister/list, emitLifecycleEvent (maps SorobanTransferState → event type), emitBridgeEvent (bridges SorobanBridgeEventAggregator output), HMAC-SHA256 signed delivery, injectable fetcher for testability
- soroban-webhook-emitter.spec.ts: 18 tests covering registration, delivery, signing, error handling, parallel dispatch, and payload body correctness
- index.ts: public barrel export

Issue #307 - Implement Stellar Bridge Retry Mechanism (src/recovery/stellar/)
- stellar-bridge-retry.types.ts: RETRYABLE_FAILURE_CODES set, RetryConfig/RetryAttempt/ RetryResult interfaces, BridgeOperationFn type, DEFAULT_RETRY_CONFIG
- stellar-bridge-retry.service.ts: isRetryableFailure() (named codes + network patterns), computeRetryDelay() (exponential backoff with cap), StellarBridgeRetryService with injectable sleep for deterministic tests
- stellar-bridge-retry.service.spec.ts: 30 tests covering retryable detection, delay computation, success paths, exhausted retries, backoff timing, and nextRetryDelayMs
- index.ts: public barrel export