### PR TITLE
Implement soroban route recommendation feedback

### DIFF
--- a/src/analytics/feedback/routes/stellar/index.ts
+++ b/src/analytics/feedback/routes/stellar/index.ts
@@ -1,0 +1,5 @@
+export * from './route-feedback-analyzer';
+
+import { StellarRouteFeedbackAnalyzer } from './route-feedback-analyzer';
+
+export const stellarRouteFeedbackAnalyzer = new StellarRouteFeedbackAnalyzer();

--- a/src/analytics/feedback/routes/stellar/route-feedback-analyzer.spec.ts
+++ b/src/analytics/feedback/routes/stellar/route-feedback-analyzer.spec.ts
@@ -1,0 +1,236 @@
+import {
+  StellarRouteFeedbackAnalyzer,
+  type RouteFeedbackInput,
+} from './route-feedback-analyzer';
+
+function feedback(overrides: Partial<RouteFeedbackInput> = {}): RouteFeedbackInput {
+  return {
+    routeId: 'XLM->USDC',
+    rating: 5,
+    accepted: true,
+    submittedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('StellarRouteFeedbackAnalyzer', () => {
+  describe('recordFeedback', () => {
+    it('stores and normalizes a feedback entry', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      const entry = analyzer.recordFeedback(
+        feedback({ routeId: '  XLM->USDC  ', comment: '  great  ' }),
+      );
+      expect(entry.routeId).toBe('XLM->USDC');
+      expect(entry.comment).toBe('great');
+      expect(analyzer.getFeedback()).toHaveLength(1);
+    });
+
+    it('defaults submittedAt to now when omitted', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      const before = Date.now();
+      const entry = analyzer.recordFeedback(feedback({ submittedAt: undefined }));
+      expect(entry.submittedAt.getTime()).toBeGreaterThanOrEqual(before);
+    });
+
+    it('rejects empty routeId', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      expect(() => analyzer.recordFeedback(feedback({ routeId: '  ' }))).toThrow(
+        /routeId/,
+      );
+    });
+
+    it('rejects out-of-range ratings', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      expect(() => analyzer.recordFeedback(feedback({ rating: 0 }))).toThrow(
+        /rating/,
+      );
+      expect(() => analyzer.recordFeedback(feedback({ rating: 6 }))).toThrow(
+        /rating/,
+      );
+      expect(() => analyzer.recordFeedback(feedback({ rating: NaN }))).toThrow(
+        /rating/,
+      );
+    });
+
+    it('drops empty comments to undefined', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      const entry = analyzer.recordFeedback(feedback({ comment: '   ' }));
+      expect(entry.comment).toBeUndefined();
+    });
+
+    it('evicts oldest entries beyond keepMaxEntries', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer({ keepMaxEntries: 2 });
+      analyzer.recordFeedback(feedback({ rating: 1 }));
+      analyzer.recordFeedback(feedback({ rating: 2 }));
+      analyzer.recordFeedback(feedback({ rating: 3 }));
+      const ratings = analyzer.getFeedback().map((e) => e.rating);
+      expect(ratings).toEqual([2, 3]);
+    });
+  });
+
+  describe('aggregateRoute', () => {
+    it('returns null when no feedback in range', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      expect(analyzer.aggregateRoute('missing')).toBeNull();
+    });
+
+    it('aggregates ratings, acceptance and sentiment', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      analyzer.recordFeedback(feedback({ rating: 5, accepted: true }));
+      analyzer.recordFeedback(feedback({ rating: 3, accepted: false, comment: 'meh' }));
+      analyzer.recordFeedback(feedback({ rating: 1, accepted: false }));
+
+      const agg = analyzer.aggregateRoute('XLM->USDC');
+      expect(agg).not.toBeNull();
+      expect(agg!.totalFeedback).toBe(3);
+      expect(agg!.averageRating).toBeCloseTo(3);
+      expect(agg!.acceptanceRate).toBeCloseTo(1 / 3);
+      expect(agg!.sentimentDistribution).toEqual({
+        positive: 1,
+        neutral: 1,
+        negative: 1,
+      });
+      expect(agg!.commentCount).toBe(1);
+      expect(agg!.lastFeedbackAt).toBeInstanceOf(Date);
+    });
+
+    it('respects date-range filtering', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      analyzer.recordFeedback(
+        feedback({ submittedAt: new Date('2026-01-01T00:00:00Z') }),
+      );
+      analyzer.recordFeedback(
+        feedback({ submittedAt: new Date('2026-02-01T00:00:00Z') }),
+      );
+      const agg = analyzer.aggregateRoute('XLM->USDC', {
+        from: new Date('2026-01-15T00:00:00Z'),
+      });
+      expect(agg!.totalFeedback).toBe(1);
+    });
+  });
+
+  describe('generateInsights', () => {
+    const build = () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      // Route A: loved + accepted.
+      for (let i = 0; i < 4; i++) {
+        analyzer.recordFeedback(feedback({ routeId: 'A', rating: 5, accepted: true }));
+      }
+      // Route B: disliked + skipped.
+      for (let i = 0; i < 4; i++) {
+        analyzer.recordFeedback(feedback({ routeId: 'B', rating: 1, accepted: false }));
+      }
+      // Route C: rated well but rarely accepted.
+      for (let i = 0; i < 4; i++) {
+        analyzer.recordFeedback(feedback({ routeId: 'C', rating: 4, accepted: false }));
+      }
+      return analyzer;
+    };
+
+    it('identifies top and underperforming routes', () => {
+      const insights = build().generateInsights();
+      expect(insights.topRoutes[0].routeId).toBe('A');
+      expect(insights.underperformingRoutes[0].routeId).toBe('B');
+    });
+
+    it('flags routes needing attention', () => {
+      const insights = build().generateInsights();
+      const flagged = insights.routesNeedingAttention.map((r) => r.routeId).sort();
+      // B is negative; C has low acceptance.
+      expect(flagged).toEqual(['B', 'C']);
+    });
+
+    it('computes feedback-weighted overall metrics', () => {
+      const insights = build().generateInsights();
+      expect(insights.totalFeedback).toBe(12);
+      expect(insights.overallAverageRating).toBeCloseTo((5 + 1 + 4) / 3);
+      expect(insights.overallAcceptanceRate).toBeCloseTo(4 / 12);
+    });
+
+    it('returns empty insights when there is no feedback', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      const insights = analyzer.generateInsights();
+      expect(insights.totalFeedback).toBe(0);
+      expect(insights.topRoutes).toHaveLength(0);
+      expect(insights.overallAverageRating).toBe(0);
+    });
+  });
+
+  describe('generateTrendReport', () => {
+    it('buckets feedback by the configured window', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      analyzer.recordFeedback(
+        feedback({ rating: 2, accepted: false, submittedAt: new Date('2026-01-01T00:00:00Z') }),
+      );
+      analyzer.recordFeedback(
+        feedback({ rating: 2, accepted: false, submittedAt: new Date('2026-01-01T06:00:00Z') }),
+      );
+      analyzer.recordFeedback(
+        feedback({ rating: 5, accepted: true, submittedAt: new Date('2026-01-03T00:00:00Z') }),
+      );
+
+      const report = analyzer.generateTrendReport({
+        routeId: 'XLM->USDC',
+        bucketSizeMs: 24 * 60 * 60 * 1000,
+      });
+
+      expect(report.routeId).toBe('XLM->USDC');
+      expect(report.buckets).toHaveLength(3);
+      expect(report.buckets[0].totalFeedback).toBe(2);
+      expect(report.buckets[0].averageRating).toBeCloseTo(2);
+      expect(report.buckets[1].totalFeedback).toBe(0);
+      expect(report.buckets[2].totalFeedback).toBe(1);
+    });
+
+    it('detects an improving rating trend', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      const days = [1, 2, 3, 4];
+      const ratings = [1, 2, 4, 5];
+      days.forEach((day, i) =>
+        analyzer.recordFeedback(
+          feedback({
+            rating: ratings[i],
+            accepted: ratings[i] >= 4,
+            submittedAt: new Date(`2026-01-0${day}T00:00:00Z`),
+          }),
+        ),
+      );
+      const report = analyzer.generateTrendReport({
+        bucketSizeMs: 24 * 60 * 60 * 1000,
+      });
+      expect(report.ratingTrend).toBe('improving');
+      expect(report.acceptanceTrend).toBe('improving');
+    });
+
+    it('rejects a non-positive bucket size', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      expect(() => analyzer.generateTrendReport({ bucketSizeMs: 0 })).toThrow(
+        /bucketSizeMs/,
+      );
+    });
+
+    it('returns an empty report when there is no feedback', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      const report = analyzer.generateTrendReport();
+      expect(report.buckets).toHaveLength(0);
+      expect(report.ratingTrend).toBe('stable');
+    });
+  });
+
+  describe('clearing', () => {
+    it('clears feedback for a single route', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      analyzer.recordFeedback(feedback({ routeId: 'A' }));
+      analyzer.recordFeedback(feedback({ routeId: 'B' }));
+      expect(analyzer.clearRoute('A')).toBe(1);
+      expect(analyzer.getRoutesWithFeedback()).toEqual(['B']);
+    });
+
+    it('clears all feedback', () => {
+      const analyzer = new StellarRouteFeedbackAnalyzer();
+      analyzer.recordFeedback(feedback());
+      analyzer.clear();
+      expect(analyzer.getFeedback()).toHaveLength(0);
+    });
+  });
+});

