### PR TITLE
feat: implement Route Health History Tracker with tests

### DIFF
--- a/src/history/health/routes/stellar/__tests__/route-health-history.spec.ts
+++ b/src/history/health/routes/stellar/__tests__/route-health-history.spec.ts
@@ -1,0 +1,292 @@
+import {
+  RouteHealthHistoryTracker,
+  type RouteHealthSample,
+} from '../route-health-history';
+
+function sample(overrides: Partial<RouteHealthSample> = {}): RouteHealthSample {
+  return {
+    routeId: 'XLM->USDC',
+    status: 'healthy',
+    availability: 1,
+    latencyMs: 100,
+    recordedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('RouteHealthHistoryTracker', () => {
+  describe('record / getHistory', () => {
+    it('stores health metrics for a route', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample());
+
+      const history = tracker.getHistory('XLM->USDC');
+      expect(history).toHaveLength(1);
+      expect(history[0].status).toBe('healthy');
+      expect(history[0].availability).toBe(1);
+    });
+
+    it('defaults recordedAt to now when omitted', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      const before = Date.now();
+      const snapshot = tracker.record(sample({ recordedAt: undefined }));
+      expect(snapshot.recordedAt.getTime()).toBeGreaterThanOrEqual(before);
+    });
+
+    it('clamps availability into the [0, 1] range', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      expect(tracker.record(sample({ availability: 2 })).availability).toBe(1);
+      expect(tracker.record(sample({ availability: -1 })).availability).toBe(0);
+      expect(tracker.record(sample({ availability: NaN })).availability).toBe(0);
+    });
+
+    it('keeps snapshots ordered chronologically even when inserted out of order', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ recordedAt: new Date('2026-01-03T00:00:00Z') }));
+      tracker.record(sample({ recordedAt: new Date('2026-01-01T00:00:00Z') }));
+      tracker.record(sample({ recordedAt: new Date('2026-01-02T00:00:00Z') }));
+
+      const times = tracker
+        .getHistory('XLM->USDC')
+        .map((s) => s.recordedAt.toISOString());
+      expect(times).toEqual([
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-02T00:00:00.000Z',
+        '2026-01-03T00:00:00.000Z',
+      ]);
+    });
+
+    it('isolates history per route', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ routeId: 'A' }));
+      tracker.record(sample({ routeId: 'B' }));
+      tracker.record(sample({ routeId: 'B' }));
+
+      expect(tracker.getHistory('A')).toHaveLength(1);
+      expect(tracker.getHistory('B')).toHaveLength(2);
+      expect(tracker.getTrackedRoutes().sort()).toEqual(['A', 'B']);
+    });
+  });
+
+  describe('history queries', () => {
+    const build = () => {
+      const tracker = new RouteHealthHistoryTracker();
+      for (let day = 1; day <= 5; day++) {
+        tracker.record(
+          sample({
+            recordedAt: new Date(`2026-01-0${day}T00:00:00Z`),
+          }),
+        );
+      }
+      return tracker;
+    };
+
+    it('filters by date range', () => {
+      const tracker = build();
+      const result = tracker.getHistory('XLM->USDC', {
+        from: new Date('2026-01-02T00:00:00Z'),
+        to: new Date('2026-01-04T00:00:00Z'),
+      });
+      expect(result).toHaveLength(3);
+    });
+
+    it('limits to the most recent N within range', () => {
+      const tracker = build();
+      const result = tracker.getHistory('XLM->USDC', { limit: 2 });
+      expect(result.map((s) => s.recordedAt.toISOString())).toEqual([
+        '2026-01-04T00:00:00.000Z',
+        '2026-01-05T00:00:00.000Z',
+      ]);
+    });
+
+    it('returns latest snapshot', () => {
+      const tracker = build();
+      expect(tracker.getLatest('XLM->USDC')?.recordedAt.toISOString()).toBe(
+        '2026-01-05T00:00:00.000Z',
+      );
+      expect(tracker.getLatest('missing')).toBeNull();
+    });
+
+    it('returns copies so callers cannot mutate stored snapshots', () => {
+      const tracker = build();
+      const history = tracker.getHistory('XLM->USDC');
+      history[0].availability = 0.5;
+      expect(tracker.getHistory('XLM->USDC')[0].availability).toBe(1);
+    });
+  });
+
+  describe('getTrend', () => {
+    it('returns null when there is no history in range', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      expect(tracker.getTrend('missing')).toBeNull();
+    });
+
+    it('aggregates availability, latency and status distribution', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(
+        sample({
+          status: 'healthy',
+          availability: 1,
+          latencyMs: 100,
+          recordedAt: new Date('2026-01-01T00:00:00Z'),
+        }),
+      );
+      tracker.record(
+        sample({
+          status: 'degraded',
+          availability: 0.6,
+          latencyMs: 300,
+          recordedAt: new Date('2026-01-02T00:00:00Z'),
+        }),
+      );
+      tracker.record(
+        sample({
+          status: 'outage',
+          availability: 0,
+          latencyMs: undefined,
+          recordedAt: new Date('2026-01-03T00:00:00Z'),
+        }),
+      );
+
+      const trend = tracker.getTrend('XLM->USDC');
+      expect(trend).not.toBeNull();
+      expect(trend!.sampleCount).toBe(3);
+      expect(trend!.averageAvailability).toBeCloseTo((1 + 0.6 + 0) / 3);
+      expect(trend!.minAvailability).toBe(0);
+      expect(trend!.maxAvailability).toBe(1);
+      // Only two snapshots had latency recorded.
+      expect(trend!.averageLatencyMs).toBeCloseTo(200);
+      expect(trend!.uptimeRatio).toBeCloseTo(1 / 3);
+      expect(trend!.currentStatus).toBe('outage');
+      expect(trend!.statusDistribution).toEqual({
+        healthy: 1,
+        degraded: 1,
+        unhealthy: 0,
+        outage: 1,
+      });
+    });
+
+    it('reports null average latency when no snapshot has latency', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ latencyMs: undefined }));
+      expect(tracker.getTrend('XLM->USDC')!.averageLatencyMs).toBeNull();
+    });
+
+    it('detects an improving availability trend', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      const avails = [0.2, 0.3, 0.9, 1];
+      avails.forEach((availability, i) =>
+        tracker.record(
+          sample({
+            availability,
+            recordedAt: new Date(`2026-01-0${i + 1}T00:00:00Z`),
+          }),
+        ),
+      );
+      expect(tracker.getTrend('XLM->USDC')!.availabilityTrend).toBe('improving');
+    });
+
+    it('detects a declining availability trend', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      const avails = [1, 0.9, 0.3, 0.1];
+      avails.forEach((availability, i) =>
+        tracker.record(
+          sample({
+            availability,
+            recordedAt: new Date(`2026-01-0${i + 1}T00:00:00Z`),
+          }),
+        ),
+      );
+      expect(tracker.getTrend('XLM->USDC')!.availabilityTrend).toBe('declining');
+    });
+
+    it('reports a stable trend for flat availability', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      [1, 1, 1, 1].forEach((availability, i) =>
+        tracker.record(
+          sample({
+            availability,
+            recordedAt: new Date(`2026-01-0${i + 1}T00:00:00Z`),
+          }),
+        ),
+      );
+      expect(tracker.getTrend('XLM->USDC')!.availabilityTrend).toBe('stable');
+    });
+  });
+
+  describe('compareRoutes', () => {
+    const build = () => {
+      const tracker = new RouteHealthHistoryTracker();
+      // Route A: perfect availability.
+      tracker.record(sample({ routeId: 'A', availability: 1, latencyMs: 200 }));
+      tracker.record(sample({ routeId: 'A', availability: 1, latencyMs: 200 }));
+      // Route B: degraded.
+      tracker.record(
+        sample({ routeId: 'B', status: 'degraded', availability: 0.5, latencyMs: 100 }),
+      );
+      // Route C: same availability as A but slower → should rank below A.
+      tracker.record(sample({ routeId: 'C', availability: 1, latencyMs: 500 }));
+      return tracker;
+    };
+
+    it('ranks routes by availability, then uptime, then latency', () => {
+      const tracker = build();
+      const ranked = tracker.compareRoutes();
+      expect(ranked.map((r) => r.routeId)).toEqual(['A', 'C', 'B']);
+      expect(ranked.map((r) => r.rank)).toEqual([1, 2, 3]);
+    });
+
+    it('compares only the requested routes', () => {
+      const tracker = build();
+      const ranked = tracker.compareRoutes(['B', 'C']);
+      expect(ranked.map((r) => r.routeId)).toEqual(['C', 'B']);
+    });
+
+    it('omits routes with no snapshots in range', () => {
+      const tracker = build();
+      const ranked = tracker.compareRoutes(['A', 'unknown']);
+      expect(ranked.map((r) => r.routeId)).toEqual(['A']);
+    });
+  });
+
+  describe('retention and bounds', () => {
+    it('evicts oldest snapshots beyond maxSnapshotsPerRoute', () => {
+      const tracker = new RouteHealthHistoryTracker({ maxSnapshotsPerRoute: 3 });
+      for (let i = 0; i < 5; i++) {
+        tracker.record(
+          sample({ recordedAt: new Date(2026, 0, 1, 0, 0, i) }),
+        );
+      }
+      const history = tracker.getHistory('XLM->USDC');
+      expect(history).toHaveLength(3);
+      expect(history[0].recordedAt.getSeconds()).toBe(2);
+    });
+
+    it('prunes snapshots older than the retention window on write', () => {
+      const tracker = new RouteHealthHistoryTracker({ retentionMs: 60_000 });
+      const now = Date.now();
+      tracker.record(sample({ recordedAt: new Date(now - 120_000) }));
+      tracker.record(sample({ recordedAt: new Date(now) }));
+      expect(tracker.getHistory('XLM->USDC')).toHaveLength(1);
+    });
+  });
+
+  describe('clearing', () => {
+    it('clears a single route', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ routeId: 'A' }));
+      tracker.record(sample({ routeId: 'B' }));
+      expect(tracker.clearRoute('A')).toBe(true);
+      expect(tracker.getHistory('A')).toHaveLength(0);
+      expect(tracker.getHistory('B')).toHaveLength(1);
+    });
+
+    it('clears all routes', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ routeId: 'A' }));
+      tracker.record(sample({ routeId: 'B' }));
+      tracker.clear();
+      expect(tracker.getTrackedRoutes()).toHaveLength(0);
+    });
+  });
+});

