### PR TITLE
feat(scoring): fix #548 by implementing stellar route quality scoring engine

### DIFF
--- a/src/scoring/routes/quality/stellar/__tests__/index.test.ts
+++ b/src/scoring/routes/quality/stellar/__tests__/index.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect } from '@jest/globals';
+import { calculateQualityScores, RouteWithMetrics, ScoredRoute } from '../index';
+
+interface MockRoute {
+  id: string;
+}
+
+describe('calculateQualityScores', () => {
+  it('returns an empty array when given no routes', () => {
+    expect(calculateQualityScores([])).toEqual([]);
+  });
+
+  it('returns a perfect score of 1.0 when given a single route', () => {
+    const routes: RouteWithMetrics<MockRoute>[] = [
+      { route: { id: 'route1' }, metrics: { latencyMs: 100, reliabilityScore: 0.9, feeStroops: 1000 } }
+    ];
+    const result = calculateQualityScores(routes);
+    expect(result).toHaveLength(1);
+    expect(result[0].qualityScore).toBe(1.0);
+  });
+
+  it('correctly scores routes with varying latency, reliability, and fees', () => {
+    const routes: RouteWithMetrics<MockRoute>[] = [
+      { route: { id: 'best-all-around' }, metrics: { latencyMs: 100, reliabilityScore: 0.99, feeStroops: 1000 } },
+      { route: { id: 'worst-all-around' }, metrics: { latencyMs: 500, reliabilityScore: 0.50, feeStroops: 5000 } },
+      { route: { id: 'mixed' }, metrics: { latencyMs: 300, reliabilityScore: 0.75, feeStroops: 3000 } }
+    ];
+
+    const result = calculateQualityScores(routes);
+    expect(result).toHaveLength(3);
+
+    const best = result.find(r => r.route.id === 'best-all-around');
+    const worst = result.find(r => r.route.id === 'worst-all-around');
+    const mixed = result.find(r => r.route.id === 'mixed');
+
+    expect(best?.qualityScore).toBe(1.0); // 1.0 on all normalized metrics
+    expect(worst?.qualityScore).toBe(0.0); // 0.0 on all normalized metrics
+    expect(mixed?.qualityScore).toBeCloseTo(0.5, 2); // exactly in the middle
+  });
+
+  it('handles missing metrics gracefully without penalizing out of proportion', () => {
+    const routes: RouteWithMetrics<MockRoute>[] = [
+      { route: { id: 'no-fee' }, metrics: { latencyMs: 200, reliabilityScore: 0.8 } }, // Fee missing -> defaults to 0.5 for fee
+      { route: { id: 'all-metrics' }, metrics: { latencyMs: 100, reliabilityScore: 0.9, feeStroops: 1000 } },
+      { route: { id: 'all-metrics-bad' }, metrics: { latencyMs: 300, reliabilityScore: 0.7, feeStroops: 2000 } }
+    ];
+
+    const result = calculateQualityScores(routes);
+    expect(result).toHaveLength(3);
+
+    const noFeeRoute = result.find(r => r.route.id === 'no-fee');
+    expect(noFeeRoute?.qualityScore).toBeDefined();
+
+    // Latency 200 is perfectly in middle -> 0.5
+    // Reliability 0.8 is perfectly in middle -> 0.5
+    // Fee is missing -> defaults to 0.5
+    expect(noFeeRoute?.qualityScore).toBeCloseTo(0.5, 2);
+  });
+
+  it('normalizes properly when all metrics are exactly the same', () => {
+    const routes: RouteWithMetrics<MockRoute>[] = [
+      { route: { id: 'route1' }, metrics: { latencyMs: 100, reliabilityScore: 0.9, feeStroops: 1000 } },
+      { route: { id: 'route2' }, metrics: { latencyMs: 100, reliabilityScore: 0.9, feeStroops: 1000 } },
+      { route: { id: 'route3' }, metrics: { latencyMs: 100, reliabilityScore: 0.9, feeStroops: 1000 } }
+    ];
+
+    const result = calculateQualityScores(routes);
+    expect(result).toHaveLength(3);
+
+    result.forEach(route => {
+      // Because min === max, they get 1.0 normalized value
+      expect(route.qualityScore).toBe(1.0);
+    });
+  });
+
+  it('supports custom weights', () => {
+    const routes: RouteWithMetrics<MockRoute>[] = [
+      { route: { id: 'low-latency-high-fee' }, metrics: { latencyMs: 10, reliabilityScore: 0.9, feeStroops: 10000 } },
+      { route: { id: 'high-latency-low-fee' }, metrics: { latencyMs: 1000, reliabilityScore: 0.9, feeStroops: 100 } }
+    ];
+
+    // Favor latency heavily
+    const latencyHeavyWeights = { latency: 0.9, reliability: 0.05, fee: 0.05 };
+    const resultLatencyHeavy = calculateQualityScores(routes, latencyHeavyWeights);
+    
+    expect(resultLatencyHeavy.find(r => r.route.id === 'low-latency-high-fee')!.qualityScore).toBeGreaterThan(
+      resultLatencyHeavy.find(r => r.route.id === 'high-latency-low-fee')!.qualityScore
+    );
+
+    // Favor fee heavily
+    const feeHeavyWeights = { latency: 0.05, reliability: 0.05, fee: 0.9 };
+    const resultFeeHeavy = calculateQualityScores(routes, feeHeavyWeights);
+    
+    expect(resultFeeHeavy.find(r => r.route.id === 'high-latency-low-fee')!.qualityScore).toBeGreaterThan(
+      resultFeeHeavy.find(r => r.route.id === 'low-latency-high-fee')!.qualityScore
+    );
+  });
+});

