### PR TITLE
feat: stellar network auto-detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "typescript-eslint": "^8.20.0"
   },
   "jest": {
+    "watchman": false,
     "moduleFileExtensions": [
       "js",
       "json",

--- a/src/monitoring/wallets/stellar/stellar-wallet-monitor.ts
+++ b/src/monitoring/wallets/stellar/stellar-wallet-monitor.ts
@@ -4,6 +4,7 @@ import type {
   WalletAccount,
 } from '../../../../packages/wallet/src';
 import { stellarMetrics } from '../../../exporters/metrics/stellar';
+import { detectStellarNetwork } from '../../../networking/stellar';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -25,6 +26,13 @@ export interface WalletMonitorConfig {
   pingTimeoutMs?: number;
   /** Custom Horizon URLs keyed by chain ID. Falls back to built-in defaults. */
   horizonUrls?: Record<string, string>;
+  /**
+   * When enabled, attempts to auto-detect the active Stellar network by querying
+   * Horizon root endpoints and reading `network_passphrase`.
+   *
+   * You can also enable this via `STELLAR_AUTO_DETECT_NETWORK=true`.
+   */
+  autoDetectNetwork?: boolean;
   /** Called when an unhandled error escapes a listener. Defaults to console.error. */
   onListenerError?: (err: unknown, report: WalletHealthReport) => void;
 }
@@ -73,6 +81,7 @@ export class StellarWalletMonitor {
 
   /** Tracks in-flight per-wallet checks to prevent overlapping polls. */
   private readonly inFlight = new Set<string>();
+  private detectedHorizonUrl: string | null = null;
 
   constructor(manager: WalletManager, config: WalletMonitorConfig = {}) {
     this.manager = manager;
@@ -80,6 +89,8 @@ export class StellarWalletMonitor {
       checkIntervalMs: config.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS,
       pingTimeoutMs:   config.pingTimeoutMs   ?? DEFAULT_PING_TIMEOUT_MS,
       horizonUrls:     config.horizonUrls     ?? {},
+      autoDetectNetwork:
+        config.autoDetectNetwork ?? process.env.STELLAR_AUTO_DETECT_NETWORK === 'true',
       onListenerError: config.onListenerError ??
         ((err, report) =>
           console.error(`[StellarWalletMonitor] Listener error for ${report.walletId}:`, err)),
@@ -297,7 +308,7 @@ export class StellarWalletMonitor {
     chainId: string,
     adapter: WalletAdapter,
   ): Promise<{ ok: boolean; error?: string }> {
-    const url = this.resolveHorizonUrl(chainId, adapter);
+    const url = await this.resolveHorizonUrl(chainId, adapter);
 
     try {
       const controller = new AbortController();
@@ -323,7 +334,10 @@ export class StellarWalletMonitor {
     }
   }
 
-  private resolveHorizonUrl(chainId: string, adapter: WalletAdapter): string {
+  private async resolveHorizonUrl(
+    chainId: string,
+    adapter: WalletAdapter,
+  ): Promise<string> {
     // 1. Caller-supplied override
     if (this.config.horizonUrls[chainId]) return this.config.horizonUrls[chainId];
 
@@ -342,7 +356,21 @@ export class StellarWalletMonitor {
       if (chainId.includes(key.split(':')[1]!)) return url;
     }
 
-    // 4. Final fallback — mainnet
+    // 4. Optional auto-detection
+    if (this.config.autoDetectNetwork) {
+      if (this.detectedHorizonUrl) return this.detectedHorizonUrl;
+      try {
+        const detected = await detectStellarNetwork({
+          timeoutMs: this.config.pingTimeoutMs,
+        });
+        this.detectedHorizonUrl = detected.horizonUrl;
+        return detected.horizonUrl;
+      } catch {
+        // Fall through
+      }
+    }
+
+    // 5. Final fallback — mainnet
     return HORIZON_URLS['stellar:public']!;
   }
 

--- a/src/networking/stellar/index.ts
+++ b/src/networking/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './stellar-network-detector';
+

--- a/src/networking/stellar/stellar-network-detector.spec.ts
+++ b/src/networking/stellar/stellar-network-detector.spec.ts
@@ -1,0 +1,62 @@
+import {
+  detectStellarNetwork,
+  resolveStellarNetworkFromPassphrase,
+  StellarNetworkDetectionError,
+  STELLAR_NETWORK_PASSPHRASES,
+} from './stellar-network-detector';
+
+describe('stellar-network-detector', () => {
+  beforeEach(() => {
+    delete process.env.STELLAR_HORIZON_URL;
+  });
+
+  it('resolves networks from known passphrases', () => {
+    expect(resolveStellarNetworkFromPassphrase(STELLAR_NETWORK_PASSPHRASES.public)).toBe(
+      'public',
+    );
+    expect(resolveStellarNetworkFromPassphrase(STELLAR_NETWORK_PASSPHRASES.testnet)).toBe(
+      'testnet',
+    );
+    expect(resolveStellarNetworkFromPassphrase(STELLAR_NETWORK_PASSPHRASES.futurenet)).toBe(
+      'futurenet',
+    );
+    expect(resolveStellarNetworkFromPassphrase('not-a-real-passphrase')).toBeNull();
+  });
+
+  it('detects network from a specific horizonUrl', async () => {
+    (global as any).fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        network_passphrase: STELLAR_NETWORK_PASSPHRASES.testnet,
+      }),
+    }));
+
+    const result = await detectStellarNetwork({
+      horizonUrl: 'https://horizon-testnet.stellar.org/',
+      timeoutMs: 250,
+    });
+
+    expect(result).toEqual({
+      network: 'testnet',
+      networkPassphrase: STELLAR_NETWORK_PASSPHRASES.testnet,
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+    });
+  });
+
+  it('errors when horizon root response is missing network_passphrase', async () => {
+    (global as any).fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    }));
+
+    await expect(
+      detectStellarNetwork({
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+        timeoutMs: 250,
+      }),
+    ).rejects.toBeInstanceOf(StellarNetworkDetectionError);
+  });
+});
+