--- a/src/analytics/feedback/routes/stellar/route-feedback-analyzer.ts
+++ b/src/analytics/feedback/routes/stellar/route-feedback-analyzer.ts
@@ -1,0 +1,477 @@
+/**
+ * User feedback analytics for Stellar route recommendations.
+ *
+ * Collects individual feedback records left by users after a route is
+ * recommended to them, then aggregates that raw data into per-route metrics,
+ * actionable recommendation insights, and time-bucketed trend reports.
+ *
+ * Storage is in-memory and bounded, mirroring the other analytics modules in
+ * `src/analytics/**\/stellar`.
+ */
+
+export type FeedbackSentiment = 'positive' | 'neutral' | 'negative';
+
+/** A single piece of user feedback on a recommended route. */
+export interface RouteFeedbackEntry {
+  routeId: string;
+  fromAsset?: string;
+  toAsset?: string;
+  recommendationId?: string;
+  userId?: string;
+  /** Star rating from 1 (worst) to 5 (best). */
+  rating: number;
+  /** Whether the user acted on / accepted the recommendation. */
+  accepted: boolean;
+  comment?: string;
+  submittedAt: Date;
+}
+
+export type RouteFeedbackInput = Omit<RouteFeedbackEntry, 'submittedAt'> & {
+  submittedAt?: Date;
+};
+
+export interface RouteFeedbackAnalyzerOptions {
+  keepMaxEntries?: number;
+  /** Ratings at or above this are treated as positive. Default 4. */
+  positiveRatingThreshold?: number;
+  /** Ratings at or below this are treated as negative. Default 2. */
+  negativeRatingThreshold?: number;
+}
+
+export interface FeedbackQuery {
+  from?: Date;
+  to?: Date;
+}
+
+/** Aggregated feedback metrics for a single route. */
+export interface RouteFeedbackAggregate {
+  routeId: string;
+  totalFeedback: number;
+  averageRating: number;
+  acceptanceRate: number;
+  sentimentDistribution: Record<FeedbackSentiment, number>;
+  positiveRate: number;
+  negativeRate: number;
+  commentCount: number;
+  lastFeedbackAt: Date | null;
+}
+
+/** A recommendation insight derived from the aggregated feedback. */
+export interface RecommendationInsight {
+  routeId: string;
+  averageRating: number;
+  acceptanceRate: number;
+  totalFeedback: number;
+  sentiment: FeedbackSentiment;
+  /** Human-readable summary of what the feedback implies. */
+  recommendation: string;
+}
+
+export interface RouteFeedbackInsights {
+  topRoutes: RecommendationInsight[];
+  underperformingRoutes: RecommendationInsight[];
+  routesNeedingAttention: RecommendationInsight[];
+  overallAverageRating: number;
+  overallAcceptanceRate: number;
+  totalFeedback: number;
+}
+
+export interface FeedbackTrendBucket {
+  periodStart: Date;
+  periodEnd: Date;
+  totalFeedback: number;
+  averageRating: number;
+  acceptanceRate: number;
+  sentimentDistribution: Record<FeedbackSentiment, number>;
+}
+
+export interface FeedbackTrendReport {
+  routeId: string | null;
+  bucketSizeMs: number;
+  from: Date;
+  to: Date;
+  buckets: FeedbackTrendBucket[];
+  ratingTrend: 'improving' | 'declining' | 'stable';
+  acceptanceTrend: 'improving' | 'declining' | 'stable';
+}
+
+const SENTIMENTS: FeedbackSentiment[] = ['positive', 'neutral', 'negative'];
+
+export class StellarRouteFeedbackAnalyzer {
+  private readonly entries: RouteFeedbackEntry[] = [];
+  private readonly maxEntries: number;
+  private readonly positiveThreshold: number;
+  private readonly negativeThreshold: number;
+
+  constructor(options: RouteFeedbackAnalyzerOptions = {}) {
+    this.maxEntries = options.keepMaxEntries ?? 10_000;
+    this.positiveThreshold = options.positiveRatingThreshold ?? 4;
+    this.negativeThreshold = options.negativeRatingThreshold ?? 2;
+  }
+
+  /** Records a single feedback entry, validating and normalizing the input. */
+  recordFeedback(input: RouteFeedbackInput): RouteFeedbackEntry {
+    if (!input.routeId?.trim()) {
+      throw new Error('routeId must be a non-empty string');
+    }
+    if (
+      typeof input.rating !== 'number' ||
+      Number.isNaN(input.rating) ||
+      input.rating < 1 ||
+      input.rating > 5
+    ) {
+      throw new Error('rating must be a number between 1 and 5');
+    }
+
+    const entry: RouteFeedbackEntry = {
+      routeId: input.routeId.trim(),
+      fromAsset: input.fromAsset?.trim(),
+      toAsset: input.toAsset?.trim(),
+      recommendationId: input.recommendationId?.trim(),
+      userId: input.userId?.trim(),
+      rating: input.rating,
+      accepted: input.accepted,
+      comment: input.comment?.trim() || undefined,
+      submittedAt: input.submittedAt ?? new Date(),
+    };
+
+    this.entries.push(entry);
+    if (this.entries.length > this.maxEntries) {
+      this.entries.splice(0, this.entries.length - this.maxEntries);
+    }
+    return entry;
+  }
+
+  /** Returns a copy of all stored feedback entries, optionally filtered. */
+  getFeedback(routeId?: string, query: FeedbackQuery = {}): RouteFeedbackEntry[] {
+    return this.entries
+      .filter((e) => (routeId ? e.routeId === routeId : true))
+      .filter((e) => withinRange(e.submittedAt, query))
+      .map((e) => ({ ...e }));
+  }
+
+  /** Lists every route that has at least one feedback entry. */
+  getRoutesWithFeedback(): string[] {
+    return Array.from(new Set(this.entries.map((e) => e.routeId)));
+  }
+
+  /**
+   * Aggregates feedback for a single route into rating, acceptance and
+   * sentiment metrics. Returns null when there is no feedback in range.
+   */
+  aggregateRoute(
+    routeId: string,
+    query: FeedbackQuery = {},
+  ): RouteFeedbackAggregate | null {
+    const entries = this.getFeedback(routeId, query);
+    if (entries.length === 0) {
+      return null;
+    }
+    return this.aggregateEntries(routeId, entries);
+  }
+
+  /** Aggregates feedback for every route with feedback in range. */
+  aggregateAll(query: FeedbackQuery = {}): RouteFeedbackAggregate[] {
+    return this.getRoutesWithFeedback()
+      .map((routeId) => this.aggregateRoute(routeId, query))
+      .filter((a): a is RouteFeedbackAggregate => a !== null);
+  }
+
+  /**
+   * Generates recommendation insights: which recommended routes users love,
+   * which underperform, and which need attention (enough feedback but poor
+   * ratings or low acceptance).
+   */
+  generateInsights(
+    query: FeedbackQuery = {},
+    options: { topN?: number; minFeedbackForAttention?: number } = {},
+  ): RouteFeedbackInsights {
+    const topN = options.topN ?? 5;
+    const minFeedbackForAttention = options.minFeedbackForAttention ?? 3;
+
+    const aggregates = this.aggregateAll(query);
+    const insights = aggregates.map((agg) => this.toInsight(agg));
+
+    const byRating = [...insights].sort(
+      (a, b) =>
+        b.averageRating - a.averageRating ||
+        b.acceptanceRate - a.acceptanceRate ||
+        b.totalFeedback - a.totalFeedback,
+    );
+
+    const topRoutes = byRating.slice(0, topN);
+    const underperformingRoutes = [...byRating]
+      .reverse()
+      .slice(0, topN);
+
+    const routesNeedingAttention = insights
+      .filter(
+        (i) =>
+          i.totalFeedback >= minFeedbackForAttention &&
+          (i.sentiment === 'negative' || i.acceptanceRate < 0.5),
+      )
+      .sort((a, b) => a.averageRating - b.averageRating);
+
+    const totalFeedback = aggregates.reduce(
+      (sum, a) => sum + a.totalFeedback,
+      0,
+    );
+    const overallAverageRating =
+      totalFeedback === 0
+        ? 0
+        : aggregates.reduce(
+            (sum, a) => sum + a.averageRating * a.totalFeedback,
+            0,
+          ) / totalFeedback;
+    const overallAcceptanceRate =
+      totalFeedback === 0
+        ? 0
+        : aggregates.reduce(
+            (sum, a) => sum + a.acceptanceRate * a.totalFeedback,
+            0,
+          ) / totalFeedback;
+
+    return {
+      topRoutes,
+      underperformingRoutes,
+      routesNeedingAttention,
+      overallAverageRating,
+      overallAcceptanceRate,
+      totalFeedback,
+    };
+  }
+
+  /**
+   * Produces a time-bucketed trend report. When `routeId` is provided the
+   * report is scoped to that route, otherwise it spans all feedback.
+   */
+  generateTrendReport(
+    options: {
+      routeId?: string;
+      bucketSizeMs?: number;
+      from?: Date;
+      to?: Date;
+    } = {},
+  ): FeedbackTrendReport {
+    const bucketSizeMs = options.bucketSizeMs ?? 24 * 60 * 60 * 1000;
+    if (bucketSizeMs <= 0) {
+      throw new Error('bucketSizeMs must be a positive number');
+    }
+
+    const entries = this.getFeedback(options.routeId, {
+      from: options.from,
+      to: options.to,
+    }).sort((a, b) => a.submittedAt.getTime() - b.submittedAt.getTime());
+
+    const from =
+      options.from ??
+      (entries.length > 0 ? entries[0].submittedAt : new Date());
+    const to =
+      options.to ??
+      (entries.length > 0
+        ? entries[entries.length - 1].submittedAt
+        : new Date(from.getTime()));
+
+    const buckets: FeedbackTrendBucket[] = [];
+    if (entries.length > 0 || options.from || options.to) {
+      const start = from.getTime();
+      const end = Math.max(to.getTime(), start);
+      for (
+        let bucketStart = start;
+        bucketStart <= end;
+        bucketStart += bucketSizeMs
+      ) {
+        const bucketEnd = bucketStart + bucketSizeMs;
+        const bucketEntries = entries.filter((e) => {
+          const t = e.submittedAt.getTime();
+          return t >= bucketStart && t < bucketEnd;
+        });
+        buckets.push({
+          periodStart: new Date(bucketStart),
+          periodEnd: new Date(bucketEnd),
+          totalFeedback: bucketEntries.length,
+          averageRating: averageRating(bucketEntries),
+          acceptanceRate: acceptanceRate(bucketEntries),
+          sentimentDistribution: this.sentimentDistribution(bucketEntries),
+        });
+      }
+    }
+
+    const populated = buckets.filter((b) => b.totalFeedback > 0);
+
+    return {
+      routeId: options.routeId ?? null,
+      bucketSizeMs,
+      from,
+      to,
+      buckets,
+      ratingTrend: computeTrend(populated.map((b) => b.averageRating)),
+      acceptanceTrend: computeTrend(populated.map((b) => b.acceptanceRate)),
+    };
+  }
+
+  /** Removes feedback for a single route. */
+  clearRoute(routeId: string): number {
+    let removed = 0;
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      if (this.entries[i].routeId === routeId) {
+        this.entries.splice(i, 1);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /** Removes all stored feedback. */
+  clear(): void {
+    this.entries.length = 0;
+  }
+
+  private aggregateEntries(
+    routeId: string,
+    entries: RouteFeedbackEntry[],
+  ): RouteFeedbackAggregate {
+    const total = entries.length;
+    const ratingSum = entries.reduce((sum, e) => sum + e.rating, 0);
+    const accepted = entries.filter((e) => e.accepted).length;
+    const sentiment = this.sentimentDistribution(entries);
+    const lastFeedbackAt = entries.reduce<Date | null>((latest, e) => {
+      if (!latest || e.submittedAt > latest) {
+        return e.submittedAt;
+      }
+      return latest;
+    }, null);
+
+    return {
+      routeId,
+      totalFeedback: total,
+      averageRating: ratingSum / total,
+      acceptanceRate: accepted / total,
+      sentimentDistribution: sentiment,
+      positiveRate: sentiment.positive / total,
+      negativeRate: sentiment.negative / total,
+      commentCount: entries.filter((e) => !!e.comment).length,
+      lastFeedbackAt,
+    };
+  }
+
+  private sentimentDistribution(
+    entries: RouteFeedbackEntry[],
+  ): Record<FeedbackSentiment, number> {
+    const distribution = emptySentiment();
+    for (const entry of entries) {
+      distribution[this.classifySentiment(entry.rating)] += 1;
+    }
+    return distribution;
+  }
+
+  private classifySentiment(rating: number): FeedbackSentiment {
+    if (rating >= this.positiveThreshold) {
+      return 'positive';
+    }
+    if (rating <= this.negativeThreshold) {
+      return 'negative';
+    }
+    return 'neutral';
+  }
+
+  private toInsight(agg: RouteFeedbackAggregate): RecommendationInsight {
+    const sentiment = dominantSentiment(agg.sentimentDistribution);
+    return {
+      routeId: agg.routeId,
+      averageRating: agg.averageRating,
+      acceptanceRate: agg.acceptanceRate,
+      totalFeedback: agg.totalFeedback,
+      sentiment,
+      recommendation: buildRecommendation(agg, sentiment),
+    };
+  }
+}
+
+function withinRange(date: Date, query: FeedbackQuery): boolean {
+  if (query.from && date < query.from) {
+    return false;
+  }
+  if (query.to && date > query.to) {
+    return false;
+  }
+  return true;
+}
+
+function emptySentiment(): Record<FeedbackSentiment, number> {
+  return SENTIMENTS.reduce(
+    (acc, s) => {
+      acc[s] = 0;
+      return acc;
+    },
+    {} as Record<FeedbackSentiment, number>,
+  );
+}
+
+function averageRating(entries: RouteFeedbackEntry[]): number {
+  if (entries.length === 0) {
+    return 0;
+  }
+  return entries.reduce((sum, e) => sum + e.rating, 0) / entries.length;
+}
+
+function acceptanceRate(entries: RouteFeedbackEntry[]): number {
+  if (entries.length === 0) {
+    return 0;
+  }
+  return entries.filter((e) => e.accepted).length / entries.length;
+}
+
+function dominantSentiment(
+  distribution: Record<FeedbackSentiment, number>,
+): FeedbackSentiment {
+  let best: FeedbackSentiment = 'neutral';
+  let bestCount = -1;
+  for (const sentiment of SENTIMENTS) {
+    if (distribution[sentiment] > bestCount) {
+      bestCount = distribution[sentiment];
+      best = sentiment;
+    }
+  }
+  return best;
+}
+
+function buildRecommendation(
+  agg: RouteFeedbackAggregate,
+  sentiment: FeedbackSentiment,
+): string {
+  if (sentiment === 'positive' && agg.acceptanceRate >= 0.6) {
+    return 'Performing well — keep prioritizing this route in recommendations.';
+  }
+  if (sentiment === 'negative') {
+    return 'Poorly received — review pricing/liquidity and consider de-prioritizing.';
+  }
+  if (agg.acceptanceRate < 0.5) {
+    return 'Low acceptance despite ratings — investigate why users skip this route.';
+  }
+  return 'Mixed feedback — monitor for emerging trends before changing priority.';
+}
+
+function computeTrend(
+  values: number[],
+): 'improving' | 'declining' | 'stable' {
+  if (values.length < 2) {
+    return 'stable';
+  }
+  const mid = Math.floor(values.length / 2);
+  const firstHalf = values.slice(0, mid);
+  const secondHalf = values.slice(mid);
+  const firstAvg =
+    firstHalf.reduce((s, v) => s + v, 0) / Math.max(firstHalf.length, 1);
+  const secondAvg =
+    secondHalf.reduce((s, v) => s + v, 0) / Math.max(secondHalf.length, 1);
+  const delta = secondAvg - firstAvg;
+  const threshold = 0.05;
+  if (delta > threshold) {
+    return 'improving';
+  }
+  if (delta < -threshold) {
+    return 'declining';
+  }
+  return 'stable';
+}

--- a/src/history/health/routes/stellar/__tests__/route-health-history.spec.ts
+++ b/src/history/health/routes/stellar/__tests__/route-health-history.spec.ts
@@ -1,0 +1,292 @@
+import {
+  RouteHealthHistoryTracker,
+  type RouteHealthSample,
+} from '../route-health-history';
+
+function sample(overrides: Partial<RouteHealthSample> = {}): RouteHealthSample {
+  return {
+    routeId: 'XLM->USDC',
+    status: 'healthy',
+    availability: 1,
+    latencyMs: 100,
+    recordedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('RouteHealthHistoryTracker', () => {
+  describe('record / getHistory', () => {
+    it('stores health metrics for a route', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample());
+
+      const history = tracker.getHistory('XLM->USDC');
+      expect(history).toHaveLength(1);
+      expect(history[0].status).toBe('healthy');
+      expect(history[0].availability).toBe(1);
+    });
+
+    it('defaults recordedAt to now when omitted', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      const before = Date.now();
+      const snapshot = tracker.record(sample({ recordedAt: undefined }));
+      expect(snapshot.recordedAt.getTime()).toBeGreaterThanOrEqual(before);
+    });
+
+    it('clamps availability into the [0, 1] range', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      expect(tracker.record(sample({ availability: 2 })).availability).toBe(1);
+      expect(tracker.record(sample({ availability: -1 })).availability).toBe(0);
+      expect(tracker.record(sample({ availability: NaN })).availability).toBe(0);
+    });
+
+    it('keeps snapshots ordered chronologically even when inserted out of order', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ recordedAt: new Date('2026-01-03T00:00:00Z') }));
+      tracker.record(sample({ recordedAt: new Date('2026-01-01T00:00:00Z') }));
+      tracker.record(sample({ recordedAt: new Date('2026-01-02T00:00:00Z') }));
+
+      const times = tracker
+        .getHistory('XLM->USDC')
+        .map((s) => s.recordedAt.toISOString());
+      expect(times).toEqual([
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-02T00:00:00.000Z',
+        '2026-01-03T00:00:00.000Z',
+      ]);
+    });
+
+    it('isolates history per route', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ routeId: 'A' }));
+      tracker.record(sample({ routeId: 'B' }));
+      tracker.record(sample({ routeId: 'B' }));
+
+      expect(tracker.getHistory('A')).toHaveLength(1);
+      expect(tracker.getHistory('B')).toHaveLength(2);
+      expect(tracker.getTrackedRoutes().sort()).toEqual(['A', 'B']);
+    });
+  });
+
+  describe('history queries', () => {
+    const build = () => {
+      const tracker = new RouteHealthHistoryTracker();
+      for (let day = 1; day <= 5; day++) {
+        tracker.record(
+          sample({
+            recordedAt: new Date(`2026-01-0${day}T00:00:00Z`),
+          }),
+        );
+      }
+      return tracker;
+    };
+
+    it('filters by date range', () => {
+      const tracker = build();
+      const result = tracker.getHistory('XLM->USDC', {
+        from: new Date('2026-01-02T00:00:00Z'),
+        to: new Date('2026-01-04T00:00:00Z'),
+      });
+      expect(result).toHaveLength(3);
+    });
+
+    it('limits to the most recent N within range', () => {
+      const tracker = build();
+      const result = tracker.getHistory('XLM->USDC', { limit: 2 });
+      expect(result.map((s) => s.recordedAt.toISOString())).toEqual([
+        '2026-01-04T00:00:00.000Z',
+        '2026-01-05T00:00:00.000Z',
+      ]);
+    });
+
+    it('returns latest snapshot', () => {
+      const tracker = build();
+      expect(tracker.getLatest('XLM->USDC')?.recordedAt.toISOString()).toBe(
+        '2026-01-05T00:00:00.000Z',
+      );
+      expect(tracker.getLatest('missing')).toBeNull();
+    });
+
+    it('returns copies so callers cannot mutate stored snapshots', () => {
+      const tracker = build();
+      const history = tracker.getHistory('XLM->USDC');
+      history[0].availability = 0.5;
+      expect(tracker.getHistory('XLM->USDC')[0].availability).toBe(1);
+    });
+  });
+
+  describe('getTrend', () => {
+    it('returns null when there is no history in range', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      expect(tracker.getTrend('missing')).toBeNull();
+    });
+
+    it('aggregates availability, latency and status distribution', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(
+        sample({
+          status: 'healthy',
+          availability: 1,
+          latencyMs: 100,
+          recordedAt: new Date('2026-01-01T00:00:00Z'),
+        }),
+      );
+      tracker.record(
+        sample({
+          status: 'degraded',
+          availability: 0.6,
+          latencyMs: 300,
+          recordedAt: new Date('2026-01-02T00:00:00Z'),
+        }),
+      );
+      tracker.record(
+        sample({
+          status: 'outage',
+          availability: 0,
+          latencyMs: undefined,
+          recordedAt: new Date('2026-01-03T00:00:00Z'),
+        }),
+      );
+
+      const trend = tracker.getTrend('XLM->USDC');
+      expect(trend).not.toBeNull();
+      expect(trend!.sampleCount).toBe(3);
+      expect(trend!.averageAvailability).toBeCloseTo((1 + 0.6 + 0) / 3);
+      expect(trend!.minAvailability).toBe(0);
+      expect(trend!.maxAvailability).toBe(1);
+      // Only two snapshots had latency recorded.
+      expect(trend!.averageLatencyMs).toBeCloseTo(200);
+      expect(trend!.uptimeRatio).toBeCloseTo(1 / 3);
+      expect(trend!.currentStatus).toBe('outage');
+      expect(trend!.statusDistribution).toEqual({
+        healthy: 1,
+        degraded: 1,
+        unhealthy: 0,
+        outage: 1,
+      });
+    });
+
+    it('reports null average latency when no snapshot has latency', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ latencyMs: undefined }));
+      expect(tracker.getTrend('XLM->USDC')!.averageLatencyMs).toBeNull();
+    });
+
+    it('detects an improving availability trend', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      const avails = [0.2, 0.3, 0.9, 1];
+      avails.forEach((availability, i) =>
+        tracker.record(
+          sample({
+            availability,
+            recordedAt: new Date(`2026-01-0${i + 1}T00:00:00Z`),
+          }),
+        ),
+      );
+      expect(tracker.getTrend('XLM->USDC')!.availabilityTrend).toBe('improving');
+    });
+
+    it('detects a declining availability trend', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      const avails = [1, 0.9, 0.3, 0.1];
+      avails.forEach((availability, i) =>
+        tracker.record(
+          sample({
+            availability,
+            recordedAt: new Date(`2026-01-0${i + 1}T00:00:00Z`),
+          }),
+        ),
+      );
+      expect(tracker.getTrend('XLM->USDC')!.availabilityTrend).toBe('declining');
+    });
+
+    it('reports a stable trend for flat availability', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      [1, 1, 1, 1].forEach((availability, i) =>
+        tracker.record(
+          sample({
+            availability,
+            recordedAt: new Date(`2026-01-0${i + 1}T00:00:00Z`),
+          }),
+        ),
+      );
+      expect(tracker.getTrend('XLM->USDC')!.availabilityTrend).toBe('stable');
+    });
+  });
+
+  describe('compareRoutes', () => {
+    const build = () => {
+      const tracker = new RouteHealthHistoryTracker();
+      // Route A: perfect availability.
+      tracker.record(sample({ routeId: 'A', availability: 1, latencyMs: 200 }));
+      tracker.record(sample({ routeId: 'A', availability: 1, latencyMs: 200 }));
+      // Route B: degraded.
+      tracker.record(
+        sample({ routeId: 'B', status: 'degraded', availability: 0.5, latencyMs: 100 }),
+      );
+      // Route C: same availability as A but slower → should rank below A.
+      tracker.record(sample({ routeId: 'C', availability: 1, latencyMs: 500 }));
+      return tracker;
+    };
+
+    it('ranks routes by availability, then uptime, then latency', () => {
+      const tracker = build();
+      const ranked = tracker.compareRoutes();
+      expect(ranked.map((r) => r.routeId)).toEqual(['A', 'C', 'B']);
+      expect(ranked.map((r) => r.rank)).toEqual([1, 2, 3]);
+    });
+
+    it('compares only the requested routes', () => {
+      const tracker = build();
+      const ranked = tracker.compareRoutes(['B', 'C']);
+      expect(ranked.map((r) => r.routeId)).toEqual(['C', 'B']);
+    });
+
+    it('omits routes with no snapshots in range', () => {
+      const tracker = build();
+      const ranked = tracker.compareRoutes(['A', 'unknown']);
+      expect(ranked.map((r) => r.routeId)).toEqual(['A']);
+    });
+  });
+
+  describe('retention and bounds', () => {
+    it('evicts oldest snapshots beyond maxSnapshotsPerRoute', () => {
+      const tracker = new RouteHealthHistoryTracker({ maxSnapshotsPerRoute: 3 });
+      for (let i = 0; i < 5; i++) {
+        tracker.record(
+          sample({ recordedAt: new Date(2026, 0, 1, 0, 0, i) }),
+        );
+      }
+      const history = tracker.getHistory('XLM->USDC');
+      expect(history).toHaveLength(3);
+      expect(history[0].recordedAt.getSeconds()).toBe(2);
+    });
+
+    it('prunes snapshots older than the retention window on write', () => {
+      const tracker = new RouteHealthHistoryTracker({ retentionMs: 60_000 });
+      const now = Date.now();
+      tracker.record(sample({ recordedAt: new Date(now - 120_000) }));
+      tracker.record(sample({ recordedAt: new Date(now) }));
+      expect(tracker.getHistory('XLM->USDC')).toHaveLength(1);
+    });
+  });
+
+  describe('clearing', () => {
+    it('clears a single route', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ routeId: 'A' }));
+      tracker.record(sample({ routeId: 'B' }));
+      expect(tracker.clearRoute('A')).toBe(true);
+      expect(tracker.getHistory('A')).toHaveLength(0);
+      expect(tracker.getHistory('B')).toHaveLength(1);
+    });
+
+    it('clears all routes', () => {
+      const tracker = new RouteHealthHistoryTracker();
+      tracker.record(sample({ routeId: 'A' }));
+      tracker.record(sample({ routeId: 'B' }));
+      tracker.clear();
+      expect(tracker.getTrackedRoutes()).toHaveLength(0);
+    });
+  });
+});

