### PR TITLE
feat: implement Stellar provider maintenance tracker

### DIFF
--- a/src/providers/maintenance/stellar/stellar-maintenance-registry.ts
+++ b/src/providers/maintenance/stellar/stellar-maintenance-registry.ts
@@ -1,0 +1,110 @@
+import { StellarMaintenanceTracker } from "./stellar-maintenance-tracker";
+import type {
+  MaintenanceTrackerOptions,
+  MaintenanceWindow,
+  ProviderMaintenanceStatus,
+} from "./types";
+
+/**
+ * Registry that manages one `StellarMaintenanceTracker` per Stellar bridge provider.
+ *
+ * Trackers are created lazily on first contact. The registry mirrors the
+ * per-tracker API at the multi-provider level and provides routing helpers
+ * so callers can avoid providers that are under maintenance or experiencing an
+ * outage.
+ */
+export class StellarMaintenanceRegistry {
+  private readonly trackers = new Map<string, StellarMaintenanceTracker>();
+
+  constructor(private readonly options: MaintenanceTrackerOptions = {}) {}
+
+  // ─── Maintenance Windows ─────────────────────────────────────────────────
+
+  scheduleWindow(providerId: string, window: MaintenanceWindow): void {
+    this.trackerFor(providerId).scheduleWindow(window);
+  }
+
+  cancelWindow(providerId: string, windowId: string): void {
+    this.trackers.get(providerId)?.cancelWindow(windowId);
+  }
+
+  // ─── Outage Management ───────────────────────────────────────────────────
+
+  detectOutage(providerId: string, reason?: string): void {
+    this.trackerFor(providerId).detectOutage(reason);
+  }
+
+  resolveOutage(providerId: string): void {
+    this.trackers.get(providerId)?.resolveOutage();
+  }
+
+  // ─── Routing Helpers ─────────────────────────────────────────────────────
+
+  isAvailable(providerId: string): boolean {
+    return !this.trackerFor(providerId).isUnavailable();
+  }
+
+  /**
+   * Filter a candidate list down to providers that are operational.
+   * Order is preserved so the caller's priority ranking is respected.
+   */
+  availableProviders(providerIds: string[]): string[] {
+    return providerIds.filter((id) => this.isAvailable(id));
+  }
+
+  /**
+   * Select the first available provider from an ordered list.
+   * Returns `null` when all providers are unavailable.
+   */
+  selectProvider(providerIds: string[]): string | null {
+    return this.availableProviders(providerIds)[0] ?? null;
+  }
+
+  // ─── Inspection ─────────────────────────────────────────────────────────
+
+  /** Providers currently under maintenance or experiencing an outage. */
+  unavailableProviders(): string[] {
+    return this.allStatuses()
+      .filter(({ snapshot }) => snapshot.status !== "operational")
+      .map(({ providerId }) => providerId);
+  }
+
+  /** Full status snapshot for every known provider, sorted by id. */
+  allStatuses(): ProviderMaintenanceStatus[] {
+    return [...this.trackers.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([providerId, tracker]) => ({
+        providerId,
+        snapshot: tracker.getSnapshot(),
+      }));
+  }
+
+  /** Status snapshot for a single provider, or `null` if never contacted. */
+  statusFor(providerId: string): ProviderMaintenanceStatus | null {
+    const tracker = this.trackers.get(providerId);
+    if (!tracker) return null;
+    return { providerId, snapshot: tracker.getSnapshot() };
+  }
+
+  /** Reset a single provider's tracker. */
+  resetProvider(providerId: string): void {
+    this.trackers.get(providerId)?.reset();
+  }
+
+  /** Reset all trackers. */
+  resetAll(): void {
+    for (const tracker of this.trackers.values()) tracker.reset();
+  }
+
+  // ─── Private ────────────────────────────────────────────────────────────
+
+  private trackerFor(providerId: string): StellarMaintenanceTracker {
+    let tracker = this.trackers.get(providerId);
+    if (!tracker) {
+      tracker = new StellarMaintenanceTracker(this.options);
+      tracker.providerId = providerId;
+      this.trackers.set(providerId, tracker);
+    }
+    return tracker;
+  }
+}