--- a/src/networking/stellar/stellar-network-detector.ts
+++ b/src/networking/stellar/stellar-network-detector.ts
@@ -1,0 +1,169 @@
+export type StellarNetwork = 'public' | 'testnet' | 'futurenet';
+
+export const STELLAR_NETWORK_PASSPHRASES: Record<StellarNetwork, string> = {
+  public: 'Public Global Stellar Network ; September 2015',
+  testnet: 'Test SDF Network ; September 2015',
+  futurenet: 'Test SDF Future Network ; October 2022',
+};
+
+export const DEFAULT_STELLAR_HORIZON_URLS: Record<StellarNetwork, string> = {
+  public: 'https://horizon.stellar.org',
+  testnet: 'https://horizon-testnet.stellar.org',
+  futurenet: 'https://horizon-futurenet.stellar.org',
+};
+
+export interface StellarNetworkDetectionResult {
+  network: StellarNetwork;
+  networkPassphrase: string;
+  horizonUrl: string;
+}
+
+export interface StellarNetworkDetectorOptions {
+  timeoutMs?: number;
+  /**
+   * Optional Horizon URL to detect against. When omitted, uses:
+   * - `STELLAR_HORIZON_URL` env var, else
+   * - built-in default Horizon URLs.
+   */
+  horizonUrl?: string;
+}
+
+export class StellarNetworkDetectionError extends Error {
+  override name = 'StellarNetworkDetectionError';
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+async function fetchWithTimeout(
+  url: string,
+  { timeoutMs }: { timeoutMs: number },
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchHorizonRoot(
+  horizonUrl: string,
+  timeoutMs: number,
+): Promise<{ network_passphrase?: unknown }> {
+  const url = normalizeBaseUrl(horizonUrl);
+  const response = await fetchWithTimeout(url, { timeoutMs });
+
+  if (!response.ok) {
+    throw new StellarNetworkDetectionError(
+      `Horizon returned HTTP ${response.status} for ${url}`,
+    );
+  }
+
+  const json: unknown = await response.json();
+  if (!json || typeof json !== 'object') return {};
+  return json as any;
+}
+
+export function resolveStellarNetworkFromPassphrase(
+  networkPassphrase: string,
+): StellarNetwork | null {
+  const entries = Object.entries(STELLAR_NETWORK_PASSPHRASES) as Array<
+    [StellarNetwork, string]
+  >;
+
+  for (const [network, passphrase] of entries) {
+    if (passphrase === networkPassphrase) return network;
+  }
+  return null;
+}
+
+/**
+ * Detect a Stellar network by querying the Horizon root endpoint and reading
+ * `network_passphrase`.
+ */
+export async function detectStellarNetwork(
+  options: StellarNetworkDetectorOptions = {},
+): Promise<StellarNetworkDetectionResult> {
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  const envHorizonUrl = process.env.STELLAR_HORIZON_URL;
+
+  const horizonUrl = options.horizonUrl ?? envHorizonUrl ?? null;
+  if (horizonUrl) {
+    const root = await fetchHorizonRoot(horizonUrl, timeoutMs);
+    const passphrase = root.network_passphrase;
+    if (typeof passphrase !== 'string' || !passphrase) {
+      throw new StellarNetworkDetectionError(
+        `Missing network_passphrase from Horizon root at ${normalizeBaseUrl(horizonUrl)}`,
+      );
+    }
+
+    const network = resolveStellarNetworkFromPassphrase(passphrase);
+    if (!network) {
+      throw new StellarNetworkDetectionError(
+        `Unknown Stellar network passphrase returned by ${normalizeBaseUrl(horizonUrl)}`,
+      );
+    }
+
+    return {
+      network,
+      networkPassphrase: passphrase,
+      horizonUrl: normalizeBaseUrl(horizonUrl),
+    };
+  }
+
+  const candidates = Object.entries(DEFAULT_STELLAR_HORIZON_URLS) as Array<
+    [StellarNetwork, string]
+  >;
+
+  const results = await Promise.allSettled(
+    candidates.map(async ([network, url]) => {
+      const root = await fetchHorizonRoot(url, timeoutMs);
+      const passphrase = root.network_passphrase;
+
+      if (typeof passphrase !== 'string' || !passphrase) {
+        throw new StellarNetworkDetectionError(
+          `Missing network_passphrase from Horizon root at ${normalizeBaseUrl(url)}`,
+        );
+      }
+
+      const resolved = resolveStellarNetworkFromPassphrase(passphrase);
+      if (!resolved) {
+        throw new StellarNetworkDetectionError(
+          `Unknown Stellar network passphrase returned by ${normalizeBaseUrl(url)}`,
+        );
+      }
+
+      // The "active" network is whichever Horizon endpoint successfully
+      // responds and self-identifies.
+      return {
+        network: resolved ?? network,
+        networkPassphrase: passphrase,
+        horizonUrl: normalizeBaseUrl(url),
+      } satisfies StellarNetworkDetectionResult;
+    }),
+  );
+
+  const fulfilled = results.find(
+    (r): r is PromiseFulfilledResult<StellarNetworkDetectionResult> =>
+      r.status === 'fulfilled',
+  );
+
+  if (fulfilled) return fulfilled.value;
+
+  const reasons = results
+    .filter((r) => r.status === 'rejected')
+    .map((r) =>
+      r.reason instanceof Error ? r.reason.message : String(r.reason),
+    );
+
+  throw new StellarNetworkDetectionError(
+    `Failed to auto-detect Stellar network from default Horizon endpoints: ${reasons.join(
+      '; ',
+    )}`,
+  );
+}
+


### PR DESCRIPTION
Closes #303
Closes #301
Closes #302
Closes #304

## Summary
- Adds a Horizon-based Stellar network detector (reads `network_passphrase`)
- Exposes it via `src/networking/stellar`
- Optionally enables auto-detection in `StellarWalletMonitor` via `STELLAR_AUTO_DETECT_NETWORK=true` or `autoDetectNetwork` config

## Testing
- `npm test -- src/networking/stellar/stellar-network-detector.spec.ts`

## Notes
- `npm run lint` and `npm run build` currently fail on `main` due to pre-existing errors in `apps/api/src/...` and other unrelated files.