### PR TITLE
feat: implement Stellar provider ranking engine

### DIFF
--- a/src/ranking/providers/stellar/index.ts
+++ b/src/ranking/providers/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./rankingEngine";

--- a/src/ranking/providers/stellar/rankingEngine.test.ts
+++ b/src/ranking/providers/stellar/rankingEngine.test.ts
@@ -1,0 +1,60 @@
+import { StellarProviderRankingEngine } from "./rankingEngine";
+import { ProviderMetrics } from "./types";
+
+describe("StellarProviderRankingEngine", () => {
+  const engine = new StellarProviderRankingEngine();
+
+  const providers: ProviderMetrics[] = [
+    {
+      providerId: "provider-a",
+      uptime: 0.99,
+      avgLatency: 100,
+      successRate: 0.98,
+      totalVolume: 0.5,
+    },
+    {
+      providerId: "provider-b",
+      uptime: 0.95,
+      avgLatency: 250,
+      successRate: 0.9,
+      totalVolume: 0.2,
+    },
+    {
+      providerId: "provider-c",
+      uptime: 0.8,
+      avgLatency: 500,
+      successRate: 0.7,
+      totalVolume: 0.1,
+    },
+  ];
+
+  it("generates rankings ordered by score", () => {
+    const rankings = engine.rank(providers);
+
+    expect(rankings.map((r) => r.providerId)).toEqual([
+      "provider-a",
+      "provider-b",
+      "provider-c",
+    ]);
+    expect(rankings[0].rank).toBe(1);
+    expect(rankings[2].rank).toBe(3);
+  });
+
+  it("assigns higher score to the better provider", () => {
+    const best = engine.score(providers[0]);
+    const worst = engine.score(providers[2]);
+
+    expect(best).toBeGreaterThan(worst);
+  });
+
+  it("supports ranking filters", () => {
+    const rankings = engine.rank(providers, {
+      minSuccessRate: 0.95,
+      maxLatency: 200,
+    });
+
+    expect(rankings).toHaveLength(1);
+    expect(rankings[0].providerId).toBe("provider-a");
+    expect(rankings[0].rank).toBe(1);
+  });
+});

--- a/src/ranking/providers/stellar/rankingEngine.ts
+++ b/src/ranking/providers/stellar/rankingEngine.ts
@@ -1,0 +1,79 @@
+import {
+  ProviderMetrics,
+  ProviderRanking,
+  RankingFilter,
+  RankingWeights,
+} from "./types";
+
+const DEFAULT_WEIGHTS: RankingWeights = {
+  uptime: 0.3,
+  latency: 0.2,
+  successRate: 0.4,
+  volume: 0.1,
+};
+
+export class StellarProviderRankingEngine {
+  constructor(
+    private readonly weights: RankingWeights = DEFAULT_WEIGHTS
+  ) {}
+
+  score(metrics: ProviderMetrics): number {
+    const latencyScore =
+      metrics.avgLatency > 0
+        ? 1 / metrics.avgLatency
+        : 0;
+
+    return (
+      metrics.uptime * this.weights.uptime +
+      latencyScore * this.weights.latency +
+      metrics.successRate * this.weights.successRate +
+      metrics.totalVolume * this.weights.volume
+    );
+  }
+
+  rank(
+    providers: ProviderMetrics[],
+    filter: RankingFilter = {}
+  ): ProviderRanking[] {
+    return providers
+      .filter((provider) => this.matchesFilter(provider, filter))
+      .map((provider) => ({
+        providerId: provider.providerId,
+        score: this.score(provider),
+        rank: 0,
+      }))
+      .sort((a, b) => b.score - a.score)
+      .map((ranking, index) => ({
+        ...ranking,
+        rank: index + 1,
+      }));
+  }
+
+  private matchesFilter(
+    metrics: ProviderMetrics,
+    filter: RankingFilter
+  ): boolean {
+    if (
+      filter.minUptime !== undefined &&
+      metrics.uptime < filter.minUptime
+    ) {
+      return false;
+    }
+
+    if (
+      filter.minSuccessRate !== undefined &&
+      metrics.successRate < filter.minSuccessRate
+    ) {
+      return false;
+    }
+
+    if (
+      filter.maxLatency !== undefined &&
+      metrics.avgLatency > filter.maxLatency
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/ranking/providers/stellar/types.ts
+++ b/src/ranking/providers/stellar/types.ts
@@ -1,0 +1,26 @@
+export interface ProviderMetrics {
+  providerId: string;
+  uptime: number;
+  avgLatency: number;
+  successRate: number;
+  totalVolume: number;
+}
+
+export interface RankingWeights {
+  uptime: number;
+  latency: number;
+  successRate: number;
+  volume: number;
+}
+
+export interface ProviderRanking {
+  providerId: string;
+  score: number;
+  rank: number;
+}
+
+export interface RankingFilter {
+  minUptime?: number;
+  minSuccessRate?: number;
+  maxLatency?: number;
+}


### PR DESCRIPTION
## 🧠 Overview
Implements a standardized ranking engine for Stellar providers based on operational metrics, resolving the lack of consistent provider comparison scoring.

Closes #556

##  Implementation Scope
`src/ranking/providers/stellar/`

## 🔧 What's Included
- **`types.ts`** — `ProviderMetrics`, `RankingWeights`, `ProviderRanking`, `RankingFilter`
- **`rankingEngine.ts`** — `StellarProviderRankingEngine`:
  - `score()` — weighted score across uptime, latency, success rate, and volume (configurable weights, sensible defaults)
  - `rank()` — applies filters, scores providers, sorts descending, and assigns ranks
  - Filter support: `minUptime`, `minSuccessRate`, `maxLatency`
- **`rankingEngine.test.ts`** — covers ranking generation, score ordering, and filtering
- **`index.ts`** — barrel exports

## 🧪 Testing
Unit tests added in `rankingEngine.test.ts` covering ranked ordering, relative scoring, and filter behavior. _(Tests run in CI — local `node_modules` is not installed in this workspace.)_