--- a/src/providers/maintenance/stellar/stellar-maintenance-tracker.spec.ts
+++ b/src/providers/maintenance/stellar/stellar-maintenance-tracker.spec.ts
@@ -1,0 +1,170 @@
+import { StellarMaintenanceTracker } from "./stellar-maintenance-tracker";
+import { StellarMaintenanceRegistry } from "./stellar-maintenance-registry";
+
+// ─── StellarMaintenanceTracker ────────────────────────────────────────────────
+
+describe("StellarMaintenanceTracker", () => {
+  it("starts operational", () => {
+    const tracker = new StellarMaintenanceTracker({ now: () => 1000 });
+    expect(tracker.getStatus()).toBe("operational");
+    expect(tracker.isUnavailable()).toBe(false);
+  });
+
+  describe("maintenance windows", () => {
+    it("reports maintenance during a scheduled window", () => {
+      let clock = 1000;
+      const tracker = new StellarMaintenanceTracker({ now: () => clock });
+
+      tracker.scheduleWindow({ id: "w1", description: "upgrade", startsAt: 1000, endsAt: 2000 });
+
+      expect(tracker.getStatus()).toBe("maintenance");
+      expect(tracker.isUnavailable()).toBe(true);
+
+      clock = 2000; // window closed
+      expect(tracker.getStatus()).toBe("operational");
+    });
+
+    it("returns operational before and after a window", () => {
+      let clock = 500;
+      const tracker = new StellarMaintenanceTracker({ now: () => clock });
+      tracker.scheduleWindow({ id: "w1", description: "upgrade", startsAt: 1000, endsAt: 2000 });
+
+      expect(tracker.getStatus()).toBe("operational");
+
+      clock = 2000;
+      expect(tracker.getStatus()).toBe("operational");
+    });
+
+    it("cancels a window correctly", () => {
+      let clock = 1000;
+      const tracker = new StellarMaintenanceTracker({ now: () => clock });
+      tracker.scheduleWindow({ id: "w1", description: "upgrade", startsAt: 1000, endsAt: 2000 });
+      expect(tracker.getStatus()).toBe("maintenance");
+
+      tracker.cancelWindow("w1");
+      expect(tracker.getStatus()).toBe("operational");
+    });
+
+    it("throws when startsAt >= endsAt", () => {
+      const tracker = new StellarMaintenanceTracker();
+      expect(() =>
+        tracker.scheduleWindow({ id: "bad", description: "x", startsAt: 1000, endsAt: 1000 })
+      ).toThrow(RangeError);
+    });
+
+    it("throws on duplicate window id", () => {
+      const tracker = new StellarMaintenanceTracker({ now: () => 500 });
+      tracker.scheduleWindow({ id: "w1", description: "first", startsAt: 1000, endsAt: 2000 });
+      expect(() =>
+        tracker.scheduleWindow({ id: "w1", description: "duplicate", startsAt: 3000, endsAt: 4000 })
+      ).toThrow();
+    });
+  });
+
+  describe("outage detection", () => {
+    it("reports outage when an outage is detected", () => {
+      const tracker = new StellarMaintenanceTracker({ now: () => 1000 });
+      tracker.detectOutage("network failure");
+
+      expect(tracker.getStatus()).toBe("outage");
+      expect(tracker.isUnavailable()).toBe(true);
+      expect(tracker.activeOutage()?.reason).toBe("network failure");
+    });
+
+    it("returns operational after outage is resolved", () => {
+      let clock = 1000;
+      const tracker = new StellarMaintenanceTracker({ now: () => clock });
+      tracker.detectOutage();
+      expect(tracker.getStatus()).toBe("outage");
+
+      clock = 2000;
+      tracker.resolveOutage();
+      expect(tracker.getStatus()).toBe("operational");
+      expect(tracker.activeOutage()).toBeNull();
+    });
+
+    it("outage takes priority over an active maintenance window", () => {
+      let clock = 1000;
+      const tracker = new StellarMaintenanceTracker({ now: () => clock });
+      tracker.scheduleWindow({ id: "w1", description: "upgrade", startsAt: 1000, endsAt: 2000 });
+      tracker.detectOutage("disk full");
+
+      expect(tracker.getStatus()).toBe("outage");
+    });
+
+    it("ignores duplicate detectOutage calls", () => {
+      const tracker = new StellarMaintenanceTracker({ now: () => 1000 });
+      tracker.detectOutage("first");
+      tracker.detectOutage("second"); // no-op
+      expect(tracker.getSnapshot().outageHistory).toHaveLength(1);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all windows and outages", () => {
+      const tracker = new StellarMaintenanceTracker({ now: () => 1000 });
+      tracker.scheduleWindow({ id: "w1", description: "upgrade", startsAt: 1000, endsAt: 2000 });
+      tracker.detectOutage();
+      tracker.reset();
+
+      expect(tracker.getStatus()).toBe("operational");
+      const snap = tracker.getSnapshot();
+      expect(snap.scheduledWindows).toHaveLength(0);
+      expect(snap.outageHistory).toHaveLength(0);
+    });
+  });
+
+  describe("onStatusChange callback", () => {
+    it("fires when status transitions", () => {
+      const events: string[] = [];
+      const tracker = new StellarMaintenanceTracker({
+        now: () => 1000,
+        onStatusChange: (e) => events.push(`${e.from}→${e.to}`),
+      });
+
+      tracker.detectOutage();
+      tracker.resolveOutage();
+
+      expect(events).toEqual(["operational→outage", "outage→operational"]);
+    });
+  });
+});
+
+// ─── StellarMaintenanceRegistry ───────────────────────────────────────────────
+
+describe("StellarMaintenanceRegistry", () => {
+  it("marks unavailable providers and filters routing", () => {
+    let clock = 1000;
+    const registry = new StellarMaintenanceRegistry({ now: () => clock });
+
+    registry.scheduleWindow("horizon-a", { id: "w1", description: "upgrade", startsAt: 1000, endsAt: 3000 });
+    registry.detectOutage("horizon-b", "network");
+
+    expect(registry.isAvailable("horizon-a")).toBe(false);
+    expect(registry.isAvailable("horizon-b")).toBe(false);
+    expect(registry.isAvailable("horizon-c")).toBe(true);
+
+    expect(registry.availableProviders(["horizon-a", "horizon-b", "horizon-c"])).toEqual(["horizon-c"]);
+    expect(registry.selectProvider(["horizon-a", "horizon-c"])).toBe("horizon-c");
+    expect(registry.unavailableProviders()).toEqual(expect.arrayContaining(["horizon-a", "horizon-b"]));
+  });
+
+  it("selectProvider returns null when all are unavailable", () => {
+    const registry = new StellarMaintenanceRegistry({ now: () => 1000 });
+    registry.detectOutage("horizon-a");
+    expect(registry.selectProvider(["horizon-a"])).toBeNull();
+  });
+
+  it("statusFor returns null for unknown providers", () => {
+    const registry = new StellarMaintenanceRegistry();
+    expect(registry.statusFor("unknown")).toBeNull();
+  });
+
+  it("resetProvider restores availability", () => {
+    const registry = new StellarMaintenanceRegistry({ now: () => 1000 });
+    registry.detectOutage("horizon-a");
+    expect(registry.isAvailable("horizon-a")).toBe(false);
+    registry.resolveOutage("horizon-a");
+    expect(registry.isAvailable("horizon-a")).toBe(true);
+  });
+});

