### PR TITLE
feat: Implement Stellar Bridge Route Validator

### DIFF
--- a/packages/route-validator/jest.config.js
+++ b/packages/route-validator/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/packages/route-validator/package.json
+++ b/packages/route-validator/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@bridgewise/route-validator",
+  "version": "0.1.0",
+  "description": "Stellar bridge route validation utilities for BridgeWise",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest",
+    "lint": "eslint src --ext .ts"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/route-validator/src/index.ts
+++ b/packages/route-validator/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  StellarRouteValidator,
+  InvalidRouteError,
+  stellarRouteValidator,
+} from './stellar-route-validator';
+export type {
+  StellarRoute,
+  RouteValidationResult,
+  StellarRouteValidatorOptions,
+} from './stellar-route-validator';

--- a/packages/route-validator/src/stellar-route-validator.ts
+++ b/packages/route-validator/src/stellar-route-validator.ts
@@ -1,0 +1,10 @@
+export {
+  StellarRouteValidator,
+  InvalidRouteError,
+  stellarRouteValidator,
+} from '../../../src/bridges/stellar/routes/stellar-route-validator';
+export type {
+  StellarRoute,
+  RouteValidationResult,
+  StellarRouteValidatorOptions,
+} from '../../../src/bridges/stellar/routes/stellar-route-validator';

--- a/packages/route-validator/tsconfig.json
+++ b/packages/route-validator/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+}

--- a/src/bridges/stellar/routes/stellar-route-validator.spec.ts
+++ b/src/bridges/stellar/routes/stellar-route-validator.spec.ts
@@ -1,0 +1,238 @@
+import {
+  StellarRouteValidator,
+  InvalidRouteError,
+  stellarRouteValidator,
+} from './stellar-route-validator';
+
+describe('StellarRouteValidator', () => {
+  let validator: StellarRouteValidator;
+
+  beforeEach(() => {
+    validator = new StellarRouteValidator({
+      availableBridgeIds: ['bridge-a', 'bridge-b'],
+    });
+  });
+
+  // ─── validateRoute ──────────────────────────────────────────────────────────
+
+  describe('validateRoute', () => {
+    it('returns isValid true for a well-formed route', () => {
+      const result = validator.validateRoute({
+        routeId: 'route-1',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'bridge-a',
+        amount: '100',
+        asset: 'USDC',
+      });
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('accepts stellar-mainnet and stellar-testnet as source chains', () => {
+      for (const src of ['stellar-mainnet', 'stellar-testnet']) {
+        const result = validator.validateRoute({
+          routeId: 'r',
+          sourceChain: src,
+          destinationChain: 'polygon',
+          bridgeId: 'bridge-a',
+        });
+        expect(result.isValid).toBe(true);
+      }
+    });
+
+    it('is case-insensitive for chain names', () => {
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'Stellar',
+        destinationChain: 'Ethereum',
+        bridgeId: 'bridge-a',
+      });
+      expect(result.isValid).toBe(true);
+    });
+
+    it('errors when routeId is empty', () => {
+      const result = validator.validateRoute({
+        routeId: '',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'bridge-a',
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('routeId must be a non-empty string');
+    });
+
+    it('errors when sourceChain is not a Stellar chain', () => {
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'ethereum',
+        destinationChain: 'polygon',
+        bridgeId: 'bridge-a',
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toMatch(/Source chain "ethereum"/);
+    });
+
+    it('errors when destinationChain is unsupported', () => {
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'stellar',
+        destinationChain: 'unknown-chain',
+        bridgeId: 'bridge-a',
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toMatch(/Destination chain "unknown-chain"/);
+    });
+
+    it('errors when source and destination chains are the same', () => {
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'stellar',
+        destinationChain: 'stellar',
+        bridgeId: 'bridge-a',
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        'sourceChain and destinationChain must be different',
+      );
+    });
+
+    it('errors when bridgeId is not registered', () => {
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'unknown-bridge',
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toMatch(/Bridge "unknown-bridge"/);
+    });
+
+    it('errors when amount is not a positive number', () => {
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'bridge-a',
+        amount: '-5',
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.errors[0]).toMatch(/amount/);
+    });
+
+    it('warns when no asset is provided', () => {
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'bridge-a',
+      });
+      expect(result.isValid).toBe(true);
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── filterValidRoutes ──────────────────────────────────────────────────────
+
+  describe('filterValidRoutes', () => {
+    const routes = [
+      {
+        routeId: 'good',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'bridge-a',
+        asset: 'XLM',
+      },
+      {
+        routeId: 'bad',
+        sourceChain: 'stellar',
+        destinationChain: 'nowhere',
+        bridgeId: 'bridge-a',
+        asset: 'XLM',
+      },
+    ];
+
+    it('returns only valid routes', () => {
+      const result = validator.filterValidRoutes(routes);
+      expect(result).toHaveLength(1);
+      expect(result[0].routeId).toBe('good');
+    });
+
+    it('throws InvalidRouteError when throwOnInvalid is true', () => {
+      expect(() => validator.filterValidRoutes(routes, true)).toThrow(
+        InvalidRouteError,
+      );
+    });
+  });
+
+  // ─── assertValid ───────────────────────────────────────────────────────────
+
+  describe('assertValid', () => {
+    it('does not throw for a valid route', () => {
+      expect(() =>
+        validator.assertValid({
+          routeId: 'r',
+          sourceChain: 'stellar',
+          destinationChain: 'polygon',
+          bridgeId: 'bridge-b',
+          asset: 'USDC',
+        }),
+      ).not.toThrow();
+    });
+
+    it('throws InvalidRouteError for an invalid route', () => {
+      expect(() =>
+        validator.assertValid({
+          routeId: 'bad-route',
+          sourceChain: 'stellar',
+          destinationChain: 'nowhere',
+          bridgeId: 'bridge-a',
+        }),
+      ).toThrow(InvalidRouteError);
+    });
+  });
+
+  // ─── bridge registration ───────────────────────────────────────────────────
+
+  describe('registerBridge / deregisterBridge', () => {
+    it('allows a newly registered bridge', () => {
+      validator.registerBridge('bridge-new');
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'bridge-new',
+        asset: 'XLM',
+      });
+      expect(result.isValid).toBe(true);
+    });
+
+    it('rejects a deregistered bridge', () => {
+      validator.deregisterBridge('bridge-a');
+      const result = validator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'bridge-a',
+        asset: 'XLM',
+      });
+      expect(result.isValid).toBe(false);
+    });
+  });
+
+  // ─── default instance ──────────────────────────────────────────────────────
+
+  describe('default stellarRouteValidator', () => {
+    it('validates with no bridge restriction', () => {
+      const result = stellarRouteValidator.validateRoute({
+        routeId: 'r',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        bridgeId: 'any-bridge',
+        asset: 'USDC',
+      });
+      expect(result.isValid).toBe(true);
+    });
+  });
+});

