### PR TITLE
feat: Stellar asset discovery API

### DIFF
--- a/apps/api/src/api/assets/discovery/stellar/asset-discovery.controller.ts
+++ b/apps/api/src/api/assets/discovery/stellar/asset-discovery.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Query, BadRequestException, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
+import { AssetDiscoveryService } from './asset-discovery.service';
+import { StellarAsset } from './asset-discovery.types';
+
+@ApiTags('Asset Discovery')
+@Controller('assets/discovery/stellar')
+export class AssetDiscoveryController {
+  constructor(private readonly assetDiscoveryService: AssetDiscoveryService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'List supported Stellar assets' })
+  @ApiResponse({ status: 200, description: 'Returns all supported Stellar assets with metadata' })
+  list(): StellarAsset[] {
+    return this.assetDiscoveryService.list();
+  }
+
+  @Get('search')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Search supported Stellar assets' })
+  @ApiQuery({ name: 'q', type: 'string', description: 'Search by symbol, name, or issuer', required: true })
+  @ApiResponse({ status: 200, description: 'Returns matching Stellar assets' })
+  search(@Query('q') query: string): StellarAsset[] {
+    if (!query?.trim()) {
+      throw new BadRequestException('Query parameter "q" is required');
+    }
+    return this.assetDiscoveryService.search(query.trim());
+  }
+}

--- a/apps/api/src/api/assets/discovery/stellar/asset-discovery.module.ts
+++ b/apps/api/src/api/assets/discovery/stellar/asset-discovery.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AssetDiscoveryController } from './asset-discovery.controller';
+import { AssetDiscoveryService } from './asset-discovery.service';
+
+@Module({
+  controllers: [AssetDiscoveryController],
+  providers: [AssetDiscoveryService],
+  exports: [AssetDiscoveryService],
+})
+export class AssetDiscoveryModule {}

--- a/apps/api/src/api/assets/discovery/stellar/asset-discovery.service.ts
+++ b/apps/api/src/api/assets/discovery/stellar/asset-discovery.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { StellarAsset } from './asset-discovery.types';
+
+@Injectable()
+export class AssetDiscoveryService {
+  private readonly assets: StellarAsset[] = [
+    {
+      symbol: 'XLM',
+      name: 'Stellar Lumens',
+      issuer: null,
+      decimals: 7,
+      isNative: true,
+      supportedChains: ['stellar', 'ethereum'],
+      logoUrl: 'https://assets.coingecko.com/coins/images/100/small/Stellar_symbol_black_RGB.png',
+    },
+    {
+      symbol: 'USDC',
+      name: 'USD Coin',
+      issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      decimals: 7,
+      isNative: false,
+      supportedChains: ['stellar', 'ethereum', 'polygon'],
+      logoUrl: 'https://assets.coingecko.com/coins/images/6319/small/usdc.png',
+    },
+    {
+      symbol: 'yXLM',
+      name: 'Yield XLM',
+      issuer: 'GARDNV3Q7YGT4AKSDF25LT32YSCCW4EV22Y2TV3I2PU2MMXJTEDL5T55',
+      decimals: 7,
+      isNative: false,
+      supportedChains: ['stellar', 'ethereum'],
+      logoUrl: null,
+    },
+  ];
+
+  list(): StellarAsset[] {
+    return this.assets;
+  }
+
+  search(query: string): StellarAsset[] {
+    const q = query.toLowerCase();
+    return this.assets.filter(
+      (a) =>
+        a.symbol.toLowerCase().includes(q) ||
+        a.name.toLowerCase().includes(q) ||
+        a.issuer?.toLowerCase().includes(q),
+    );
+  }
+}

--- a/apps/api/src/api/assets/discovery/stellar/asset-discovery.types.ts
+++ b/apps/api/src/api/assets/discovery/stellar/asset-discovery.types.ts
@@ -1,0 +1,9 @@
+export interface StellarAsset {
+  symbol: string;
+  name: string;
+  issuer: string | null;
+  decimals: number;
+  isNative: boolean;
+  supportedChains: string[];
+  logoUrl: string | null;
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -22,6 +22,7 @@ import { Transaction } from './transactions/entities/transaction.entity';
 import { WalletSession } from './wallet/entities/wallet-session.entity';
 import { RecommendationV2Module } from './api/routes/v2/recommendation.module';
 import { IntelligenceHubModule } from './intelligence-hub/stellar/intelligence-hub.module';
+import { AssetDiscoveryModule } from './api/assets/discovery/stellar/asset-discovery.module';
 
 @Module({
   imports: [
@@ -56,6 +57,7 @@ import { IntelligenceHubModule } from './intelligence-hub/stellar/intelligence-h
     StellarTimeoutModule,
     RecommendationV2Module,
     IntelligenceHubModule,
+    AssetDiscoveryModule,
     ThrottlerModule.forRoot([
       {
         ttl: 60000,


### PR DESCRIPTION
closes #549 

## Summary

Implements the Stellar asset discovery API under `src/api/assets/discovery/stellar/`.

## Endpoints

- `GET /assets/discovery/stellar` — lists all supported Stellar assets with metadata
- `GET /assets/discovery/stellar/search?q=` — searches assets by symbol, name, or issuer

## Changes

- `asset-discovery.types.ts` — `StellarAsset` interface
- `asset-discovery.service.ts` — `list()` and `search()` logic
- `asset-discovery.controller.ts` — REST endpoints with Swagger decorators
- `asset-discovery.module.ts` — NestJS module
- `app.module.ts` — registers `AssetDiscoveryModule`

Assets (XLM, USDC, yXLM) are consistent with existing bridge provider and intelligence hub data.

## Verified

- All 5 changed files pass TypeScript diagnostics with zero errors
- Follows existing controller/service/module pattern
- No new dependencies