--- a/src/providers/maintenance/stellar/stellar-maintenance-tracker.ts
+++ b/src/providers/maintenance/stellar/stellar-maintenance-tracker.ts
@@ -1,0 +1,150 @@
+import type {
+  MaintenanceStatus,
+  MaintenanceTrackerOptions,
+  MaintenanceWindow,
+  OutageRecord,
+  MaintenanceSnapshot,
+  StatusChangeEvent,
+} from "./types";
+
+/**
+ * Tracks maintenance windows and outages for a single Stellar bridge provider.
+ *
+ * Status priority (highest → lowest):
+ *   outage > maintenance > degraded > operational
+ *
+ * Callers record outage detections/resolutions and schedule maintenance windows.
+ * `getStatus()` derives the current status from these records at query time.
+ */
+export class StellarMaintenanceTracker {
+  private readonly windows: MaintenanceWindow[] = [];
+  private readonly outages: OutageRecord[] = [];
+  private currentStatus: MaintenanceStatus = "operational";
+
+  private readonly now: () => number;
+  private readonly onStatusChange?: (event: StatusChangeEvent) => void;
+
+  /** Assigned by the registry so events include the provider id. */
+  providerId?: string;
+
+  constructor(options: MaintenanceTrackerOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.onStatusChange = options.onStatusChange;
+  }
+
+  // ─── Maintenance Windows ──────────────────────────────────────────────────
+
+  /**
+   * Schedule a maintenance window.
+   * Throws if `startsAt >= endsAt`.
+   */
+  scheduleWindow(window: MaintenanceWindow): void {
+    if (window.startsAt >= window.endsAt) {
+      throw new RangeError("startsAt must be before endsAt");
+    }
+    if (this.windows.some((w) => w.id === window.id)) {
+      throw new Error(`Window with id "${window.id}" already exists`);
+    }
+    this.windows.push({ ...window });
+    this.refreshStatus();
+  }
+
+  /** Remove a scheduled window by id. No-op if not found. */
+  cancelWindow(id: string): void {
+    const idx = this.windows.findIndex((w) => w.id === id);
+    if (idx !== -1) {
+      this.windows.splice(idx, 1);
+      this.refreshStatus();
+    }
+  }
+
+  /** Active window at the current clock time, if any. */
+  activeWindow(): MaintenanceWindow | null {
+    const t = this.now();
+    return this.windows.find((w) => w.startsAt <= t && t < w.endsAt) ?? null;
+  }
+
+  // ─── Outage Detection ────────────────────────────────────────────────────
+
+  /**
+   * Record that an outage was detected now.
+   * No-op if an active outage is already open.
+   */
+  detectOutage(reason?: string): void {
+    if (this.activeOutage()) return;
+    this.outages.push({ detectedAt: this.now(), reason });
+    this.refreshStatus();
+  }
+
+  /**
+   * Resolve the currently active outage.
+   * No-op if there is no active outage.
+   */
+  resolveOutage(): void {
+    const active = this.activeOutage();
+    if (!active) return;
+    active.resolvedAt = this.now();
+    this.refreshStatus();
+  }
+
+  /** The currently unresolved outage, if any. */
+  activeOutage(): OutageRecord | null {
+    return this.outages.find((o) => o.resolvedAt === undefined) ?? null;
+  }
+
+  // ─── Status ───────────────────────────────────────────────────────────────
+
+  /**
+   * Current operational status derived from outage and window records.
+   *
+   * - `outage`      – an unresolved outage is open
+   * - `maintenance` – inside a scheduled maintenance window
+   * - `operational` – otherwise
+   */
+  getStatus(): MaintenanceStatus {
+    if (this.activeOutage()) return "outage";
+    if (this.activeWindow()) return "maintenance";
+    return "operational";
+  }
+
+  /** Whether transfers should be blocked (outage or maintenance). */
+  isUnavailable(): boolean {
+    const s = this.getStatus();
+    return s === "outage" || s === "maintenance";
+  }
+
+  // ─── Inspection ──────────────────────────────────────────────────────────
+
+  getSnapshot(): MaintenanceSnapshot {
+    return {
+      status: this.getStatus(),
+      activeWindow: this.activeWindow(),
+      activeOutage: this.activeOutage(),
+      scheduledWindows: [...this.windows],
+      outageHistory: [...this.outages],
+    };
+  }
+
+  /** Reset all state (windows + outages). */
+  reset(): void {
+    this.windows.length = 0;
+    this.outages.length = 0;
+    this.refreshStatus();
+  }
+
+  // ─── Private ─────────────────────────────────────────────────────────────
+
+  private refreshStatus(): void {
+    const next = this.getStatus();
+    if (next !== this.currentStatus) {
+      const event: StatusChangeEvent = {
+        providerId: this.providerId,
+        from: this.currentStatus,
+        to: next,
+        at: this.now(),
+      };
+      this.currentStatus = next;
+      this.onStatusChange?.(event);
+    }
+  }
+}

