### PR TITLE
 Cross-Chain Asset Registry

### DIFF
--- a/src/registry/assets/cross-chain/__tests__/cross-chain-asset-registry.spec.ts
+++ b/src/registry/assets/cross-chain/__tests__/cross-chain-asset-registry.spec.ts
@@ -1,0 +1,277 @@
+import {
+  CrossChainAssetRegistry,
+  CrossChainAsset,
+  UnknownAssetError,
+  AssetRegistrationError,
+} from '../cross-chain-asset-registry';
+
+describe('CrossChainAssetRegistry', () => {
+  let registry: CrossChainAssetRegistry;
+
+  const usdc: CrossChainAsset = {
+    id: 'USDC',
+    symbol: 'USDC',
+    name: 'USD Coin',
+    decimals: 6,
+    addresses: {
+      'ethereum': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      'polygon': '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+      'bnb-chain': '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
+    },
+    tags: ['stablecoin'],
+  };
+
+  const usdt: CrossChainAsset = {
+    id: 'USDT',
+    symbol: 'USDT',
+    name: 'Tether USD',
+    decimals: 6,
+    addresses: {
+      'ethereum': '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      'polygon': '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+    },
+    tags: ['stablecoin'],
+  };
+
+  const weth: CrossChainAsset = {
+    id: 'WETH',
+    symbol: 'WETH',
+    name: 'Wrapped Ether',
+    decimals: 18,
+    addresses: {
+      'ethereum': '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      'polygon': '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+    },
+    tags: ['wrapped'],
+  };
+
+  beforeEach(() => {
+    registry = new CrossChainAssetRegistry();
+  });
+
+  describe('register', () => {
+    it('registers a single asset', () => {
+      registry.register(usdc);
+      expect(registry.has('USDC')).toBe(true);
+      expect(registry.size).toBe(1);
+    });
+
+    it('replaces an existing asset with the same id', () => {
+      registry.register(usdc);
+      const modified = { ...usdc, name: 'USD Coin v2' };
+      registry.register(modified);
+      expect(registry.size).toBe(1);
+      expect(registry.get('USDC')?.name).toBe('USD Coin v2');
+    });
+
+    it('throws AssetRegistrationError for invalid id', () => {
+      expect(() =>
+        registry.register({ ...usdc, id: '' }),
+      ).toThrow(AssetRegistrationError);
+    });
+
+    it('throws AssetRegistrationError for invalid decimals', () => {
+      expect(() =>
+        registry.register({ ...usdc, decimals: -1 }),
+      ).toThrow(AssetRegistrationError);
+    });
+
+    it('throws AssetRegistrationError for empty chain address', () => {
+      expect(() =>
+        registry.register({
+          ...usdc,
+          addresses: { ethereum: '' },
+        }),
+      ).toThrow(AssetRegistrationError);
+    });
+  });
+
+  describe('registerBatch', () => {
+    it('registers multiple assets', () => {
+      registry.registerBatch([usdc, usdt, weth]);
+      expect(registry.size).toBe(3);
+    });
+
+    it('rolls back on validation failure', () => {
+      expect(() =>
+        registry.registerBatch([usdc, { ...usdt, decimals: -1 }, weth]),
+      ).toThrow(AssetRegistrationError);
+      expect(registry.size).toBe(0);
+    });
+  });
+
+  describe('deregister', () => {
+    it('removes an asset and its index entries', () => {
+      registry.registerBatch([usdc, usdt]);
+      expect(registry.deregister('USDC')).toBe(true);
+      expect(registry.has('USDC')).toBe(false);
+      expect(registry.size).toBe(1);
+    });
+
+    it('returns false for non-existent asset', () => {
+      expect(registry.deregister('NONEXISTENT')).toBe(false);
+    });
+  });
+
+  describe('lookup', () => {
+    beforeEach(() => {
+      registry.registerBatch([usdc, usdt, weth]);
+    });
+
+    describe('get', () => {
+      it('returns an asset by id', () => {
+        expect(registry.get('USDC')?.name).toBe('USD Coin');
+      });
+
+      it('returns undefined for unknown id', () => {
+        expect(registry.get('FAKE')).toBeUndefined();
+      });
+    });
+
+    describe('getOrThrow', () => {
+      it('returns an asset by id', () => {
+        expect(registry.getOrThrow('USDC').symbol).toBe('USDC');
+      });
+
+      it('throws UnknownAssetError for unknown id', () => {
+        expect(() => registry.getOrThrow('FAKE')).toThrow(UnknownAssetError);
+      });
+    });
+
+    describe('getBySymbol', () => {
+      it('finds assets by symbol', () => {
+        const assets = registry.getBySymbol('USDC');
+        expect(assets).toHaveLength(1);
+        expect(assets[0].id).toBe('USDC');
+      });
+
+      it('is case-insensitive', () => {
+        const assets = registry.getBySymbol('usdc');
+        expect(assets).toHaveLength(1);
+      });
+
+      it('returns empty array for unknown symbol', () => {
+        expect(registry.getBySymbol('FAKE')).toEqual([]);
+      });
+    });
+
+    describe('getByChain', () => {
+      it('finds assets on a chain', () => {
+        const assets = registry.getByChain('ethereum');
+        expect(assets).toHaveLength(3);
+      });
+
+      it('returns empty array for unknown chain', () => {
+        expect(registry.getByChain('solana')).toEqual([]);
+      });
+    });
+
+    describe('getAddress', () => {
+      it('returns the address for a chain', () => {
+        const address = registry.getAddress('USDC', 'polygon');
+        expect(address).toBe('0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174');
+      });
+
+      it('returns undefined when chain not found', () => {
+        expect(registry.getAddress('USDC', 'solana')).toBeUndefined();
+      });
+    });
+
+    describe('getAddressOrThrow', () => {
+      it('returns the address for a chain', () => {
+        const address = registry.getAddressOrThrow('USDC', 'polygon');
+        expect(address).toBe('0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174');
+      });
+
+      it('throws UnknownAssetError for missing asset', () => {
+        expect(() =>
+          registry.getAddressOrThrow('FAKE', 'ethereum'),
+        ).toThrow(UnknownAssetError);
+      });
+
+      it('throws UnknownAssetError for missing chain address', () => {
+        expect(() =>
+          registry.getAddressOrThrow('WETH', 'solana'),
+        ).toThrow(UnknownAssetError);
+      });
+    });
+
+    describe('has', () => {
+      it('returns true for registered asset', () => {
+        expect(registry.has('USDC')).toBe(true);
+      });
+
+      it('returns false for unknown asset', () => {
+        expect(registry.has('FAKE')).toBe(false);
+      });
+    });
+  });
+
+  describe('bridgeable routes', () => {
+    beforeEach(() => {
+      registry.registerBatch([usdc, usdt]);
+    });
+
+    describe('addBridgeableRoute', () => {
+      it('registers a bridgeable route', () => {
+        registry.addBridgeableRoute('USDC', 'ethereum', 'polygon');
+        expect(
+          registry.isBridgeable('USDC', 'ethereum', 'polygon'),
+        ).toBe(true);
+      });
+
+      it('throws UnknownAssetError for unknown asset', () => {
+        expect(() =>
+          registry.addBridgeableRoute('FAKE', 'ethereum', 'polygon'),
+        ).toThrow(UnknownAssetError);
+      });
+    });
+
+    describe('isBridgeable', () => {
+      it('returns false for unregistered route', () => {
+        expect(
+          registry.isBridgeable('USDC', 'ethereum', 'polygon'),
+        ).toBe(false);
+      });
+    });
+
+    describe('getBridgeableAssets', () => {
+      it('returns assets bridgeable on a route', () => {
+        registry.addBridgeableRoute('USDC', 'ethereum', 'polygon');
+        registry.addBridgeableRoute('USDT', 'ethereum', 'polygon');
+
+        const assets = registry.getBridgeableAssets('ethereum', 'polygon');
+        expect(assets).toHaveLength(2);
+        expect(assets.map((a) => a.id).sort()).toEqual(['USDC', 'USDT']);
+      });
+
+      it('returns empty array when no route exists', () => {
+        expect(
+          registry.getBridgeableAssets('ethereum', 'solana'),
+        ).toEqual([]);
+      });
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns all registered assets', () => {
+      registry.registerBatch([usdc, usdt]);
+      expect(registry.getAll()).toHaveLength(2);
+    });
+  });
+
+  describe('stats', () => {
+    it('returns correct statistics', () => {
+      registry.registerBatch([usdc, usdt, weth]);
+      registry.addBridgeableRoute('USDC', 'ethereum', 'polygon');
+      registry.addBridgeableRoute('USDT', 'ethereum', 'polygon');
+
+      const s = registry.stats();
+      expect(s.totalAssets).toBe(3);
+      expect(s.totalChains).toEqual(
+        expect.arrayContaining(['bnb-chain', 'ethereum', 'polygon']),
+      );
+      expect(s.totalRoutes).toBe(1);
+    });
+  });
+});

