### PR TITLE
Implement Stellar telemetry provider (collect, normalize, store)

### DIFF
--- a/src/telemetry/providers/stellar/stellar-telemetry-pipeline.spec.ts
+++ b/src/telemetry/providers/stellar/stellar-telemetry-pipeline.spec.ts
@@ -1,0 +1,192 @@
+import { StellarTelemetryPipeline } from './stellar-telemetry-pipeline';
+import { SorobanBridgeAuditLogger } from '../../../logging/audit/stellar/soroban-bridge-audit-logger';
+import { StellarMetricsExporter } from '../../../exporters/metrics/stellar';
+
+describe('StellarTelemetryPipeline', () => {
+  let pipeline: StellarTelemetryPipeline;
+  let auditLogger: SorobanBridgeAuditLogger;
+  let metricsExporter: StellarMetricsExporter;
+  let clockTime: number;
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    clockTime = 1718500000000;
+    auditLogger = new SorobanBridgeAuditLogger();
+    metricsExporter = new StellarMetricsExporter('test_namespace');
+    pipeline = new StellarTelemetryPipeline({
+      auditLogger,
+      metricsExporter,
+      providerId: 'stellar-test',
+      now: () => clockTime,
+    });
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  // ─── Event: quote.requested ───────────────────────────────────────────────
+
+  it('records and normalizes quote requested event', () => {
+    const event = pipeline.recordQuoteRequested('100.5', { route: 'routeA' });
+
+    // Verify normalized event returned
+    expect(event).toEqual({
+      eventName: 'quote.requested',
+      timestamp: 1718500000000,
+      providerId: 'stellar-test',
+      status: 'success',
+      amount: '100.5',
+      metadata: { route: 'routeA' },
+    });
+
+    // Verify console output
+    expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(event));
+
+    // Verify Audit Logger entry
+    const auditEvents = auditLogger.getAll();
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0].type).toBe('transfer.initiated');
+    expect(auditEvents[0].providerId).toBe('stellar-test');
+    expect(auditEvents[0].metadata).toMatchObject({
+      eventName: 'quote.requested',
+      status: 'success',
+      amount: '100.5',
+      route: 'routeA',
+    });
+  });
+
+  // ─── Event: transfer.submitted ─────────────────────────────────────────────
+
+  it('records and normalizes transfer submitted event', () => {
+    const event = pipeline.recordTransferSubmitted('tx-123', '250.0', { route: 'routeB' });
+
+    expect(event).toEqual({
+      eventName: 'transfer.submitted',
+      timestamp: 1718500000000,
+      providerId: 'stellar-test',
+      status: 'pending',
+      transferId: 'tx-123',
+      amount: '250.0',
+      metadata: { route: 'routeB' },
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(event));
+
+    const auditEvents = auditLogger.getAll();
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0].type).toBe('transfer.submitted');
+    expect(auditEvents[0].transferId).toBe('tx-123');
+    expect(auditEvents[0].metadata).toMatchObject({
+      eventName: 'transfer.submitted',
+      status: 'pending',
+      amount: '250.0',
+      route: 'routeB',
+    });
+  });
+
+  // ─── Event: transfer.confirmed ─────────────────────────────────────────────
+
+  it('records and normalizes transfer confirmed event and records metrics', () => {
+    jest.spyOn(metricsExporter, 'recordTransaction');
+    jest.spyOn(metricsExporter, 'recordLatency');
+    jest.spyOn(metricsExporter, 'recordFee');
+
+    const event = pipeline.recordTransferConfirmed(
+      'tx-123',
+      4500,
+      '250.0',
+      1.25,
+      { route: 'routeC', asset: 'USDC' }
+    );
+
+    expect(event).toEqual({
+      eventName: 'transfer.confirmed',
+      timestamp: 1718500000000,
+      providerId: 'stellar-test',
+      status: 'success',
+      transferId: 'tx-123',
+      amount: '250.0',
+      latencyMs: 4500,
+      feeUsd: 1.25,
+      metadata: { route: 'routeC', asset: 'USDC' },
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(event));
+
+    const auditEvents = auditLogger.getAll();
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0].type).toBe('transfer.confirmed');
+    expect(auditEvents[0].metadata).toMatchObject({
+      eventName: 'transfer.confirmed',
+      status: 'success',
+      amount: '250.0',
+      latencyMs: 4500,
+      feeUsd: 1.25,
+      route: 'routeC',
+      asset: 'USDC',
+    });
+
+    // Verify metrics calls
+    expect(metricsExporter.recordTransaction).toHaveBeenCalledWith({
+      route: 'routeC',
+      status: 'success',
+    });
+    expect(metricsExporter.recordLatency).toHaveBeenCalledWith(
+      { route: 'routeC' },
+      4500
+    );
+    expect(metricsExporter.recordFee).toHaveBeenCalledWith(
+      { route: 'routeC', asset: 'USDC' },
+      1.25
+    );
+  });
+
+  // ─── Event: transfer.failed ────────────────────────────────────────────────
+
+  it('records and normalizes transfer failed event and records metrics', () => {
+    jest.spyOn(metricsExporter, 'recordTransaction');
+    jest.spyOn(metricsExporter, 'recordLatency');
+
+    const event = pipeline.recordTransferFailed(
+      'tx-123',
+      2500,
+      'Timeout expired',
+      { route: 'routeD' }
+    );
+
+    expect(event).toEqual({
+      eventName: 'transfer.failed',
+      timestamp: 1718500000000,
+      providerId: 'stellar-test',
+      status: 'failed',
+      transferId: 'tx-123',
+      latencyMs: 2500,
+      error: 'Timeout expired',
+      metadata: { route: 'routeD' },
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(event));
+
+    const auditEvents = auditLogger.getAll();
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0].type).toBe('transfer.failed');
+    expect(auditEvents[0].metadata).toMatchObject({
+      eventName: 'transfer.failed',
+      status: 'failed',
+      latencyMs: 2500,
+      error: 'Timeout expired',
+      route: 'routeD',
+    });
+
+    expect(metricsExporter.recordTransaction).toHaveBeenCalledWith({
+      route: 'routeD',
+      status: 'failure',
+    });
+    expect(metricsExporter.recordLatency).toHaveBeenCalledWith(
+      { route: 'routeD' },
+      2500
+    );
+  });
+});

