### PR TITLE
feat: Implement Soroban Bridge Adapter Interface

### DIFF
--- a/packages/adapters/stellar/src/index.ts
+++ b/packages/adapters/stellar/src/index.ts
@@ -56,5 +56,19 @@ export function createStellarAdapter(
   return new StellarBridgeExecutor(wallet, bridgeContract, horizonUrl);
 }
 
+// Adapter interface exports
+export type {
+  IBridgeAdapter,
+  ISorobanBridgeAdapter,
+  AdapterTransferRequest,
+  AdapterTransferOptions,
+  AdapterTransferResult,
+  AdapterTransferStatus,
+  AdapterTransferStatusResult,
+  AdapterFeeEstimate,
+  AdapterNetworkStats,
+  AdapterInfo,
+} from './interfaces/SorobanBridgeAdapter';
+
 // Version export
 export const version = '0.1.0';

--- a/packages/adapters/stellar/src/interfaces/SorobanBridgeAdapter.spec.ts
+++ b/packages/adapters/stellar/src/interfaces/SorobanBridgeAdapter.spec.ts
@@ -1,0 +1,170 @@
+import type {
+  IBridgeAdapter,
+  ISorobanBridgeAdapter,
+  AdapterTransferRequest,
+  AdapterTransferOptions,
+  AdapterTransferResult,
+  AdapterTransferStatusResult,
+  AdapterFeeEstimate,
+  AdapterNetworkStats,
+  AdapterInfo,
+} from './SorobanBridgeAdapter';
+
+// ─── Minimal stub implementations used in structural tests ───────────────────
+
+class StubBridgeAdapter implements IBridgeAdapter {
+  private connected = false;
+
+  async connect(_network: 'mainnet' | 'testnet'): Promise<void> {
+    this.connected = true;
+  }
+
+  disconnect(): void {
+    this.connected = false;
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async executeTransfer(
+    _transfer: AdapterTransferRequest,
+    _options?: AdapterTransferOptions,
+  ): Promise<AdapterTransferResult> {
+    return {
+      success: true,
+      transactionHash: 'abc123',
+      operationId: 'op-1',
+      bridgedAmount: '1000',
+      estimatedTimeMs: 5000,
+    };
+  }
+
+  async estimateFees(
+    _transfer: AdapterTransferRequest,
+  ): Promise<AdapterFeeEstimate> {
+    return {
+      networkFee: '100',
+      bridgeFee: '10',
+      totalFee: '110',
+      feePercentage: '0.1',
+      gasEstimate: '300000',
+    };
+  }
+
+  async getTransferStatus(
+    operationId: string,
+  ): Promise<AdapterTransferStatusResult> {
+    return {
+      operationId,
+      status: 'confirmed',
+      transactionHash: 'abc123',
+      bridgedAmount: '1000',
+      estimatedTimeMs: 0,
+    };
+  }
+}
+
+class StubSorobanAdapter
+  extends StubBridgeAdapter
+  implements ISorobanBridgeAdapter
+{
+  async getNetworkStats(): Promise<AdapterNetworkStats> {
+    return { baseFee: 100, averageTimeMs: 5000, pendingTransactions: 3 };
+  }
+
+  getAdapterInfo(): AdapterInfo {
+    return {
+      name: 'StubSorobanAdapter',
+      version: '0.1.0',
+      network: 'testnet',
+      supportedSourceChains: ['stellar', 'stellar-testnet'],
+      supportedDestinationChains: ['ethereum', 'polygon'],
+    };
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('IBridgeAdapter', () => {
+  let adapter: IBridgeAdapter;
+
+  beforeEach(() => {
+    adapter = new StubBridgeAdapter();
+  });
+
+  it('starts disconnected', () => {
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('reports connected after connect()', async () => {
+    await adapter.connect('testnet');
+    expect(adapter.isConnected()).toBe(true);
+  });
+
+  it('reports disconnected after disconnect()', async () => {
+    await adapter.connect('testnet');
+    adapter.disconnect();
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('executeTransfer returns a result with success flag', async () => {
+    const result = await adapter.executeTransfer({
+      sourceChain: 'stellar',
+      targetChain: 'ethereum',
+      sourceAmount: '1000',
+      recipient: '0xRecipient',
+    });
+    expect(result.success).toBe(true);
+    expect(result.transactionHash).toBeDefined();
+  });
+
+  it('estimateFees returns networkFee, bridgeFee and totalFee', async () => {
+    const estimate = await adapter.estimateFees({
+      sourceChain: 'stellar',
+      targetChain: 'polygon',
+      sourceAmount: '500',
+      recipient: '0xRecipient',
+    });
+    expect(estimate.networkFee).toBeDefined();
+    expect(estimate.bridgeFee).toBeDefined();
+    expect(estimate.totalFee).toBeDefined();
+  });
+
+  it('getTransferStatus returns status for the given operationId', async () => {
+    const statusResult = await adapter.getTransferStatus('op-42');
+    expect(statusResult.operationId).toBe('op-42');
+    expect(['pending', 'confirmed', 'failed']).toContain(statusResult.status);
+  });
+});
+
+describe('ISorobanBridgeAdapter', () => {
+  let adapter: ISorobanBridgeAdapter;
+
+  beforeEach(() => {
+    adapter = new StubSorobanAdapter();
+  });
+
+  it('satisfies IBridgeAdapter contract', async () => {
+    await adapter.connect('mainnet');
+    expect(adapter.isConnected()).toBe(true);
+    adapter.disconnect();
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('getNetworkStats returns baseFee and averageTimeMs', async () => {
+    const stats = await adapter.getNetworkStats();
+    expect(typeof stats.baseFee).toBe('number');
+    expect(typeof stats.averageTimeMs).toBe('number');
+    expect(typeof stats.pendingTransactions).toBe('number');
+  });
+
+  it('getAdapterInfo returns name, version, and supported chains', () => {
+    const info = adapter.getAdapterInfo();
+    expect(info.name).toBeTruthy();
+    expect(info.version).toBeTruthy();
+    expect(['mainnet', 'testnet']).toContain(info.network);
+    expect(Array.isArray(info.supportedSourceChains)).toBe(true);
+    expect(Array.isArray(info.supportedDestinationChains)).toBe(true);
+  });
+});

--- a/packages/adapters/stellar/src/interfaces/SorobanBridgeAdapter.ts
+++ b/packages/adapters/stellar/src/interfaces/SorobanBridgeAdapter.ts
@@ -1,0 +1,130 @@
+// ─── Shared Transfer Types ────────────────────────────────────────────────────
+
+export interface AdapterTransferRequest {
+  sourceChain: string;
+  targetChain: string;
+  sourceAmount: string;
+  recipient: string;
+  asset?: string;
+  tokenAddress?: string;
+}
+
+export interface AdapterTransferOptions {
+  slippage?: number;
+  deadline?: number;
+  gasLimit?: number;
+  priorityFee?: string;
+}
+
+export interface AdapterTransferResult {
+  success: boolean;
+  transactionHash?: string;
+  operationId?: string;
+  bridgedAmount?: string;
+  estimatedTimeMs?: number;
+  error?: string;
+}
+
+export type AdapterTransferStatus = 'pending' | 'confirmed' | 'failed';
+
+export interface AdapterTransferStatusResult {
+  operationId: string;
+  status: AdapterTransferStatus;
+  transactionHash?: string;
+  bridgedAmount?: string;
+  estimatedTimeMs?: number;
+}
+
+// ─── Fee Types ────────────────────────────────────────────────────────────────
+
+export interface AdapterFeeEstimate {
+  networkFee: string;
+  bridgeFee: string;
+  totalFee: string;
+  feePercentage?: string;
+  gasEstimate?: string;
+}
+
+// ─── Network Types ────────────────────────────────────────────────────────────
+
+export interface AdapterNetworkStats {
+  baseFee: number;
+  averageTimeMs: number;
+  pendingTransactions: number;
+}
+
+// ─── Adapter Metadata ─────────────────────────────────────────────────────────
+
+export interface AdapterInfo {
+  name: string;
+  version: string;
+  network: 'mainnet' | 'testnet';
+  supportedSourceChains: string[];
+  supportedDestinationChains: string[];
+}
+
+// ─── Base Bridge Adapter Interface ───────────────────────────────────────────
+
+/**
+ * Generic bridge adapter interface that all bridge implementations must satisfy.
+ * Provides a uniform API for connecting wallets, executing transfers, estimating
+ * fees and querying transfer status regardless of the underlying bridge provider.
+ */
+export interface IBridgeAdapter {
+  /**
+   * Establish a connection to the user's wallet on the specified network.
+   */
+  connect(network: 'mainnet' | 'testnet'): Promise<void>;
+
+  /**
+   * Release any resources associated with the current wallet connection.
+   */
+  disconnect(): void;
+
+  /**
+   * Returns true if a wallet connection is currently active.
+   */
+  isConnected(): boolean;
+
+  /**
+   * Execute a cross-chain bridge transfer.
+   */
+  executeTransfer(
+    transfer: AdapterTransferRequest,
+    options?: AdapterTransferOptions,
+  ): Promise<AdapterTransferResult>;
+
+  /**
+   * Estimate the fees required for a cross-chain transfer without executing it.
+   */
+  estimateFees(transfer: AdapterTransferRequest): Promise<AdapterFeeEstimate>;
+
+  /**
+   * Query the current status of a previously submitted transfer.
+   */
+  getTransferStatus(operationId: string): Promise<AdapterTransferStatusResult>;
+}
+
+// ─── Soroban-Specific Bridge Adapter Interface ────────────────────────────────
+
+/**
+ * Soroban bridge adapter interface extending the base adapter with
+ * Soroban/Stellar-specific capabilities.
+ *
+ * Implementations of this interface provide a standardised, reusable entry
+ * point for any Soroban-based bridge integration within the BridgeWise
+ * monorepo.
+ */
+export interface ISorobanBridgeAdapter extends IBridgeAdapter {
+  /**
+   * Fetch current Stellar network statistics useful for fee and timing
+   * estimates (base fee, average confirmation time, pending queue depth).
+   */
+  getNetworkStats(): Promise<AdapterNetworkStats>;
+
+  /**
+   * Return static metadata describing this adapter instance (name, version,
+   * target network, supported chain pairs).
+   */
+  getAdapterInfo(): AdapterInfo;
+}


### PR DESCRIPTION
Closes #294

## Summary
- Adds `IBridgeAdapter` base interface in `packages/adapters/stellar/src/interfaces/SorobanBridgeAdapter.ts` providing a uniform contract (connect, disconnect, isConnected, executeTransfer, estimateFees, getTransferStatus) for any bridge adapter
- Extends it with `ISorobanBridgeAdapter` to add Soroban-specific methods (`getNetworkStats`, `getAdapterInfo`)
- Introduces shared types (`AdapterTransferRequest`, `AdapterTransferResult`, `AdapterFeeEstimate`, `AdapterNetworkStats`, `AdapterInfo`, etc.) enabling consistent data shapes across bridge integrations
- Re-exports all new interfaces and types from the package root so consumers get everything from a single import
- Includes a test file that verifies the structural contract via stub implementations

## Test plan
- [ ] `IBridgeAdapter` stub reports correct connected/disconnected state
- [ ] `executeTransfer` returns a result with a `success` flag
- [ ] `estimateFees` returns `networkFee`, `bridgeFee` and `totalFee`
- [ ] `getTransferStatus` returns a valid status enum value
- [ ] `ISorobanBridgeAdapter` stub satisfies the full `IBridgeAdapter` contract
- [ ] `getNetworkStats` returns numeric `baseFee`, `averageTimeMs` and `pendingTransactions`
- [ ] `getAdapterInfo` returns `name`, `version`, `network` and supported chain arrays