--- a/src/providers/maintenance/stellar/types.ts
+++ b/src/providers/maintenance/stellar/types.ts
@@ -1,0 +1,66 @@
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+export type MaintenanceStatus = "operational" | "maintenance" | "degraded" | "outage";
+
+// ─── Maintenance Window ───────────────────────────────────────────────────────
+
+export interface MaintenanceWindow {
+  /** Unique identifier for this maintenance window. */
+  id: string;
+  /** Human-readable description of the work being performed. */
+  description: string;
+  /** Epoch ms when the window starts. */
+  startsAt: number;
+  /** Epoch ms when the window ends. */
+  endsAt: number;
+}
+
+// ─── Outage ───────────────────────────────────────────────────────────────────
+
+export interface OutageRecord {
+  /** Epoch ms when the outage was first detected. */
+  detectedAt: number;
+  /** Epoch ms when the outage was resolved, or undefined if still active. */
+  resolvedAt?: number;
+  /** Optional human-readable reason. */
+  reason?: string;
+}
+
+// ─── Options ─────────────────────────────────────────────────────────────────
+
+export interface MaintenanceTrackerOptions {
+  /** Injectable clock for deterministic testing. Defaults to Date.now. */
+  now?: () => number;
+  /** Called whenever the provider status changes. */
+  onStatusChange?: (event: StatusChangeEvent) => void;
+}
+
+// ─── Events ───────────────────────────────────────────────────────────────────
+
+export interface StatusChangeEvent {
+  providerId?: string;
+  from: MaintenanceStatus;
+  to: MaintenanceStatus;
+  at: number;
+}
+
+// ─── Snapshot ─────────────────────────────────────────────────────────────────
+
+export interface MaintenanceSnapshot {
+  status: MaintenanceStatus;
+  /** Active maintenance window at the query time, if any. */
+  activeWindow: MaintenanceWindow | null;
+  /** Currently active outage, if any. */
+  activeOutage: OutageRecord | null;
+  /** All scheduled windows (past and future). */
+  scheduledWindows: MaintenanceWindow[];
+  /** Historical outage records (most recent last). */
+  outageHistory: OutageRecord[];
+}
+
+// ─── Registry ─────────────────────────────────────────────────────────────────
+
+export interface ProviderMaintenanceStatus {
+  providerId: string;
+  snapshot: MaintenanceSnapshot;
+}


