### PR TITLE
feat(reputation): implement Stellar provider reputation tracker (#532)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule } from './config/config.module';
 import { ConfigService } from './config/config.service';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { StellarReputationModule } from './reputation/providers/stellar/stellar-reputation.module';
 import { TransactionsModule } from './transactions/transactions.module';
 import { BenchmarkModule } from './benchmark/benchmark.module';
 import { AnalyticsModule } from './analytics/analytics.module';
@@ -50,6 +51,7 @@ import { RecommendationV2Module } from './api/routes/v2/recommendation.module';
     AnalyticsModule,
     TokenMetadataModule,
     VersionModule,
+       StellarReputationModule,
     WalletModule,
     SorobanContractModule,
     StellarTimeoutModule,

--- a/apps/api/src/reputation/providers/stellar/stellar-reputation.calculator.ts
+++ b/apps/api/src/reputation/providers/stellar/stellar-reputation.calculator.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { ProviderHistoryEntry, ReputationScore } from './types';
+
+@Injectable()
+export class StellarReputationCalculator {
+  /**
+   * Weights must sum to 1.0
+   */
+  private readonly WEIGHTS = {
+    reliability: 0.40,
+    performance: 0.25,
+    feeAccuracy: 0.20,
+    slippageControl: 0.15,
+  };
+
+  private readonly RESPONSE_TIME_BASELINE_MS = 2000; // 2s = score of 50
+
+  calculate(
+    providerId: string,
+    history: ProviderHistoryEntry[]
+  ): ReputationScore {
+    if (history.length === 0) {
+      return this.zeroScore(providerId);
+    }
+
+    const reliability = this.calcReliability(history);
+    const performance = this.calcPerformance(history);
+    const feeAccuracy = this.calcFeeAccuracy(history);
+    const slippageControl = this.calcSlippageControl(history);
+
+    const overall =
+      reliability  * this.WEIGHTS.reliability +
+      performance  * this.WEIGHTS.performance +
+      feeAccuracy  * this.WEIGHTS.feeAccuracy +
+      slippageControl * this.WEIGHTS.slippageControl;
+
+    return {
+      providerId,
+      overall:         Math.round(overall),
+      reliability:     Math.round(reliability),
+      performance:     Math.round(performance),
+      feeAccuracy:     Math.round(feeAccuracy),
+      slippageControl: Math.round(slippageControl),
+      calculatedAt:    new Date(),
+    };
+  }
+
+  private calcReliability(history: ProviderHistoryEntry[]): number {
+    const successRate = history.filter((e) => e.success).length / history.length;
+    return successRate * 100;
+  }
+
+  private calcPerformance(history: ProviderHistoryEntry[]): number {
+    const avgMs =
+      history.reduce((sum, e) => sum + e.responseTimeMs, 0) / history.length;
+
+    // Score 100 at 0ms, 50 at baseline, approaches 0 above 4× baseline
+    const score = 100 - (avgMs / this.RESPONSE_TIME_BASELINE_MS) * 50;
+    return Math.max(0, Math.min(100, score));
+  }
+
+  private calcFeeAccuracy(history: ProviderHistoryEntry[]): number {
+    const avg =
+      history.reduce((sum, e) => sum + e.feeAccuracy, 0) / history.length;
+    return avg * 100;
+  }
+
+  private calcSlippageControl(history: ProviderHistoryEntry[]): number {
+    // Lower slippage = higher score; 0% slippage = 100, 5%+ slippage = 0
+    const avgSlippage =
+      history.reduce((sum, e) => sum + e.slippageActual, 0) / history.length;
+    return Math.max(0, 100 - avgSlippage * 20);
+  }
+
+  private zeroScore(providerId: string): ReputationScore {
+    return {
+      providerId,
+      overall: 0,
+      reliability: 0,
+      performance: 0,
+      feeAccuracy: 0,
+      slippageControl: 0,
+      calculatedAt: new Date(),
+    };
+  }
+}

--- a/apps/api/src/reputation/providers/stellar/stellar-reputation.module.ts
+++ b/apps/api/src/reputation/providers/stellar/stellar-reputation.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { StellarReputationStore }      from './stellar-reputation.store';
+import { StellarReputationCalculator } from './stellar-reputation.calculator';
+import { StellarReputationReporter }   from './stellar-reputation.reporter';
+import { StellarReputationTracker }    from './stellar-reputation.tracker';
+
+@Module({
+  providers: [
+    StellarReputationStore,
+    StellarReputationCalculator,
+    StellarReputationReporter,
+    StellarReputationTracker,
+  ],
+  exports: [StellarReputationTracker],
+})
+export class StellarReputationModule {}

--- a/apps/api/src/reputation/providers/stellar/stellar-reputation.reporter.ts
+++ b/apps/api/src/reputation/providers/stellar/stellar-reputation.reporter.ts
@@ -1,0 +1,105 @@
+import { Injectable } from '@nestjs/common';
+import { ProviderHistoryEntry, TrendReport } from './types';
+import { StellarReputationCalculator } from './stellar-reputation.calculator';
+
+@Injectable()
+export class StellarReputationReporter {
+  constructor(private readonly calculator: StellarReputationCalculator) {}
+
+  generate(
+    providerId: string,
+    allHistory: ProviderHistoryEntry[],
+    period: TrendReport['period'] = 'weekly'
+  ): TrendReport {
+    const buckets = this.bucketByPeriod(allHistory, period);
+
+    const dataPoints = buckets.map(({ date, entries }) => {
+      const score = this.calculator.calculate(providerId, entries);
+      const successRate =
+        entries.length > 0
+          ? entries.filter((e) => e.success).length / entries.length
+          : 0;
+      const avgResponseTimeMs =
+        entries.length > 0
+          ? entries.reduce((s, e) => s + e.responseTimeMs, 0) / entries.length
+          : 0;
+
+      return {
+        date,
+        score: score.overall,
+        successRate: Math.round(successRate * 100) / 100,
+        avgResponseTimeMs: Math.round(avgResponseTimeMs),
+      };
+    });
+
+    const trend = this.detectTrend(dataPoints.map((d) => d.score));
+    const percentageChange = this.calcPercentageChange(
+      dataPoints.map((d) => d.score)
+    );
+
+    return {
+      providerId,
+      period,
+      dataPoints,
+      trend,
+      percentageChange,
+      generatedAt: new Date(),
+    };
+  }
+
+  private bucketByPeriod(
+    history: ProviderHistoryEntry[],
+    period: TrendReport['period']
+  ): { date: Date; entries: ProviderHistoryEntry[] }[] {
+    const msPerBucket =
+      period === 'daily'
+        ? 86_400_000
+        : period === 'weekly'
+        ? 7 * 86_400_000
+        : 30 * 86_400_000;
+
+    if (history.length === 0) return [];
+
+    const sorted = [...history].sort(
+      (a, b) => a.timestamp.getTime() - b.timestamp.getTime()
+    );
+    const start = sorted[0].timestamp.getTime();
+    const end = Date.now();
+    const buckets: { date: Date; entries: ProviderHistoryEntry[] }[] = [];
+
+    for (let t = start; t <= end; t += msPerBucket) {
+      const bucketStart = t;
+      const bucketEnd = t + msPerBucket;
+      buckets.push({
+        date: new Date(bucketStart),
+        entries: sorted.filter(
+          (e) =>
+            e.timestamp.getTime() >= bucketStart &&
+            e.timestamp.getTime() < bucketEnd
+        ),
+      });
+    }
+
+    return buckets;
+  }
+
+  private detectTrend(scores: number[]): TrendReport['trend'] {
+    if (scores.length < 2) return 'stable';
+    const first = scores.slice(0, Math.ceil(scores.length / 2));
+    const last  = scores.slice(Math.floor(scores.length / 2));
+    const avgFirst = first.reduce((a, b) => a + b, 0) / first.length;
+    const avgLast  = last.reduce((a, b) => a + b, 0)  / last.length;
+    const delta = avgLast - avgFirst;
+    if (delta > 3)  return 'improving';
+    if (delta < -3) return 'degrading';
+    return 'stable';
+  }
+
+  private calcPercentageChange(scores: number[]): number {
+    if (scores.length < 2) return 0;
+    const first = scores[0];
+    const last  = scores[scores.length - 1];
+    if (first === 0) return 0;
+    return Math.round(((last - first) / first) * 100 * 100) / 100;
+  }
+}

--- a/apps/api/src/reputation/providers/stellar/stellar-reputation.store.ts
+++ b/apps/api/src/reputation/providers/stellar/stellar-reputation.store.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { ProviderRecord, ProviderHistoryEntry } from './types';
+
+@Injectable()
+export class StellarReputationStore {
+  // In production replace with a DB/Redis-backed store
+  private readonly store = new Map<string, ProviderRecord>();
+
+  getOrCreate(providerId: string): ProviderRecord {
+    if (!this.store.has(providerId)) {
+      this.store.set(providerId, {
+        providerId,
+        history: [],
+        currentScore: null,
+        lastUpdated: new Date(),
+      });
+    }
+    return this.store.get(providerId)!;
+  }
+
+  appendEntry(providerId: string, entry: ProviderHistoryEntry): void {
+    const record = this.getOrCreate(providerId);
+    record.history.push(entry);
+    record.lastUpdated = new Date();
+  }
+
+  getHistory(
+    providerId: string,
+    since?: Date
+  ): ProviderHistoryEntry[] {
+    const record = this.getOrCreate(providerId);
+    if (!since) return record.history;
+    return record.history.filter((e) => e.timestamp >= since);
+  }
+
+  setScore(providerId: string, score: import('./types').ReputationScore): void {
+    const record = this.getOrCreate(providerId);
+    record.currentScore = score;
+  }
+
+  getScore(providerId: string) {
+    return this.getOrCreate(providerId).currentScore;
+  }
+
+  getAllProviderIds(): string[] {
+    return Array.from(this.store.keys());
+  }
+}

--- a/apps/api/src/reputation/providers/stellar/stellar-reputation.tracker.ts
+++ b/apps/api/src/reputation/providers/stellar/stellar-reputation.tracker.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { StellarReputationStore }      from './stellar-reputation.store';
+import { StellarReputationCalculator } from './stellar-reputation.calculator';
+import { StellarReputationReporter }   from './stellar-reputation.reporter';
+import { ProviderHistoryEntry, ReputationScore, TrendReport } from './types';
+
+@Injectable()
+export class StellarReputationTracker {
+  constructor(
+    private readonly store:      StellarReputationStore,
+    private readonly calculator: StellarReputationCalculator,
+    private readonly reporter:   StellarReputationReporter,
+  ) {}
+
+  /**
+   * Record a provider interaction and refresh their score.
+   */
+  track(providerId: string, entry: ProviderHistoryEntry): ReputationScore {
+    this.store.appendEntry(providerId, entry);
+
+    const history = this.store.getHistory(providerId);
+    const score   = this.calculator.calculate(providerId, history);
+    this.store.setScore(providerId, score);
+
+    return score;
+  }
+
+  /**
+   * Get the latest cached reputation score for a provider.
+   */
+  getScore(providerId: string): ReputationScore | null {
+    return this.store.getScore(providerId);
+  }
+
+  /**
+   * Get reputation scores for all tracked providers.
+   */
+  getAllScores(): ReputationScore[] {
+    return this.store
+      .getAllProviderIds()
+      .map((id) => this.store.getScore(id))
+      .filter((s): s is ReputationScore => s !== null);
+  }
+
+  /**
+   * Generate a trend report for a provider.
+   */
+  getTrendReport(
+    providerId: string,
+    period: TrendReport['period'] = 'weekly'
+  ): TrendReport {
+    const history = this.store.getHistory(providerId);
+    return this.reporter.generate(providerId, history, period);
+  }
+}

--- a/apps/api/src/reputation/providers/stellar/types.ts
+++ b/apps/api/src/reputation/providers/stellar/types.ts
@@ -1,0 +1,40 @@
+export interface ProviderHistoryEntry {
+  timestamp: Date;
+  responseTimeMs: number;
+  success: boolean;
+  errorCode?: string;
+  transactionVolume: number;
+  feeAccuracy: number;     // 0–1: how close quoted fee was to actual
+  slippageActual: number;  // actual slippage %
+}
+
+export interface ReputationScore {
+  providerId: string;
+  overall: number;          // 0–100
+  reliability: number;      // 0–100 based on success rate
+  performance: number;      // 0–100 based on response time
+  feeAccuracy: number;      // 0–100
+  slippageControl: number;  // 0–100
+  calculatedAt: Date;
+}
+
+export interface TrendReport {
+  providerId: string;
+  period: 'daily' | 'weekly' | 'monthly';
+  dataPoints: {
+    date: Date;
+    score: number;
+    successRate: number;
+    avgResponseTimeMs: number;
+  }[];
+  trend: 'improving' | 'stable' | 'degrading';
+  percentageChange: number;
+  generatedAt: Date;
+}
+
+export interface ProviderRecord {
+  providerId: string;
+  history: ProviderHistoryEntry[];
+  currentScore: ReputationScore | null;
+  lastUpdated: Date;
+}


### PR DESCRIPTION
- Add ProviderHistoryEntry, ReputationScore, TrendReport types
- Add StellarReputationStore for in-memory provider history
- Add StellarReputationCalculator with weighted scoring (reliability 40%, performance 25%, fee accuracy 20%, slippage 15%)
- Add StellarReputationReporter with daily/weekly/monthly trend bucketing
- Add StellarReputationTracker as the public-facing service
- Register all providers in StellarReputationModule (exported)
## Summary
Implements issue #532 — tracks Stellar bridge provider reputation over time,
calculates composite scores, and generates trend reports.

## New Files
| File | Purpose |
|---|---|
| `types.ts` | Shared interfaces for history entries, scores, and reports |
| `stellar-reputation.store.ts` | In-memory store for provider history and scores |
| `stellar-reputation.calculator.ts` | Weighted reputation score calculator |
| `stellar-reputation.reporter.ts` | Trend bucketing and report generation |
| `stellar-reputation.tracker.ts` | Public-facing service (track, getScore, getTrendReport) |
| `stellar-reputation.module.ts` | NestJS module wiring |

## Scoring Model
| Dimension | Weight | Signal |
|---|---|---|
| Reliability | 40% | Success rate |
| Performance | 25% | Response time vs 2s baseline |
| Fee Accuracy | 20% | Quoted vs actual fee delta |
| Slippage Control | 15% | Actual slippage % |

## Acceptance Criteria
- [x] Provider history tracked per interaction via `tracker.track()`
- [x] Reputation scores available via `tracker.getScore()` / `tracker.getAllScores()`
- [x] Trend reports generated via `tracker.getTrendReport(id, 'weekly')`
- [x] Trend direction detected: `improving` / `stable` / `degrading`

## Notes
- Store is in-memory for now — swap `StellarReputationStore` for a
  DB-backed implementation without touching any other class
- Period buckets support `daily`, `weekly`, and `monthly`
closes #532 