--- a/src/scoring/routes/quality/stellar/index.ts
+++ b/src/scoring/routes/quality/stellar/index.ts
@@ -1,0 +1,143 @@
+export interface RouteQualityMetrics {
+  latencyMs?: number;
+  reliabilityScore?: number;
+  feeStroops?: number;
+}
+
+export interface RouteWithMetrics<T> {
+  route: T;
+  metrics: RouteQualityMetrics;
+}
+
+export interface ScoredRoute<T> extends RouteWithMetrics<T> {
+  qualityScore: number;
+}
+
+export interface QualityWeights {
+  latency: number;
+  reliability: number;
+  fee: number;
+}
+
+const DEFAULT_WEIGHTS: QualityWeights = {
+  reliability: 0.4,
+  fee: 0.4,
+  latency: 0.2,
+};
+
+/**
+ * Generates holistic quality scores for Stellar bridge routes.
+ * Optimized for O(N) time and O(1) extra space complexity (excluding output) by using a two-pass approach.
+ * 
+ * @param routes - Array of routes containing their respective metrics
+ * @param weights - Optional custom weights for scoring (default: Reliability 40%, Fee 40%, Latency 20%)
+ * @returns Array of ScoredRoutes with computed quality scores
+ */
+export function calculateQualityScores<T>(
+  routes: RouteWithMetrics<T>[],
+  weights: QualityWeights = DEFAULT_WEIGHTS
+): ScoredRoute<T>[] {
+  if (routes.length === 0) return [];
+  if (routes.length === 1) {
+    return [{ ...routes[0], qualityScore: 1.0 }];
+  }
+
+  // Pass 1: Find min and max for each metric to use for normalization
+  // Space complexity: O(1)
+  // Time complexity: O(N)
+  let minLatency = Infinity, maxLatency = -Infinity;
+  let minReliability = Infinity, maxReliability = -Infinity;
+  let minFee = Infinity, maxFee = -Infinity;
+
+  let hasLatency = false, hasReliability = false, hasFee = false;
+
+  for (const r of routes) {
+    const { latencyMs, reliabilityScore, feeStroops } = r.metrics;
+    
+    if (latencyMs !== undefined) {
+      if (latencyMs < minLatency) minLatency = latencyMs;
+      if (latencyMs > maxLatency) maxLatency = latencyMs;
+      hasLatency = true;
+    }
+    
+    if (reliabilityScore !== undefined) {
+      if (reliabilityScore < minReliability) minReliability = reliabilityScore;
+      if (reliabilityScore > maxReliability) maxReliability = reliabilityScore;
+      hasReliability = true;
+    }
+    
+    if (feeStroops !== undefined) {
+      if (feeStroops < minFee) minFee = feeStroops;
+      if (feeStroops > maxFee) maxFee = feeStroops;
+      hasFee = true;
+    }
+  }
+
+  // Pass 2: Normalize values and calculate composite score
+  // Space complexity: O(N) for output array
+  // Time complexity: O(N)
+  const scoredRoutes: ScoredRoute<T>[] = [];
+
+  for (const r of routes) {
+    const { latencyMs, reliabilityScore, feeStroops } = r.metrics;
+
+    let latencyNorm = 0.5; // Neutral default
+    if (hasLatency && latencyMs !== undefined) {
+      if (maxLatency > minLatency) {
+        // Lower latency is better
+        latencyNorm = 1 - (latencyMs - minLatency) / (maxLatency - minLatency);
+      } else {
+        latencyNorm = 1.0;
+      }
+    }
+
+    let reliabilityNorm = 0.5;
+    if (hasReliability && reliabilityScore !== undefined) {
+      if (maxReliability > minReliability) {
+        // Higher reliability is better
+        reliabilityNorm = (reliabilityScore - minReliability) / (maxReliability - minReliability);
+      } else {
+        reliabilityNorm = 1.0;
+      }
+    }
+
+    let feeNorm = 0.5;
+    if (hasFee && feeStroops !== undefined) {
+      if (maxFee > minFee) {
+        // Lower fee is better
+        feeNorm = 1 - (feeStroops - minFee) / (maxFee - minFee);
+      } else {
+        feeNorm = 1.0;
+      }
+    }
+
+    // Calculate total applicable weights
+    let totalWeight = 0;
+    let score = 0;
+
+    if (latencyMs !== undefined) {
+      score += latencyNorm * weights.latency;
+      totalWeight += weights.latency;
+    }
+    
+    if (reliabilityScore !== undefined) {
+      score += reliabilityNorm * weights.reliability;
+      totalWeight += weights.reliability;
+    }
+    
+    if (feeStroops !== undefined) {
+      score += feeNorm * weights.fee;
+      totalWeight += weights.fee;
+    }
+
+    // If no metrics were provided, return a neutral score
+    const qualityScore = totalWeight > 0 ? score / totalWeight : 0.5;
+
+    scoredRoutes.push({
+      ...r,
+      qualityScore,
+    });
+  }
+
+  return scoredRoutes;
+}


