### PR TITLE
feat: implement Soroban provider status aggregator

### DIFF
--- a/src/status/providers/stellar/index.ts
+++ b/src/status/providers/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./statusAggregator";

--- a/src/status/providers/stellar/statusAggregator.test.ts
+++ b/src/status/providers/stellar/statusAggregator.test.ts
@@ -1,0 +1,52 @@
+import { SorobanProviderStatusAggregator } from "./statusAggregator";
+import { RawProviderStatus } from "./types";
+
+describe("SorobanProviderStatusAggregator", () => {
+  const aggregator = new SorobanProviderStatusAggregator();
+
+  const statuses: RawProviderStatus[] = [
+    { providerId: "provider-a", state: "OK", latency: 120 },
+    { providerId: "provider-b", state: "degraded", errorRate: 0.1 },
+    { providerId: "provider-c", state: "offline" },
+    { providerId: "provider-d", state: "unknown-value" },
+  ];
+
+  it("normalizes varied status formats into canonical states", () => {
+    const normalized = aggregator.collect(statuses);
+
+    expect(normalized.map((s) => s.state)).toEqual([
+      "operational",
+      "degraded",
+      "down",
+      "down",
+    ]);
+  });
+
+  it("defaults missing latency and error rate to zero", () => {
+    const normalized = aggregator.normalize({
+      providerId: "provider-x",
+      state: "healthy",
+    });
+
+    expect(normalized.latency).toBe(0);
+    expect(normalized.errorRate).toBe(0);
+    expect(normalized.state).toBe("operational");
+  });
+
+  it("generates a health summary", () => {
+    const summary = aggregator.summarize(statuses);
+
+    expect(summary.total).toBe(4);
+    expect(summary.operational).toBe(1);
+    expect(summary.degraded).toBe(1);
+    expect(summary.down).toBe(2);
+    expect(summary.healthScore).toBeCloseTo(0.375);
+  });
+
+  it("returns a zero health score for no providers", () => {
+    const summary = aggregator.summarize([]);
+
+    expect(summary.total).toBe(0);
+    expect(summary.healthScore).toBe(0);
+  });
+});

--- a/src/status/providers/stellar/statusAggregator.ts
+++ b/src/status/providers/stellar/statusAggregator.ts
@@ -1,0 +1,70 @@
+import {
+  HealthSummary,
+  NormalizedProviderStatus,
+  ProviderState,
+  RawProviderStatus,
+} from "./types";
+
+const STATE_ALIASES: Record<string, ProviderState> = {
+  operational: "operational",
+  ok: "operational",
+  healthy: "operational",
+  up: "operational",
+  online: "operational",
+  degraded: "degraded",
+  partial: "degraded",
+  slow: "degraded",
+  down: "down",
+  offline: "down",
+  unavailable: "down",
+  error: "down",
+};
+
+export class SorobanProviderStatusAggregator {
+  normalize(raw: RawProviderStatus): NormalizedProviderStatus {
+    return {
+      providerId: raw.providerId,
+      state: this.normalizeState(raw.state),
+      latency: raw.latency ?? 0,
+      errorRate: raw.errorRate ?? 0,
+    };
+  }
+
+  collect(
+    statuses: RawProviderStatus[]
+  ): NormalizedProviderStatus[] {
+    return statuses.map((status) => this.normalize(status));
+  }
+
+  summarize(statuses: RawProviderStatus[]): HealthSummary {
+    const normalized = this.collect(statuses);
+
+    const operational = normalized.filter(
+      (status) => status.state === "operational"
+    ).length;
+    const degraded = normalized.filter(
+      (status) => status.state === "degraded"
+    ).length;
+    const down = normalized.filter(
+      (status) => status.state === "down"
+    ).length;
+
+    const total = normalized.length;
+    const healthScore =
+      total > 0
+        ? (operational + degraded * 0.5) / total
+        : 0;
+
+    return {
+      total,
+      operational,
+      degraded,
+      down,
+      healthScore,
+    };
+  }
+
+  private normalizeState(state: string): ProviderState {
+    return STATE_ALIASES[state.trim().toLowerCase()] ?? "down";
+  }
+}

--- a/src/status/providers/stellar/types.ts
+++ b/src/status/providers/stellar/types.ts
@@ -1,0 +1,23 @@
+export type ProviderState = "operational" | "degraded" | "down";
+
+export interface RawProviderStatus {
+  providerId: string;
+  state: string;
+  latency?: number;
+  errorRate?: number;
+}
+
+export interface NormalizedProviderStatus {
+  providerId: string;
+  state: ProviderState;
+  latency: number;
+  errorRate: number;
+}
+
+export interface HealthSummary {
+  total: number;
+  operational: number;
+  degraded: number;
+  down: number;
+  healthScore: number;
+}


### PR DESCRIPTION
## 🧠 Overview
Aggregates fragmented Soroban/Stellar provider status data into a unified, normalized view with health summaries.

Closes #551

## 📁 Implementation Scope
`src/status/providers/stellar/`

## 🔧 What's Included
- **`types.ts`** — `ProviderState`, `RawProviderStatus`, `NormalizedProviderStatus`, `HealthSummary`
- **`statusAggregator.ts`** — `SorobanProviderStatusAggregator`:
  - `normalize()` — maps varied vendor status strings to canonical `operational` / `degraded` / `down`
  - `collect()` — normalizes a batch of provider statuses
  - `summarize()` — aggregates counts and computes a weighted `healthScore`
- **`statusAggregator.test.ts`** — normalization, field defaults, summary math, empty-input edge case
- **`index.ts`** — barrel exports