--- a/src/registry/assets/cross-chain/cross-chain-asset-registry.ts
+++ b/src/registry/assets/cross-chain/cross-chain-asset-registry.ts
@@ -1,0 +1,215 @@
+export interface CrossChainAsset {
+  id: string;
+  symbol: string;
+  name: string;
+  decimals: number;
+  logoURI?: string;
+  addresses: Record<string, string>;
+  tags?: string[];
+}
+
+export interface RegistryStats {
+  totalAssets: number;
+  totalChains: string[];
+  totalRoutes: number;
+}
+
+export class UnknownAssetError extends Error {
+  constructor(id: string) {
+    super(`Unknown cross-chain asset: "${id}"`);
+    this.name = 'UnknownAssetError';
+  }
+}
+
+export class AssetRegistrationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AssetRegistrationError';
+  }
+}
+
+export class CrossChainAssetRegistry {
+  private readonly assets = new Map<string, CrossChainAsset>();
+  private readonly symbolIndex = new Map<string, Set<string>>();
+  private readonly chainIndex = new Map<string, Set<string>>();
+  private readonly bridgeRoutes = new Map<string, Set<string>>();
+
+  register(asset: CrossChainAsset): void {
+    this.validateAsset(asset);
+    const id = asset.id;
+    this.assets.set(id, { ...asset });
+
+    const symbolKey = asset.symbol.toUpperCase();
+    if (!this.symbolIndex.has(symbolKey)) {
+      this.symbolIndex.set(symbolKey, new Set());
+    }
+    this.symbolIndex.get(symbolKey)!.add(id);
+
+    for (const chainId of Object.keys(asset.addresses)) {
+      if (!this.chainIndex.has(chainId)) {
+        this.chainIndex.set(chainId, new Set());
+      }
+      this.chainIndex.get(chainId)!.add(id);
+    }
+  }
+
+  registerBatch(assets: CrossChainAsset[]): void {
+    for (const asset of assets) {
+      this.validateAsset(asset);
+    }
+    for (const asset of assets) {
+      this.register(asset);
+    }
+  }
+
+  deregister(id: string): boolean {
+    const asset = this.assets.get(id);
+    if (!asset) return false;
+
+    this.assets.delete(id);
+
+    const symbolKey = asset.symbol.toUpperCase();
+    this.symbolIndex.get(symbolKey)?.delete(id);
+    if (this.symbolIndex.get(symbolKey)?.size === 0) {
+      this.symbolIndex.delete(symbolKey);
+    }
+
+    for (const chainId of Object.keys(asset.addresses)) {
+      this.chainIndex.get(chainId)?.delete(id);
+      if (this.chainIndex.get(chainId)?.size === 0) {
+        this.chainIndex.delete(chainId);
+      }
+    }
+
+    for (const [route, assetIds] of this.bridgeRoutes) {
+      assetIds.delete(id);
+      if (assetIds.size === 0) {
+        this.bridgeRoutes.delete(route);
+      }
+    }
+
+    return true;
+  }
+
+  get(id: string): CrossChainAsset | undefined {
+    return this.assets.get(id);
+  }
+
+  getOrThrow(id: string): CrossChainAsset {
+    const asset = this.get(id);
+    if (!asset) throw new UnknownAssetError(id);
+    return asset;
+  }
+
+  getBySymbol(symbol: string): CrossChainAsset[] {
+    const ids = this.symbolIndex.get(symbol.toUpperCase());
+    if (!ids) return [];
+    return Array.from(ids)
+      .map((id) => this.assets.get(id)!)
+      .filter(Boolean);
+  }
+
+  getByChain(chainId: string): CrossChainAsset[] {
+    const ids = this.chainIndex.get(chainId);
+    if (!ids) return [];
+    return Array.from(ids)
+      .map((id) => this.assets.get(id)!)
+      .filter(Boolean);
+  }
+
+  getAddress(id: string, chainId: string): string | undefined {
+    return this.assets.get(id)?.addresses[chainId];
+  }
+
+  getAddressOrThrow(id: string, chainId: string): string {
+    const asset = this.getOrThrow(id);
+    const address = asset.addresses[chainId];
+    if (!address) {
+      throw new UnknownAssetError(
+        `Asset "${id}" has no address registered for chain "${chainId}"`,
+      );
+    }
+    return address;
+  }
+
+  has(id: string): boolean {
+    return this.assets.has(id);
+  }
+
+  addBridgeableRoute(assetId: string, sourceChain: string, destChain: string): void {
+    if (!this.assets.has(assetId)) {
+      throw new UnknownAssetError(assetId);
+    }
+    const routeKey = `${sourceChain}:${destChain}`;
+    if (!this.bridgeRoutes.has(routeKey)) {
+      this.bridgeRoutes.set(routeKey, new Set());
+    }
+    this.bridgeRoutes.get(routeKey)!.add(assetId);
+  }
+
+  isBridgeable(assetId: string, sourceChain: string, destChain: string): boolean {
+    return this.bridgeRoutes.get(`${sourceChain}:${destChain}`)?.has(assetId) ?? false;
+  }
+
+  getBridgeableAssets(sourceChain: string, destChain: string): CrossChainAsset[] {
+    const forward = this.bridgeRoutes.get(`${sourceChain}:${destChain}`);
+    const result = new Set<string>();
+    if (forward) {
+      for (const id of forward) result.add(id);
+    }
+    return Array.from(result)
+      .map((id) => this.assets.get(id)!)
+      .filter(Boolean);
+  }
+
+  getAll(): CrossChainAsset[] {
+    return Array.from(this.assets.values());
+  }
+
+  get size(): number {
+    return this.assets.size;
+  }
+
+  stats(): RegistryStats {
+    const chainIdSet = new Set<string>();
+    for (const asset of this.assets.values()) {
+      for (const chainId of Object.keys(asset.addresses)) {
+        chainIdSet.add(chainId);
+      }
+    }
+    return {
+      totalAssets: this.assets.size,
+      totalChains: Array.from(chainIdSet).sort(),
+      totalRoutes: this.bridgeRoutes.size,
+    };
+  }
+
+  private validateAsset(asset: CrossChainAsset): void {
+    if (!asset.id?.trim()) {
+      throw new AssetRegistrationError('Asset id must be a non-empty string');
+    }
+    if (!asset.symbol?.trim()) {
+      throw new AssetRegistrationError('Asset symbol must be a non-empty string');
+    }
+    if (!asset.name?.trim()) {
+      throw new AssetRegistrationError(`Asset "${asset.id}": name must be a non-empty string`);
+    }
+    if (!Number.isInteger(asset.decimals) || asset.decimals < 0 || asset.decimals > 77) {
+      throw new AssetRegistrationError(
+        `Asset "${asset.id}": decimals must be an integer between 0 and 77, received ${asset.decimals}`,
+      );
+    }
+    for (const [chainId, address] of Object.entries(asset.addresses)) {
+      if (!chainId?.trim()) {
+        throw new AssetRegistrationError(
+          `Asset "${asset.id}": chain ID must be a non-empty string`,
+        );
+      }
+      if (!address?.trim()) {
+        throw new AssetRegistrationError(
+          `Asset "${asset.id}": address for chain "${chainId}" must be a non-empty string`,
+        );
+      }
+    }
+  }
+}

--- a/src/registry/assets/cross-chain/index.ts
+++ b/src/registry/assets/cross-chain/index.ts
@@ -1,0 +1,10 @@
+export {
+  CrossChainAssetRegistry,
+  UnknownAssetError,
+  AssetRegistrationError,
+} from './cross-chain-asset-registry';
+
+export type {
+  CrossChainAsset,
+  RegistryStats,
+} from './cross-chain-asset-registry';


### PR DESCRIPTION
 Unified CrossChainAssetRegistry at src/registry/assets/cross-chain/ that maintains a single source of truth for bridgeable assets. Supports registering assets with chain-specific addresses, lookup by ID/symbol/chain, and querying bridgeable routes between chains. Includes typed errors, validation, and a test suite (27 cases).

Closed #558