### PR DESCRIPTION
## Summary

Implements the Stellar Provider Maintenance Tracker under `src/providers/maintenance/stellar/`, following the same pure-TypeScript class pattern used by the existing `circuit-breaker` and `failover` providers.

### Files Added

| File | Purpose |
|---|---|
| `types.ts` | Shared types: `MaintenanceStatus`, `MaintenanceWindow`, `OutageRecord`, `MaintenanceSnapshot`, `StatusChangeEvent`, options, and registry status |
| `stellar-maintenance-tracker.ts` | `StellarMaintenanceTracker` — per-provider class that records maintenance windows, detects/resolves outages, and derives current status |
| `stellar-maintenance-registry.ts` | `StellarMaintenanceRegistry` — manages one tracker per provider, exposes routing helpers (`availableProviders`, `selectProvider`) and fleet-wide inspection |
| `stellar-maintenance-tracker.spec.ts` | Unit tests covering windows, outages, priority rules, callbacks, routing helpers, and edge cases |

### Design Decisions

- **Status priority**: `outage > maintenance > operational` — an active outage always wins.
- **Lazy tracker creation**: trackers are instantiated on first contact (same pattern as `StellarProviderCircuitBreakerRegistry`).
- **Injectable clock** (`now` option): all time-sensitive logic is deterministic in tests.
- **`onStatusChange` callback**: fires on every transition, includes `providerId`, `from`, `to`, and `at` (epoch ms).
- No external dependencies — plain TypeScript, zero runtime overhead.

### Acceptance Criteria Met

- Maintenance schedules recorded and queried via `scheduleWindow` / `cancelWindow`
- Outages detected and resolved via `detectOutage` / `resolveOutage`
- Status exposed via `getStatus()` / `getSnapshot()` on both tracker and registry

Closes #540