--- a/src/telemetry/providers/stellar/stellar-telemetry-pipeline.ts
+++ b/src/telemetry/providers/stellar/stellar-telemetry-pipeline.ts
@@ -1,0 +1,190 @@
+import { SorobanBridgeAuditLogger } from '../../../logging/audit/stellar/soroban-bridge-audit-logger';
+import { AuditEventType } from '../../../logging/audit/stellar/soroban-bridge-audit-logger.types';
+import { stellarMetrics, StellarMetricsExporter } from '../../../exporters/metrics/stellar';
+import { StellarTelemetryEvent, StellarTelemetryEventType } from './types';
+
+export interface StellarTelemetryPipelineConfig {
+  auditLogger?: SorobanBridgeAuditLogger;
+  metricsExporter?: StellarMetricsExporter;
+  providerId?: string;
+  now?: () => number;
+}
+
+export class StellarTelemetryPipeline {
+  private readonly auditLogger: SorobanBridgeAuditLogger;
+  private readonly metricsExporter: StellarMetricsExporter;
+  private readonly providerId: string;
+  private readonly now: () => number;
+
+  constructor(config: StellarTelemetryPipelineConfig = {}) {
+    this.auditLogger = config.auditLogger ?? new SorobanBridgeAuditLogger();
+    this.metricsExporter = config.metricsExporter ?? stellarMetrics;
+    this.providerId = config.providerId ?? 'stellar';
+    this.now = config.now ?? (() => Date.now());
+  }
+
+  /**
+   * Helper to normalize raw event params into the standard telemetry event shape.
+   */
+  private normalizeEvent(
+    eventName: StellarTelemetryEventType,
+    status: 'success' | 'failed' | 'pending',
+    params: {
+      transferId?: string;
+      amount?: string;
+      latencyMs?: number;
+      feeUsd?: number;
+      slippage?: number;
+      error?: string;
+      metadata?: Record<string, unknown>;
+    }
+  ): StellarTelemetryEvent {
+    return {
+      eventName,
+      timestamp: this.now(),
+      providerId: this.providerId,
+      status,
+      transferId: params.transferId,
+      amount: params.amount,
+      latencyMs: params.latencyMs,
+      feeUsd: params.feeUsd,
+      slippage: params.slippage,
+      error: params.error,
+      metadata: params.metadata,
+    };
+  }
+
+  /**
+   * Persists the normalized event to the console, audit log, and metrics system.
+   */
+  private processEvent(event: StellarTelemetryEvent): void {
+    // 1. Console logging (JSON format, system standard)
+    console.log(JSON.stringify(event));
+
+    // 2. Audit Logger insertion (mapped to closest AuditEventType)
+    let auditType: AuditEventType;
+    switch (event.eventName) {
+      case 'quote.requested':
+        auditType = 'transfer.initiated';
+        break;
+      case 'transfer.submitted':
+        auditType = 'transfer.submitted';
+        break;
+      case 'transfer.confirmed':
+        auditType = 'transfer.confirmed';
+        break;
+      case 'transfer.failed':
+        auditType = 'transfer.failed';
+        break;
+      default:
+        auditType = 'transfer.initiated';
+    }
+
+    this.auditLogger.log(auditType, {
+      transferId: event.transferId,
+      providerId: event.providerId,
+      metadata: {
+        eventName: event.eventName,
+        status: event.status,
+        latencyMs: event.latencyMs,
+        amount: event.amount,
+        feeUsd: event.feeUsd,
+        slippage: event.slippage,
+        error: event.error,
+        ...event.metadata,
+      },
+    });
+
+    // 3. Exporters / Metrics client recording
+    const routeName = (event.metadata?.route as string) || 'stellar-bridge';
+    const assetName = (event.metadata?.asset as string) || 'XLM';
+
+    if (event.eventName === 'transfer.confirmed' || event.eventName === 'transfer.failed') {
+      const metricStatus = event.eventName === 'transfer.confirmed' ? 'success' : 'failure';
+      this.metricsExporter.recordTransaction({
+        route: routeName,
+        status: metricStatus,
+      });
+
+      if (event.latencyMs !== undefined) {
+        this.metricsExporter.recordLatency({ route: routeName }, event.latencyMs);
+      }
+    }
+
+    if (event.feeUsd !== undefined) {
+      this.metricsExporter.recordFee({ route: routeName, asset: assetName }, event.feeUsd);
+    }
+  }
+
+  // ─── High-Level Event Tracking Methods ────────────────────────────────────
+
+  recordQuoteRequested(
+    amount: string,
+    metadata?: Record<string, unknown>
+  ): StellarTelemetryEvent {
+    const event = this.normalizeEvent('quote.requested', 'success', {
+      amount,
+      metadata,
+    });
+    this.processEvent(event);
+    return event;
+  }
+
+  recordTransferSubmitted(
+    transferId: string,
+    amount: string,
+    metadata?: Record<string, unknown>
+  ): StellarTelemetryEvent {
+    const event = this.normalizeEvent('transfer.submitted', 'pending', {
+      transferId,
+      amount,
+      metadata,
+    });
+    this.processEvent(event);
+    return event;
+  }
+
+  recordTransferConfirmed(
+    transferId: string,
+    latencyMs: number,
+    amount: string,
+    feeUsd?: number,
+    metadata?: Record<string, unknown>
+  ): StellarTelemetryEvent {
+    const event = this.normalizeEvent('transfer.confirmed', 'success', {
+      transferId,
+      latencyMs,
+      amount,
+      feeUsd,
+      metadata,
+    });
+    this.processEvent(event);
+    return event;
+  }
+
+  recordTransferFailed(
+    transferId: string,
+    latencyMs: number,
+    error: string,
+    metadata?: Record<string, unknown>
+  ): StellarTelemetryEvent {
+    const event = this.normalizeEvent('transfer.failed', 'failed', {
+      transferId,
+      latencyMs,
+      error,
+      metadata,
+    });
+    this.processEvent(event);
+    return event;
+  }
+
+  /** Get underlying audit logger instance (useful for retrieval/verification in tests). */
+  getAuditLogger(): SorobanBridgeAuditLogger {
+    return this.auditLogger;
+  }
+
+  /** Get underlying metrics exporter instance. */
+  getMetricsExporter(): StellarMetricsExporter {
+    return this.metricsExporter;
+  }
+}

--- a/src/telemetry/providers/stellar/types.ts
+++ b/src/telemetry/providers/stellar/types.ts
@@ -1,0 +1,19 @@
+export type StellarTelemetryEventType =
+  | 'quote.requested'
+  | 'transfer.submitted'
+  | 'transfer.confirmed'
+  | 'transfer.failed';
+
+export interface StellarTelemetryEvent {
+  eventName: StellarTelemetryEventType;
+  timestamp: number;
+  providerId: string;
+  status: 'success' | 'failed' | 'pending';
+  latencyMs?: number;
+  amount?: string;
+  feeUsd?: number;
+  slippage?: number;
+  transferId?: string;
+  error?: string;
+  metadata?: Record<string, unknown>;
+}


### PR DESCRIPTION
Adds telemetry collection for the Stellar bridge provider under src/telemetry/providers/stellar/. Events are normalized into the project's existing metric shape and stored via the established storage mechanism. Scope is intentionally minimal — covers core bridge lifecycle events (quote, submit, confirm/fail) without introducing new infrastructure.