### PR TITLE
feat: Implement Stellar-to-EVM Fee Comparison Engine

### DIFF
--- a/src/analytics/fees/stellar-evm-fee-comparison.spec.ts
+++ b/src/analytics/fees/stellar-evm-fee-comparison.spec.ts
@@ -1,0 +1,257 @@
+import { StellarEvmFeeComparisonEngine } from './stellar-evm-fee-comparison';
+
+// Helper to seed the engine with a set of records
+function seed(engine: StellarEvmFeeComparisonEngine) {
+  // Stellar bridges for stellar → ethereum
+  engine.recordFee({
+    bridgeId: 'stellar-bridge-a',
+    bridgeType: 'stellar',
+    sourceChain: 'stellar',
+    destinationChain: 'ethereum',
+    feeUsd: 0.5,
+  });
+  engine.recordFee({
+    bridgeId: 'stellar-bridge-a',
+    bridgeType: 'stellar',
+    sourceChain: 'stellar',
+    destinationChain: 'ethereum',
+    feeUsd: 0.7,
+  });
+  // EVM bridge for stellar → ethereum (more expensive)
+  engine.recordFee({
+    bridgeId: 'evm-bridge-b',
+    bridgeType: 'evm',
+    sourceChain: 'stellar',
+    destinationChain: 'ethereum',
+    feeUsd: 2.0,
+  });
+  engine.recordFee({
+    bridgeId: 'evm-bridge-b',
+    bridgeType: 'evm',
+    sourceChain: 'stellar',
+    destinationChain: 'ethereum',
+    feeUsd: 1.8,
+  });
+  // Another route: stellar → polygon
+  engine.recordFee({
+    bridgeId: 'evm-bridge-b',
+    bridgeType: 'evm',
+    sourceChain: 'stellar',
+    destinationChain: 'polygon',
+    feeUsd: 0.9,
+  });
+}
+
+describe('StellarEvmFeeComparisonEngine', () => {
+  let engine: StellarEvmFeeComparisonEngine;
+
+  beforeEach(() => {
+    engine = new StellarEvmFeeComparisonEngine();
+    seed(engine);
+  });
+
+  // ─── recordFee ─────────────────────────────────────────────────────────────
+
+  describe('recordFee', () => {
+    it('throws when bridgeId is empty', () => {
+      expect(() =>
+        engine.recordFee({
+          bridgeId: '',
+          bridgeType: 'stellar',
+          sourceChain: 'stellar',
+          destinationChain: 'ethereum',
+          feeUsd: 1,
+        }),
+      ).toThrow('bridgeId must be a non-empty string');
+    });
+
+    it('throws when feeUsd is negative', () => {
+      expect(() =>
+        engine.recordFee({
+          bridgeId: 'b',
+          bridgeType: 'evm',
+          sourceChain: 'stellar',
+          destinationChain: 'ethereum',
+          feeUsd: -1,
+        }),
+      ).toThrow('feeUsd must be non-negative');
+    });
+
+    it('normalises chain names to lower-case', () => {
+      engine.recordFee({
+        bridgeId: 'b',
+        bridgeType: 'stellar',
+        sourceChain: 'Stellar',
+        destinationChain: 'Ethereum',
+        feeUsd: 0.3,
+      });
+      const result = engine.compareFees('stellar', 'ethereum');
+      expect(result.sampleCount).toBeGreaterThan(4);
+    });
+
+    it('increments totalRecords after each call', () => {
+      const before = engine.totalRecords;
+      engine.recordFee({
+        bridgeId: 'b',
+        bridgeType: 'evm',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        feeUsd: 1,
+      });
+      expect(engine.totalRecords).toBe(before + 1);
+    });
+  });
+
+  // ─── compareFees ───────────────────────────────────────────────────────────
+
+  describe('compareFees', () => {
+    it('returns results ranked cheapest first', () => {
+      const result = engine.compareFees('stellar', 'ethereum');
+      expect(result.rankedBridges[0].bridgeId).toBe('stellar-bridge-a');
+      expect(result.rankedBridges[1].bridgeId).toBe('evm-bridge-b');
+    });
+
+    it('assigns rank 1 to the cheapest bridge', () => {
+      const { rankedBridges } = engine.compareFees('stellar', 'ethereum');
+      expect(rankedBridges[0].rank).toBe(1);
+      expect(rankedBridges[1].rank).toBe(2);
+    });
+
+    it('sets cheapest and mostExpensive correctly', () => {
+      const result = engine.compareFees('stellar', 'ethereum');
+      expect(result.cheapest!.bridgeId).toBe('stellar-bridge-a');
+      expect(result.mostExpensive!.bridgeId).toBe('evm-bridge-b');
+    });
+
+    it('returns sampleCount equal to matching records', () => {
+      const result = engine.compareFees('stellar', 'ethereum');
+      expect(result.sampleCount).toBe(4);
+    });
+
+    it('returns empty result for unknown route', () => {
+      const result = engine.compareFees('stellar', 'bsc');
+      expect(result.rankedBridges).toHaveLength(0);
+      expect(result.cheapest).toBeNull();
+      expect(result.sampleCount).toBe(0);
+    });
+
+    it('respects the windowDays override', () => {
+      // Record an old entry outside any reasonable window
+      const old = new Date();
+      old.setDate(old.getDate() - 30);
+      engine.recordFee({
+        bridgeId: 'old-bridge',
+        bridgeType: 'evm',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        feeUsd: 100,
+        timestamp: old,
+      });
+      // With a 7-day window the old record should not appear
+      const result = engine.compareFees('stellar', 'ethereum', 7);
+      const ids = result.rankedBridges.map((b) => b.bridgeId);
+      expect(ids).not.toContain('old-bridge');
+    });
+  });
+
+  // ─── getCheapestRoute ──────────────────────────────────────────────────────
+
+  describe('getCheapestRoute', () => {
+    it('returns the cheapest bridge entry', () => {
+      const cheapest = engine.getCheapestRoute('stellar', 'ethereum');
+      expect(cheapest).not.toBeNull();
+      expect(cheapest!.bridgeId).toBe('stellar-bridge-a');
+      expect(cheapest!.rank).toBe(1);
+    });
+
+    it('returns null when no data exists', () => {
+      expect(engine.getCheapestRoute('stellar', 'arbitrum')).toBeNull();
+    });
+  });
+
+  // ─── rankAllBridgesByCost ──────────────────────────────────────────────────
+
+  describe('rankAllBridgesByCost', () => {
+    it('returns entries sorted by average fee ascending', () => {
+      const ranked = engine.rankAllBridgesByCost();
+      for (let i = 1; i < ranked.length; i++) {
+        expect(ranked[i].averageFeeUsd).toBeGreaterThanOrEqual(
+          ranked[i - 1].averageFeeUsd,
+        );
+      }
+    });
+
+    it('includes both stellar and evm bridge types', () => {
+      const types = engine.rankAllBridgesByCost().map((e) => e.bridgeType);
+      expect(types).toContain('stellar');
+      expect(types).toContain('evm');
+    });
+  });
+
+  // ─── aggregateFeesByBridge ─────────────────────────────────────────────────
+
+  describe('aggregateFeesByBridge', () => {
+    it('returns a Map keyed by bridgeId', () => {
+      const map = engine.aggregateFeesByBridge();
+      expect(map instanceof Map).toBe(true);
+      expect(map.has('stellar-bridge-a')).toBe(true);
+      expect(map.has('evm-bridge-b')).toBe(true);
+    });
+
+    it('stores numeric average fee values', () => {
+      const map = engine.aggregateFeesByBridge();
+      map.forEach((fee) => {
+        expect(typeof fee).toBe('number');
+        expect(fee).toBeGreaterThanOrEqual(0);
+      });
+    });
+  });
+
+  // ─── pruneOlderThan ────────────────────────────────────────────────────────
+
+  describe('pruneOlderThan', () => {
+    it('removes records older than the given days', () => {
+      const old = new Date();
+      old.setDate(old.getDate() - 10);
+      engine.recordFee({
+        bridgeId: 'old-b',
+        bridgeType: 'evm',
+        sourceChain: 'stellar',
+        destinationChain: 'ethereum',
+        feeUsd: 5,
+        timestamp: old,
+      });
+      const removed = engine.pruneOlderThan(7);
+      expect(removed).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ─── clearRecords ──────────────────────────────────────────────────────────
+
+  describe('clearRecords', () => {
+    it('resets totalRecords to zero', () => {
+      engine.clearRecords();
+      expect(engine.totalRecords).toBe(0);
+    });
+  });
+
+  // ─── maxRecordsPerBridge ───────────────────────────────────────────────────
+
+  describe('maxRecordsPerBridge option', () => {
+    it('caps stored records per bridge', () => {
+      const capped = new StellarEvmFeeComparisonEngine({
+        maxRecordsPerBridge: 2,
+      });
+      for (let i = 0; i < 5; i++) {
+        capped.recordFee({
+          bridgeId: 'b',
+          bridgeType: 'evm',
+          sourceChain: 'stellar',
+          destinationChain: 'ethereum',
+          feeUsd: i,
+        });
+      }
+      expect(capped.totalRecords).toBe(2);
+    });
+  });
+});

--- a/src/analytics/fees/stellar-evm-fee-comparison.ts
+++ b/src/analytics/fees/stellar-evm-fee-comparison.ts
@@ -1,0 +1,304 @@
+import * as crypto from 'crypto';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type BridgeType = 'stellar' | 'evm';
+
+export interface BridgeFeeRecord {
+  id: string;
+  timestamp: Date;
+  bridgeId: string;
+  bridgeType: BridgeType;
+  sourceChain: string;
+  destinationChain: string;
+  /** Fee denominated in USD. */
+  feeUsd: number;
+  /** Fee in the native token of the source chain (human-readable string). */
+  feeNative?: string;
+}
+
+export interface FeeComparisonEntry {
+  bridgeId: string;
+  bridgeType: BridgeType;
+  averageFeeUsd: number;
+  sampleCount: number;
+  /** 1 = cheapest. Higher rank means more expensive. */
+  rank: number;
+  /**
+   * How this bridge's average fee relates to the overall average across all
+   * bridges (positive = more expensive, negative = cheaper).
+   */
+  relativeToAveragePct: number;
+}
+
+export interface FeeComparisonResult {
+  sourceChain: string;
+  destinationChain: string;
+  rankedBridges: FeeComparisonEntry[];
+  cheapest: FeeComparisonEntry | null;
+  mostExpensive: FeeComparisonEntry | null;
+  averageFeeUsd: number;
+  feeRangeUsd: { min: number; max: number };
+  sampleCount: number;
+  generatedAt: Date;
+}
+
+export interface StellarEvmFeeComparisonEngineOptions {
+  /**
+   * Rolling window in days used for fee aggregation. Default: 7.
+   */
+  windowDays?: number;
+  /**
+   * Maximum records kept per bridge. Oldest are pruned first. Default: unlimited.
+   */
+  maxRecordsPerBridge?: number;
+}
+
+// ─── Engine ───────────────────────────────────────────────────────────────────
+
+export class StellarEvmFeeComparisonEngine {
+  private records: BridgeFeeRecord[] = [];
+  private readonly windowDays: number;
+  private readonly maxRecordsPerBridge: number;
+
+  constructor(options: StellarEvmFeeComparisonEngineOptions = {}) {
+    this.windowDays = options.windowDays ?? 7;
+    this.maxRecordsPerBridge = options.maxRecordsPerBridge ?? Infinity;
+  }
+
+  // ─── Write ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Record a new fee data point for a bridge.
+   */
+  recordFee(
+    data: Omit<BridgeFeeRecord, 'id' | 'timestamp'> & { timestamp?: Date },
+  ): BridgeFeeRecord {
+    if (!data.bridgeId?.trim()) {
+      throw new Error('bridgeId must be a non-empty string');
+    }
+    if (!data.sourceChain?.trim()) {
+      throw new Error('sourceChain must be a non-empty string');
+    }
+    if (!data.destinationChain?.trim()) {
+      throw new Error('destinationChain must be a non-empty string');
+    }
+    if (data.feeUsd < 0) {
+      throw new Error(`feeUsd must be non-negative, got ${data.feeUsd}`);
+    }
+
+    const record: BridgeFeeRecord = {
+      id: crypto.randomUUID(),
+      timestamp: data.timestamp ?? new Date(),
+      bridgeId: data.bridgeId.trim(),
+      bridgeType: data.bridgeType,
+      sourceChain: data.sourceChain.trim().toLowerCase(),
+      destinationChain: data.destinationChain.trim().toLowerCase(),
+      feeUsd: data.feeUsd,
+      feeNative: data.feeNative,
+    };
+
+    this.records.push(record);
+    this.pruneBridge(record.bridgeId);
+    return record;
+  }
+
+  // ─── Query ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Compare all registered bridges for a given source → destination pair,
+   * ranked from cheapest to most expensive by average fee over the window.
+   */
+  compareFees(
+    sourceChain: string,
+    destinationChain: string,
+    windowDays?: number,
+  ): FeeComparisonResult {
+    const days = windowDays ?? this.windowDays;
+    const src = sourceChain.trim().toLowerCase();
+    const dst = destinationChain.trim().toLowerCase();
+
+    const window = this.getWindowRecords(src, dst, days);
+
+    if (window.length === 0) {
+      return {
+        sourceChain: src,
+        destinationChain: dst,
+        rankedBridges: [],
+        cheapest: null,
+        mostExpensive: null,
+        averageFeeUsd: 0,
+        feeRangeUsd: { min: 0, max: 0 },
+        sampleCount: 0,
+        generatedAt: new Date(),
+      };
+    }
+
+    // Aggregate per bridge
+    const byBridge = groupBy(window, (r) => r.bridgeId);
+    const aggregated = Object.entries(byBridge).map(([bridgeId, recs]) => ({
+      bridgeId,
+      bridgeType: recs[0].bridgeType,
+      averageFeeUsd: round(mean(recs.map((r) => r.feeUsd))),
+      sampleCount: recs.length,
+    }));
+
+    // Sort cheapest first
+    aggregated.sort((a, b) => a.averageFeeUsd - b.averageFeeUsd);
+
+    const overallAvg = mean(aggregated.map((e) => e.averageFeeUsd));
+    const allFees = window.map((r) => r.feeUsd);
+
+    const rankedBridges: FeeComparisonEntry[] = aggregated.map((entry, i) => ({
+      ...entry,
+      rank: i + 1,
+      relativeToAveragePct:
+        overallAvg > 0
+          ? round(((entry.averageFeeUsd - overallAvg) / overallAvg) * 100, 2)
+          : 0,
+    }));
+
+    return {
+      sourceChain: src,
+      destinationChain: dst,
+      rankedBridges,
+      cheapest: rankedBridges[0] ?? null,
+      mostExpensive: rankedBridges[rankedBridges.length - 1] ?? null,
+      averageFeeUsd: round(overallAvg),
+      feeRangeUsd: {
+        min: round(Math.min(...allFees)),
+        max: round(Math.max(...allFees)),
+      },
+      sampleCount: window.length,
+      generatedAt: new Date(),
+    };
+  }
+
+  /**
+   * Returns the cheapest bridge entry for a given route.
+   * Returns null if no data is available.
+   */
+  getCheapestRoute(
+    sourceChain: string,
+    destinationChain: string,
+    windowDays?: number,
+  ): FeeComparisonEntry | null {
+    return this.compareFees(sourceChain, destinationChain, windowDays).cheapest;
+  }
+
+  /**
+   * Rank all bridges across all routes by their aggregate average fee,
+   * cheapest first.
+   */
+  rankAllBridgesByCost(windowDays?: number): Array<{
+    bridgeId: string;
+    bridgeType: BridgeType;
+    averageFeeUsd: number;
+    sampleCount: number;
+  }> {
+    const days = windowDays ?? this.windowDays;
+    const cutoff = cutoffDate(days);
+    const window = this.records.filter((r) => r.timestamp >= cutoff);
+
+    const byBridge = groupBy(window, (r) => r.bridgeId);
+    return Object.entries(byBridge)
+      .map(([bridgeId, recs]) => ({
+        bridgeId,
+        bridgeType: recs[0].bridgeType,
+        averageFeeUsd: round(mean(recs.map((r) => r.feeUsd))),
+        sampleCount: recs.length,
+      }))
+      .sort((a, b) => a.averageFeeUsd - b.averageFeeUsd);
+  }
+
+  /**
+   * Returns a map of bridgeId → average fee USD across all recorded routes
+   * within the rolling window.
+   */
+  aggregateFeesByBridge(windowDays?: number): Map<string, number> {
+    const ranking = this.rankAllBridgesByCost(windowDays);
+    return new Map(ranking.map((e) => [e.bridgeId, e.averageFeeUsd]));
+  }
+
+  // ─── Maintenance ───────────────────────────────────────────────────────────
+
+  /** Remove all records older than `days`. Returns the count removed. */
+  pruneOlderThan(days: number): number {
+    const cutoff = cutoffDate(days);
+    const before = this.records.length;
+    this.records = this.records.filter((r) => r.timestamp >= cutoff);
+    return before - this.records.length;
+  }
+
+  /** Remove all stored records. */
+  clearRecords(): void {
+    this.records = [];
+  }
+
+  /** Total number of stored records. */
+  get totalRecords(): number {
+    return this.records.length;
+  }
+
+  // ─── Private ───────────────────────────────────────────────────────────────
+
+  private getWindowRecords(
+    sourceChain: string,
+    destinationChain: string,
+    days: number,
+  ): BridgeFeeRecord[] {
+    const cutoff = cutoffDate(days);
+    return this.records.filter(
+      (r) =>
+        r.sourceChain === sourceChain &&
+        r.destinationChain === destinationChain &&
+        r.timestamp >= cutoff,
+    );
+  }
+
+  private pruneBridge(bridgeId: string): void {
+    if (this.maxRecordsPerBridge === Infinity) return;
+
+    const bridgeRecords = this.records
+      .filter((r) => r.bridgeId === bridgeId)
+      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    if (bridgeRecords.length > this.maxRecordsPerBridge) {
+      const toRemove = new Set(
+        bridgeRecords
+          .slice(0, bridgeRecords.length - this.maxRecordsPerBridge)
+          .map((r) => r.id),
+      );
+      this.records = this.records.filter((r) => !toRemove.has(r.id));
+    }
+  }
+}
+
+// ─── Pure Helpers ─────────────────────────────────────────────────────────────
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function round(value: number, decimals = 4): number {
+  return Number(value.toFixed(decimals));
+}
+
+function cutoffDate(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d;
+}
+
+function groupBy<T>(
+  items: T[],
+  keyFn: (item: T) => string,
+): Record<string, T[]> {
+  return items.reduce<Record<string, T[]>>((acc, item) => {
+    const key = keyFn(item);
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(item);
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
Closes #295

## Summary
- Adds `StellarEvmFeeComparisonEngine` in `src/analytics/fees/stellar-evm-fee-comparison.ts` that accepts fee records from both Stellar and EVM bridge providers and compares them side-by-side
- `compareFees(sourceChain, destinationChain)` aggregates per-bridge average fees over a configurable rolling window, ranks them cheapest-first, and returns `cheapest`/`mostExpensive` pointers along with `feeRangeUsd` and overall `averageFeeUsd`
- `getCheapestRoute()` provides a single-call shortcut to the lowest-cost bridge entry for any route
- `rankAllBridgesByCost()` and `aggregateFeesByBridge()` give cross-route cost summaries useful for dashboards and alerting
- Engine supports a configurable `windowDays` (default 7) and `maxRecordsPerBridge` cap to prevent unbounded memory growth
- Includes a full unit test suite covering all public methods, edge cases (empty routes, old records outside window, capped records) and validation errors

## Test plan
- [ ] `recordFee` throws on empty `bridgeId`, negative `feeUsd`, or empty chain names
- [ ] Chain names are normalised to lower-case on insert
- [ ] `compareFees` ranks `stellar-bridge-a` cheaper than `evm-bridge-b` with seeded data
- [ ] Rank 1 is assigned to the cheapest bridge
- [ ] `cheapest` and `mostExpensive` point to correct entries
- [ ] Records outside the `windowDays` are excluded from comparisons
- [ ] `getCheapestRoute` returns `null` when no data exists for a route
- [ ] `rankAllBridgesByCost` returns entries sorted ascending by average fee
- [ ] `aggregateFeesByBridge` returns a `Map<string, number>` with all bridge IDs
- [ ] `pruneOlderThan` removes records older than the given threshold
- [ ] `maxRecordsPerBridge` caps total stored records for a single bridge