--- a/src/history/health/routes/stellar/index.ts
+++ b/src/history/health/routes/stellar/index.ts
@@ -1,0 +1,5 @@
+export * from './route-health-history';
+
+import { RouteHealthHistoryTracker } from './route-health-history';
+
+export const routeHealthHistoryTracker = new RouteHealthHistoryTracker();

--- a/src/history/health/routes/stellar/route-health-history.ts
+++ b/src/history/health/routes/stellar/route-health-history.ts
@@ -1,0 +1,329 @@
+import type { RouteHealthStatus } from '../../../../monitoring/routes/stellar/stellar-route-health-monitor';
+
+/**
+ * A single point-in-time health observation for a Stellar route. These are the
+ * raw records the tracker persists so that trends can be reconstructed later.
+ */
+export interface RouteHealthSnapshot {
+  routeId: string;
+  status: RouteHealthStatus;
+  availability: number;
+  latencyMs?: number;
+  consecutiveFailures?: number;
+  errorMessage?: string;
+  recordedAt: Date;
+}
+
+/**
+ * Input accepted when recording a snapshot. `recordedAt` is optional and
+ * defaults to the current time so callers can simply forward a health state.
+ */
+export interface RouteHealthSample {
+  routeId: string;
+  status: RouteHealthStatus;
+  availability: number;
+  latencyMs?: number;
+  consecutiveFailures?: number;
+  errorMessage?: string;
+  recordedAt?: Date;
+}
+
+export interface RouteHealthHistoryConfig {
+  /** Maximum number of snapshots kept per route. Oldest are evicted first. */
+  maxSnapshotsPerRoute?: number;
+  /** Snapshots older than this (in ms) are pruned on write. 0 disables. */
+  retentionMs?: number;
+}
+
+export interface HistoryQuery {
+  from?: Date;
+  to?: Date;
+  /** When set, only the most recent N (within the range) are returned. */
+  limit?: number;
+}
+
+/**
+ * Aggregated view of a route's health over a window of snapshots. Used to
+ * surface trends without forcing callers to crunch raw snapshots themselves.
+ */
+export interface RouteHealthTrend {
+  routeId: string;
+  sampleCount: number;
+  from?: Date;
+  to?: Date;
+  averageAvailability: number;
+  minAvailability: number;
+  maxAvailability: number;
+  averageLatencyMs: number | null;
+  uptimeRatio: number;
+  statusDistribution: Record<RouteHealthStatus, number>;
+  currentStatus: RouteHealthStatus | null;
+  /** Direction of availability change across the window. */
+  availabilityTrend: 'improving' | 'declining' | 'stable';
+}
+
+export interface RouteHealthComparison {
+  routeId: string;
+  sampleCount: number;
+  averageAvailability: number;
+  uptimeRatio: number;
+  averageLatencyMs: number | null;
+  currentStatus: RouteHealthStatus | null;
+  /** 1 = best ranked route in the comparison. */
+  rank: number;
+}
+
+const ALL_STATUSES: RouteHealthStatus[] = [
+  'healthy',
+  'degraded',
+  'unhealthy',
+  'outage',
+];
+
+/**
+ * Stores historical Stellar route health metrics and derives trends and
+ * cross-route comparisons from them. Storage is in-memory and bounded by the
+ * configured retention/size limits, mirroring the other in-memory history and
+ * monitoring modules in the codebase.
+ */
+export class RouteHealthHistoryTracker {
+  private readonly config: Required<RouteHealthHistoryConfig>;
+  private readonly snapshots = new Map<string, RouteHealthSnapshot[]>();
+
+  constructor(config: RouteHealthHistoryConfig = {}) {
+    this.config = {
+      maxSnapshotsPerRoute: config.maxSnapshotsPerRoute ?? 1000,
+      retentionMs: config.retentionMs ?? 0,
+    };
+  }
+
+  /** Records a single health observation for a route. */
+  record(sample: RouteHealthSample): RouteHealthSnapshot {
+    const snapshot: RouteHealthSnapshot = {
+      routeId: sample.routeId,
+      status: sample.status,
+      availability: clampAvailability(sample.availability),
+      latencyMs: sample.latencyMs,
+      consecutiveFailures: sample.consecutiveFailures,
+      errorMessage: sample.errorMessage,
+      recordedAt: sample.recordedAt ?? new Date(),
+    };
+
+    const series = this.snapshots.get(sample.routeId) ?? [];
+    series.push(snapshot);
+    series.sort((a, b) => a.recordedAt.getTime() - b.recordedAt.getTime());
+    this.prune(series);
+    this.snapshots.set(sample.routeId, series);
+
+    return snapshot;
+  }
+
+  /** Returns the raw snapshots for a route, optionally filtered by a query. */
+  getHistory(routeId: string, query: HistoryQuery = {}): RouteHealthSnapshot[] {
+    const series = this.snapshots.get(routeId) ?? [];
+    let result = series.filter((s) => withinRange(s.recordedAt, query));
+    if (query.limit !== undefined && query.limit >= 0) {
+      result = result.slice(-query.limit);
+    }
+    return result.map((s) => ({ ...s }));
+  }
+
+  /** Returns the most recent snapshot recorded for a route, if any. */
+  getLatest(routeId: string): RouteHealthSnapshot | null {
+    const series = this.snapshots.get(routeId);
+    if (!series || series.length === 0) {
+      return null;
+    }
+    return { ...series[series.length - 1] };
+  }
+
+  /** Lists every route that has at least one recorded snapshot. */
+  getTrackedRoutes(): string[] {
+    return Array.from(this.snapshots.keys());
+  }
+
+  /**
+   * Builds an aggregated health trend for a route over the given window.
+   * Returns null when there are no snapshots in range.
+   */
+  getTrend(routeId: string, query: HistoryQuery = {}): RouteHealthTrend | null {
+    const series = this.getHistory(routeId, query);
+    if (series.length === 0) {
+      return null;
+    }
+
+    const statusDistribution = emptyStatusDistribution();
+    let availabilitySum = 0;
+    let minAvailability = Number.POSITIVE_INFINITY;
+    let maxAvailability = Number.NEGATIVE_INFINITY;
+    let latencySum = 0;
+    let latencyCount = 0;
+    let healthyCount = 0;
+
+    for (const snapshot of series) {
+      statusDistribution[snapshot.status] += 1;
+      availabilitySum += snapshot.availability;
+      minAvailability = Math.min(minAvailability, snapshot.availability);
+      maxAvailability = Math.max(maxAvailability, snapshot.availability);
+      if (typeof snapshot.latencyMs === 'number') {
+        latencySum += snapshot.latencyMs;
+        latencyCount += 1;
+      }
+      if (snapshot.status === 'healthy') {
+        healthyCount += 1;
+      }
+    }
+
+    return {
+      routeId,
+      sampleCount: series.length,
+      from: series[0].recordedAt,
+      to: series[series.length - 1].recordedAt,
+      averageAvailability: availabilitySum / series.length,
+      minAvailability,
+      maxAvailability,
+      averageLatencyMs: latencyCount > 0 ? latencySum / latencyCount : null,
+      uptimeRatio: healthyCount / series.length,
+      statusDistribution,
+      currentStatus: series[series.length - 1].status,
+      availabilityTrend: computeAvailabilityTrend(series),
+    };
+  }
+
+  /**
+   * Ranks the supplied routes (or all tracked routes) by health over the
+   * window. Routes are ordered by average availability, then uptime ratio,
+   * then lower latency. Routes without snapshots in range are omitted.
+   */
+  compareRoutes(
+    routeIds?: string[],
+    query: HistoryQuery = {},
+  ): RouteHealthComparison[] {
+    const ids = routeIds ?? this.getTrackedRoutes();
+    const comparisons: RouteHealthComparison[] = [];
+
+    for (const routeId of ids) {
+      const trend = this.getTrend(routeId, query);
+      if (!trend) {
+        continue;
+      }
+      comparisons.push({
+        routeId,
+        sampleCount: trend.sampleCount,
+        averageAvailability: trend.averageAvailability,
+        uptimeRatio: trend.uptimeRatio,
+        averageLatencyMs: trend.averageLatencyMs,
+        currentStatus: trend.currentStatus,
+        rank: 0,
+      });
+    }
+
+    comparisons.sort((a, b) => {
+      if (b.averageAvailability !== a.averageAvailability) {
+        return b.averageAvailability - a.averageAvailability;
+      }
+      if (b.uptimeRatio !== a.uptimeRatio) {
+        return b.uptimeRatio - a.uptimeRatio;
+      }
+      const latencyA = a.averageLatencyMs ?? Number.POSITIVE_INFINITY;
+      const latencyB = b.averageLatencyMs ?? Number.POSITIVE_INFINITY;
+      return latencyA - latencyB;
+    });
+
+    comparisons.forEach((comparison, index) => {
+      comparison.rank = index + 1;
+    });
+
+    return comparisons;
+  }
+
+  /** Removes history for a single route. Returns true if anything was removed. */
+  clearRoute(routeId: string): boolean {
+    return this.snapshots.delete(routeId);
+  }
+
+  /** Removes all recorded history across every route. */
+  clear(): void {
+    this.snapshots.clear();
+  }
+
+  private prune(series: RouteHealthSnapshot[]): void {
+    if (this.config.retentionMs > 0) {
+      const cutoff = Date.now() - this.config.retentionMs;
+      let removable = 0;
+      while (
+        removable < series.length &&
+        series[removable].recordedAt.getTime() < cutoff
+      ) {
+        removable += 1;
+      }
+      if (removable > 0) {
+        series.splice(0, removable);
+      }
+    }
+
+    const overflow = series.length - this.config.maxSnapshotsPerRoute;
+    if (overflow > 0) {
+      series.splice(0, overflow);
+    }
+  }
+}
+
+function clampAvailability(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function withinRange(recordedAt: Date, query: HistoryQuery): boolean {
+  if (query.from && recordedAt < query.from) {
+    return false;
+  }
+  if (query.to && recordedAt > query.to) {
+    return false;
+  }
+  return true;
+}
+
+function emptyStatusDistribution(): Record<RouteHealthStatus, number> {
+  return ALL_STATUSES.reduce(
+    (acc, status) => {
+      acc[status] = 0;
+      return acc;
+    },
+    {} as Record<RouteHealthStatus, number>,
+  );
+}
+
+function computeAvailabilityTrend(
+  series: RouteHealthSnapshot[],
+): 'improving' | 'declining' | 'stable' {
+  if (series.length < 2) {
+    return 'stable';
+  }
+
+  const mid = Math.floor(series.length / 2);
+  const firstHalf = series.slice(0, mid);
+  const secondHalf = series.slice(mid);
+
+  const firstAvg = average(firstHalf.map((s) => s.availability));
+  const secondAvg = average(secondHalf.map((s) => s.availability));
+  const delta = secondAvg - firstAvg;
+
+  const threshold = 0.01;
+  if (delta > threshold) {
+    return 'improving';
+  }
+  if (delta < -threshold) {
+    return 'declining';
+  }
+  return 'stable';
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}


### PR DESCRIPTION
Closes #557 

## 🧠 Concept
Analyze user feedback on route recommendations so the signal users give (ratings, acceptance, comments) is turned into aggregated metrics, actionable recommendation insights, and trend reports.

## ⚠️ Problem
Feedback data on route recommendations was collected but not utilized effectively — there was no way to aggregate it, surface which recommended routes users actually value, or track how sentiment changes over time.

## 📁 Implementation Scope
`src/analytics/feedback/routes/stellar/`

| File | Purpose |
| --- | --- |
| `route-feedback-analyzer.ts` | Core `StellarRouteFeedbackAnalyzer` plus the feedback/aggregate/insight/trend types. |
| `index.ts` | Re-exports the module and provides a shared `stellarRouteFeedbackAnalyzer` singleton. |
| `route-feedback-analyzer.spec.ts` | Unit tests covering recording, aggregation, insights, trend reports, and clearing. |

## ✨ What's included

### Aggregate feedback data
- `recordFeedback(input)` validates and normalizes a `RouteFeedbackEntry` (routeId, rating 1–5, accepted flag, optional asset pair / recommendationId / userId / comment, timestamp).
- Storage is in-memory and bounded by `keepMaxEntries` (oldest evicted first), mirroring the other `src/analytics/**/stellar` modules.
- `aggregateRoute(routeId, query)` / `aggregateAll(query)` produce per-route metrics: total feedback, average rating, acceptance rate, sentiment distribution (positive / neutral / negative), positive & negative rates, comment count, and last feedback time.
- Sentiment thresholds are configurable (`positiveRatingThreshold`, `negativeRatingThreshold`).

### Generate recommendation insights
- `generateInsights(query, options)` returns:
  - `topRoutes` — best-rated recommended routes.
  - `underperformingRoutes` — worst-rated routes.
  - `routesNeedingAttention` — routes with enough feedback but negative sentiment or low acceptance.
  - feedback-weighted `overallAverageRating` and `overallAcceptanceRate`, plus `totalFeedback`.
- Each insight carries a human-readable `recommendation` string (e.g. keep prioritizing, investigate low acceptance, de-prioritize).

### Produce trend reports
- `generateTrendReport(options)` buckets feedback into fixed time windows (default 24h), scoped to a single route or all routes.
- Each bucket reports total feedback, average rating, acceptance rate, and sentiment distribution.
- Derives `ratingTrend` and `acceptanceTrend` (`improving` / `declining` / `stable`) by comparing the first and second halves of the populated buckets.

### Housekeeping
- `getFeedback`, `getRoutesWithFeedback`, `clearRoute`, and `clear` for inspection and cleanup.

## 🎯 Acceptance Criteria
- ✅ Feedback analytics implemented (`StellarRouteFeedbackAnalyzer`).
- ✅ Reports generated successfully (`aggregateAll`, `generateInsights`, `generateTrendReport`).

## 🧪 Testing
`route-feedback-analyzer.spec.ts` covers:
- Recording: normalization, default timestamps, validation (empty routeId, out-of-range ratings), empty-comment handling, and max-entry eviction.
- Aggregation: rating/acceptance/sentiment metrics, comment counts, null when empty, and date-range filtering.
- Insights: top/underperforming routes, attention flagging, feedback-weighted overall metrics, and the empty-feedback case.
- Trend reports: time bucketing (including empty buckets), improving-trend detection, invalid bucket size rejection, and the empty case.
- Clearing a single route and all feedback.

Run with:

```bash
npx jest src/analytics/feedback/routes/stellar
```

> Note: the suite was authored to match the repo's Jest config but has not yet been executed locally — `node_modules` is not installed in this environment. Run `npm install` then the command above to verify.

## 🔗 Notes
In-memory storage follows the existing analytics modules (`src/analytics/throughput/stellar`, `src/analytics/congestion/stellar`). The analyzer can be fed from whatever surface collects user feedback on recommendations.