--- a/src/bridges/stellar/routes/stellar-route-validator.ts
+++ b/src/bridges/stellar/routes/stellar-route-validator.ts
@@ -1,0 +1,232 @@
+// ─── Interfaces ───────────────────────────────────────────────────────────────
+
+export interface StellarRoute {
+  routeId: string;
+  sourceChain: string;
+  destinationChain: string;
+  bridgeId: string;
+  amount?: string;
+  asset?: string;
+}
+
+export interface RouteValidationResult {
+  routeId: string;
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface StellarRouteValidatorOptions {
+  /** Allowed source chain identifiers. Defaults to standard Stellar chain names. */
+  allowedSourceChains?: string[];
+  /** Allowed destination chain identifiers. Defaults to known EVM chains. */
+  allowedDestinationChains?: string[];
+  /** Registered bridge IDs that are available for routing. */
+  availableBridgeIds?: string[];
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_STELLAR_SOURCE_CHAINS = [
+  'stellar',
+  'stellar-mainnet',
+  'stellar-testnet',
+];
+
+const DEFAULT_EVM_DESTINATION_CHAINS = [
+  'ethereum',
+  'polygon',
+  'bsc',
+  'bnb',
+  'arbitrum',
+  'optimism',
+  'base',
+  'avalanche',
+  'gnosis',
+];
+
+// ─── Error ────────────────────────────────────────────────────────────────────
+
+export class InvalidRouteError extends Error {
+  constructor(
+    public readonly routeId: string,
+    public readonly validationErrors: string[],
+  ) {
+    super(
+      `Invalid Stellar bridge route "${routeId}": ${validationErrors.join('; ')}`,
+    );
+    this.name = 'InvalidRouteError';
+  }
+}
+
+// ─── Validator ────────────────────────────────────────────────────────────────
+
+export class StellarRouteValidator {
+  private readonly allowedSourceChains: Set<string>;
+  private readonly allowedDestinationChains: Set<string>;
+  private readonly availableBridgeIds: Set<string>;
+
+  constructor(options: StellarRouteValidatorOptions = {}) {
+    this.allowedSourceChains = new Set(
+      (options.allowedSourceChains ?? DEFAULT_STELLAR_SOURCE_CHAINS).map((c) =>
+        c.toLowerCase(),
+      ),
+    );
+    this.allowedDestinationChains = new Set(
+      (
+        options.allowedDestinationChains ?? DEFAULT_EVM_DESTINATION_CHAINS
+      ).map((c) => c.toLowerCase()),
+    );
+    this.availableBridgeIds = new Set(options.availableBridgeIds ?? []);
+  }
+
+  /**
+   * Validates a single Stellar bridge route.
+   * Returns a detailed result describing any errors or warnings.
+   */
+  validateRoute(route: StellarRoute): RouteValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    if (!route.routeId?.trim()) {
+      errors.push('routeId must be a non-empty string');
+    }
+
+    if (!route.sourceChain?.trim()) {
+      errors.push('sourceChain must be a non-empty string');
+    } else if (
+      !this.allowedSourceChains.has(route.sourceChain.toLowerCase())
+    ) {
+      errors.push(
+        `Source chain "${route.sourceChain}" is not a recognised Stellar chain. ` +
+          `Allowed: ${[...this.allowedSourceChains].join(', ')}`,
+      );
+    }
+
+    if (!route.destinationChain?.trim()) {
+      errors.push('destinationChain must be a non-empty string');
+    } else if (
+      !this.allowedDestinationChains.has(route.destinationChain.toLowerCase())
+    ) {
+      errors.push(
+        `Destination chain "${route.destinationChain}" is not supported. ` +
+          `Allowed: ${[...this.allowedDestinationChains].join(', ')}`,
+      );
+    }
+
+    if (
+      route.sourceChain?.trim() &&
+      route.destinationChain?.trim() &&
+      route.sourceChain.toLowerCase() === route.destinationChain.toLowerCase()
+    ) {
+      errors.push('sourceChain and destinationChain must be different');
+    }
+
+    if (!route.bridgeId?.trim()) {
+      errors.push('bridgeId must be a non-empty string');
+    } else if (
+      this.availableBridgeIds.size > 0 &&
+      !this.availableBridgeIds.has(route.bridgeId)
+    ) {
+      errors.push(
+        `Bridge "${route.bridgeId}" is not registered as an available bridge`,
+      );
+    }
+
+    if (route.amount !== undefined) {
+      const parsed = parseFloat(route.amount);
+      if (isNaN(parsed) || parsed <= 0) {
+        errors.push(`amount "${route.amount}" must be a positive numeric value`);
+      }
+    }
+
+    if (!route.asset?.trim()) {
+      warnings.push('No asset specified; route will apply to any asset');
+    }
+
+    return {
+      routeId: route.routeId ?? '',
+      isValid: errors.length === 0,
+      errors,
+      warnings,
+    };
+  }
+
+  /**
+   * Validates an array of routes and returns results for each.
+   */
+  validateRoutes(routes: StellarRoute[]): RouteValidationResult[] {
+    return routes.map((r) => this.validateRoute(r));
+  }
+
+  /**
+   * Filters out invalid routes and returns only the valid ones.
+   * Throws InvalidRouteError on the first invalid route when throwOnInvalid is true.
+   */
+  filterValidRoutes(
+    routes: StellarRoute[],
+    throwOnInvalid = false,
+  ): StellarRoute[] {
+    const valid: StellarRoute[] = [];
+
+    for (const route of routes) {
+      const result = this.validateRoute(route);
+      if (result.isValid) {
+        valid.push(route);
+      } else if (throwOnInvalid) {
+        throw new InvalidRouteError(result.routeId, result.errors);
+      }
+    }
+
+    return valid;
+  }
+
+  /**
+   * Asserts a route is valid; throws InvalidRouteError if not.
+   */
+  assertValid(route: StellarRoute): void {
+    const result = this.validateRoute(route);
+    if (!result.isValid) {
+      throw new InvalidRouteError(result.routeId, result.errors);
+    }
+  }
+
+  /**
+   * Returns true if the route passes all validation checks.
+   */
+  isValid(route: StellarRoute): boolean {
+    return this.validateRoute(route).isValid;
+  }
+
+  /**
+   * Register additional bridge IDs as available.
+   */
+  registerBridge(bridgeId: string): void {
+    this.availableBridgeIds.add(bridgeId);
+  }
+
+  /**
+   * Deregister a bridge ID.
+   */
+  deregisterBridge(bridgeId: string): void {
+    this.availableBridgeIds.delete(bridgeId);
+  }
+
+  /**
+   * Returns the set of allowed source chains.
+   */
+  getAllowedSourceChains(): string[] {
+    return [...this.allowedSourceChains];
+  }
+
+  /**
+   * Returns the set of allowed destination chains.
+   */
+  getAllowedDestinationChains(): string[] {
+    return [...this.allowedDestinationChains];
+  }
+}
+
+// ─── Default Instance ─────────────────────────────────────────────────────────
+
+export const stellarRouteValidator = new StellarRouteValidator();


### PR DESCRIPTION
Closes #293

## Summary
- Adds `StellarRouteValidator` class in `src/bridges/stellar/routes/stellar-route-validator.ts` that validates source/destination chains and bridge ID compatibility before a route is executed
- Invalid routes are rejected with a descriptive `InvalidRouteError`; valid routes pass through with any warnings attached
- Ships a new `packages/route-validator` workspace package that re-exports the validator for use across the monorepo
- Includes a full unit-test suite (`stellar-route-validator.spec.ts`) covering all validation paths, edge-cases, and the default singleton instance

## Test plan
- [ ] `StellarRouteValidator` accepts valid Stellar → EVM routes
- [ ] Rejects routes with unknown source/destination chains or unregistered bridge IDs
- [ ] `filterValidRoutes` returns only valid routes; throws when `throwOnInvalid = true`
- [ ] `assertValid` throws `InvalidRouteError` for bad routes
- [ ] `registerBridge` / `deregisterBridge` dynamically update allowed bridges
- [ ] Default `stellarRouteValidator` singleton works with no bridge restriction