--- a/src/history/health/routes/stellar/index.ts
+++ b/src/history/health/routes/stellar/index.ts
@@ -1,0 +1,5 @@
+export * from './route-health-history';
+
+import { RouteHealthHistoryTracker } from './route-health-history';
+
+export const routeHealthHistoryTracker = new RouteHealthHistoryTracker();

--- a/src/history/health/routes/stellar/route-health-history.ts
+++ b/src/history/health/routes/stellar/route-health-history.ts
@@ -1,0 +1,329 @@
+import type { RouteHealthStatus } from '../../../../monitoring/routes/stellar/stellar-route-health-monitor';
+
+/**
+ * A single point-in-time health observation for a Stellar route. These are the
+ * raw records the tracker persists so that trends can be reconstructed later.
+ */
+export interface RouteHealthSnapshot {
+  routeId: string;
+  status: RouteHealthStatus;
+  availability: number;
+  latencyMs?: number;
+  consecutiveFailures?: number;
+  errorMessage?: string;
+  recordedAt: Date;
+}
+
+/**
+ * Input accepted when recording a snapshot. `recordedAt` is optional and
+ * defaults to the current time so callers can simply forward a health state.
+ */
+export interface RouteHealthSample {
+  routeId: string;
+  status: RouteHealthStatus;
+  availability: number;
+  latencyMs?: number;
+  consecutiveFailures?: number;
+  errorMessage?: string;
+  recordedAt?: Date;
+}
+
+export interface RouteHealthHistoryConfig {
+  /** Maximum number of snapshots kept per route. Oldest are evicted first. */
+  maxSnapshotsPerRoute?: number;
+  /** Snapshots older than this (in ms) are pruned on write. 0 disables. */
+  retentionMs?: number;
+}
+
+export interface HistoryQuery {
+  from?: Date;
+  to?: Date;
+  /** When set, only the most recent N (within the range) are returned. */
+  limit?: number;
+}
+
+/**
+ * Aggregated view of a route's health over a window of snapshots. Used to
+ * surface trends without forcing callers to crunch raw snapshots themselves.
+ */
+export interface RouteHealthTrend {
+  routeId: string;
+  sampleCount: number;
+  from?: Date;
+  to?: Date;
+  averageAvailability: number;
+  minAvailability: number;
+  maxAvailability: number;
+  averageLatencyMs: number | null;
+  uptimeRatio: number;
+  statusDistribution: Record<RouteHealthStatus, number>;
+  currentStatus: RouteHealthStatus | null;
+  /** Direction of availability change across the window. */
+  availabilityTrend: 'improving' | 'declining' | 'stable';
+}
+
+export interface RouteHealthComparison {
+  routeId: string;
+  sampleCount: number;
+  averageAvailability: number;
+  uptimeRatio: number;
+  averageLatencyMs: number | null;
+  currentStatus: RouteHealthStatus | null;
+  /** 1 = best ranked route in the comparison. */
+  rank: number;
+}
+
+const ALL_STATUSES: RouteHealthStatus[] = [
+  'healthy',
+  'degraded',
+  'unhealthy',
+  'outage',
+];
+
+/**
+ * Stores historical Stellar route health metrics and derives trends and
+ * cross-route comparisons from them. Storage is in-memory and bounded by the
+ * configured retention/size limits, mirroring the other in-memory history and
+ * monitoring modules in the codebase.
+ */
+export class RouteHealthHistoryTracker {
+  private readonly config: Required<RouteHealthHistoryConfig>;
+  private readonly snapshots = new Map<string, RouteHealthSnapshot[]>();
+
+  constructor(config: RouteHealthHistoryConfig = {}) {
+    this.config = {
+      maxSnapshotsPerRoute: config.maxSnapshotsPerRoute ?? 1000,
+      retentionMs: config.retentionMs ?? 0,
+    };
+  }
+
+  /** Records a single health observation for a route. */
+  record(sample: RouteHealthSample): RouteHealthSnapshot {
+    const snapshot: RouteHealthSnapshot = {
+      routeId: sample.routeId,
+      status: sample.status,
+      availability: clampAvailability(sample.availability),
+      latencyMs: sample.latencyMs,
+      consecutiveFailures: sample.consecutiveFailures,
+      errorMessage: sample.errorMessage,
+      recordedAt: sample.recordedAt ?? new Date(),
+    };
+
+    const series = this.snapshots.get(sample.routeId) ?? [];
+    series.push(snapshot);
+    series.sort((a, b) => a.recordedAt.getTime() - b.recordedAt.getTime());
+    this.prune(series);
+    this.snapshots.set(sample.routeId, series);
+
+    return snapshot;
+  }
+
+  /** Returns the raw snapshots for a route, optionally filtered by a query. */
+  getHistory(routeId: string, query: HistoryQuery = {}): RouteHealthSnapshot[] {
+    const series = this.snapshots.get(routeId) ?? [];
+    let result = series.filter((s) => withinRange(s.recordedAt, query));
+    if (query.limit !== undefined && query.limit >= 0) {
+      result = result.slice(-query.limit);
+    }
+    return result.map((s) => ({ ...s }));
+  }
+
+  /** Returns the most recent snapshot recorded for a route, if any. */
+  getLatest(routeId: string): RouteHealthSnapshot | null {
+    const series = this.snapshots.get(routeId);
+    if (!series || series.length === 0) {
+      return null;
+    }
+    return { ...series[series.length - 1] };
+  }
+
+  /** Lists every route that has at least one recorded snapshot. */
+  getTrackedRoutes(): string[] {
+    return Array.from(this.snapshots.keys());
+  }
+
+  /**
+   * Builds an aggregated health trend for a route over the given window.
+   * Returns null when there are no snapshots in range.
+   */
+  getTrend(routeId: string, query: HistoryQuery = {}): RouteHealthTrend | null {
+    const series = this.getHistory(routeId, query);
+    if (series.length === 0) {
+      return null;
+    }
+
+    const statusDistribution = emptyStatusDistribution();
+    let availabilitySum = 0;
+    let minAvailability = Number.POSITIVE_INFINITY;
+    let maxAvailability = Number.NEGATIVE_INFINITY;
+    let latencySum = 0;
+    let latencyCount = 0;
+    let healthyCount = 0;
+
+    for (const snapshot of series) {
+      statusDistribution[snapshot.status] += 1;
+      availabilitySum += snapshot.availability;
+      minAvailability = Math.min(minAvailability, snapshot.availability);
+      maxAvailability = Math.max(maxAvailability, snapshot.availability);
+      if (typeof snapshot.latencyMs === 'number') {
+        latencySum += snapshot.latencyMs;
+        latencyCount += 1;
+      }
+      if (snapshot.status === 'healthy') {
+        healthyCount += 1;
+      }
+    }
+
+    return {
+      routeId,
+      sampleCount: series.length,
+      from: series[0].recordedAt,
+      to: series[series.length - 1].recordedAt,
+      averageAvailability: availabilitySum / series.length,
+      minAvailability,
+      maxAvailability,
+      averageLatencyMs: latencyCount > 0 ? latencySum / latencyCount : null,
+      uptimeRatio: healthyCount / series.length,
+      statusDistribution,
+      currentStatus: series[series.length - 1].status,
+      availabilityTrend: computeAvailabilityTrend(series),
+    };
+  }
+
+  /**
+   * Ranks the supplied routes (or all tracked routes) by health over the
+   * window. Routes are ordered by average availability, then uptime ratio,
+   * then lower latency. Routes without snapshots in range are omitted.
+   */
+  compareRoutes(
+    routeIds?: string[],
+    query: HistoryQuery = {},
+  ): RouteHealthComparison[] {
+    const ids = routeIds ?? this.getTrackedRoutes();
+    const comparisons: RouteHealthComparison[] = [];
+
+    for (const routeId of ids) {
+      const trend = this.getTrend(routeId, query);
+      if (!trend) {
+        continue;
+      }
+      comparisons.push({
+        routeId,
+        sampleCount: trend.sampleCount,
+        averageAvailability: trend.averageAvailability,
+        uptimeRatio: trend.uptimeRatio,
+        averageLatencyMs: trend.averageLatencyMs,
+        currentStatus: trend.currentStatus,
+        rank: 0,
+      });
+    }
+
+    comparisons.sort((a, b) => {
+      if (b.averageAvailability !== a.averageAvailability) {
+        return b.averageAvailability - a.averageAvailability;
+      }
+      if (b.uptimeRatio !== a.uptimeRatio) {
+        return b.uptimeRatio - a.uptimeRatio;
+      }
+      const latencyA = a.averageLatencyMs ?? Number.POSITIVE_INFINITY;
+      const latencyB = b.averageLatencyMs ?? Number.POSITIVE_INFINITY;
+      return latencyA - latencyB;
+    });
+
+    comparisons.forEach((comparison, index) => {
+      comparison.rank = index + 1;
+    });
+
+    return comparisons;
+  }
+
+  /** Removes history for a single route. Returns true if anything was removed. */
+  clearRoute(routeId: string): boolean {
+    return this.snapshots.delete(routeId);
+  }
+
+  /** Removes all recorded history across every route. */
+  clear(): void {
+    this.snapshots.clear();
+  }
+
+  private prune(series: RouteHealthSnapshot[]): void {
+    if (this.config.retentionMs > 0) {
+      const cutoff = Date.now() - this.config.retentionMs;
+      let removable = 0;
+      while (
+        removable < series.length &&
+        series[removable].recordedAt.getTime() < cutoff
+      ) {
+        removable += 1;
+      }
+      if (removable > 0) {
+        series.splice(0, removable);
+      }
+    }
+
+    const overflow = series.length - this.config.maxSnapshotsPerRoute;
+    if (overflow > 0) {
+      series.splice(0, overflow);
+    }
+  }
+}
+
+function clampAvailability(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function withinRange(recordedAt: Date, query: HistoryQuery): boolean {
+  if (query.from && recordedAt < query.from) {
+    return false;
+  }
+  if (query.to && recordedAt > query.to) {
+    return false;
+  }
+  return true;
+}
+
+function emptyStatusDistribution(): Record<RouteHealthStatus, number> {
+  return ALL_STATUSES.reduce(
+    (acc, status) => {
+      acc[status] = 0;
+      return acc;
+    },
+    {} as Record<RouteHealthStatus, number>,
+  );
+}
+
+function computeAvailabilityTrend(
+  series: RouteHealthSnapshot[],
+): 'improving' | 'declining' | 'stable' {
+  if (series.length < 2) {
+    return 'stable';
+  }
+
+  const mid = Math.floor(series.length / 2);
+  const firstHalf = series.slice(0, mid);
+  const secondHalf = series.slice(mid);
+
+  const firstAvg = average(firstHalf.map((s) => s.availability));
+  const secondAvg = average(secondHalf.map((s) => s.availability));
+  const delta = secondAvg - firstAvg;
+
+  const threshold = 0.01;
+  if (delta > threshold) {
+    return 'improving';
+  }
+  if (delta < -threshold) {
+    return 'declining';
+  }
+  return 'stable';
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}


### PR DESCRIPTION
Closes #555 

# Implement Soroban Route Health History Tracker

## 🧠 Concept
Track historical route health metrics for Stellar/Soroban routes so health trends can be analyzed over time and routes compared against one another.

## ⚠️ Problem
Route health was only observed in real time by `StellarRouteHealthMonitor`. Once a health state changed, the previous values were lost — there was no historical record, so trends could not be reconstructed and routes could not be compared on their health over a window.

## 📁 Implementation Scope
`src/history/health/routes/stellar/`

| File | Purpose |
| --- | --- |
| `route-health-history.ts` | Core `RouteHealthHistoryTracker` plus the snapshot/trend/comparison types. |
| `index.ts` | Re-exports the module and provides a shared `routeHealthHistoryTracker` singleton. |
| `__tests__/route-health-history.spec.ts` | Unit tests covering storage, queries, trends, comparisons, retention and clearing. |

## ✨ What's included

### Store health metrics
- `record(sample)` persists a point-in-time `RouteHealthSnapshot` (status, availability, latency, consecutive failures, error message, timestamp).
- `recordedAt` defaults to the current time; availability is clamped into `[0, 1]`.
- Snapshots are stored per route, kept in chronological order, and bounded by:
  - `maxSnapshotsPerRoute` (oldest evicted first), and
  - `retentionMs` (snapshots older than the window pruned on write).
- Reuses the `RouteHealthStatus` type from the existing `StellarRouteHealthMonitor` to stay consistent with the monitoring module.

### Generate historical trends
- `getHistory(routeId, query)` returns raw snapshots filtered by date range and/or limited to the most recent N. Returned snapshots are copies so stored state cannot be mutated.
- `getLatest(routeId)` returns the most recent snapshot.
- `getTrend(routeId, query)` aggregates a window into a `RouteHealthTrend`: average / min / max availability, average latency, uptime ratio, status distribution, current status, and an `availabilityTrend` (`improving` / `declining` / `stable`) derived from comparing the first and second halves of the window.

### Support route comparisons
- `compareRoutes(routeIds?, query)` ranks routes (all tracked, or a requested subset) by average availability, then uptime ratio, then lower average latency. Routes with no snapshots in range are omitted; each result is assigned a `rank`.

### Housekeeping
- `getTrackedRoutes()`, `clearRoute(routeId)` and `clear()` for inspection and cleanup.

## 🎯 Acceptance Criteria
- ✅ Health tracker implemented (`RouteHealthHistoryTracker`).
- ✅ Historical data accessible (`getHistory`, `getLatest`, `getTrend`, `compareRoutes`).

## 🧪 Testing
`__tests__/route-health-history.spec.ts` covers:
- Recording, per-route isolation, chronological ordering, availability clamping, and default timestamps.
- Date-range filtering, `limit`, latest lookup, and immutability of returned snapshots.
- Trend aggregation (availability stats, latency averaging with missing values, status distribution, uptime ratio) and trend direction detection (improving / declining / stable).
- Route ranking, subset comparison, and omission of empty routes.
- `maxSnapshotsPerRoute` eviction and `retentionMs` pruning.
- Single-route and full clearing.

Run with:

```bash
npx jest src/history/health/routes/stellar
```

## 🔗 Notes
In-memory storage mirrors the existing `src/history/routes/stellar` and `src/monitoring/routes/stellar` modules. The tracker can be wired to `StellarRouteHealthMonitor`'s `status-change` events to capture history automatically.