### PR DESCRIPTION
closes #548 
# PR Description
This PR addresses issue #548 by introducing a comprehensive Stellar Route Quality Scoring Engine. Previously, downstream consumers and users had to manually evaluate disparate route metrics (latency, reliability, and varying fee constraints) to decide on optimal bridge execution paths. This change aggregates these metrics into a single, normalized `qualityScore` bound between 0.0 and 1.0. 

The implementation features an O(N) dual-pass mathematical normalization sequence to prioritize execution performance during heavy routing computations. Safe fallback handling ensures routes missing specific telemetry dimensions are neutralized gracefully without being artificially penalized.

# Changes Made
- Added `src/scoring/routes/quality/stellar/index.ts` to expose the new `calculateQualityScores` scoring engine.
- Implemented robust `O(N)` bounds mapping to resolve normalized weights for fees (stroops), latencies (ms), and success rates.
- Integrated `src/scoring/routes/quality/stellar/__tests__/index.test.ts` containing a full suite of unit test validators for metrics boundary evaluations and edge-case testing.
- # Testing
Unit tests were executed locally against the new components in the `jsdom` testing environment:
```bash
npx jest src/scoring/routes/quality/stellar/__tests__/index.test.ts
```
**Results:**
- `PASS src/scoring/routes/quality/stellar/__tests__/index.test.ts`
- 6 tests passed (100% of the suite). Functionality including custom weighting and boundary ties validated successfully.
- 