### PR TITLE
Metadata Verifier for Stellar Asset & Provider Metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -769,7 +769,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -782,7 +782,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2247,7 +2247,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2268,7 +2268,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2994,61 +2994,6 @@
         "sodium-native": "^4.3.3"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3201,28 +3146,28 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/aria-query": {
@@ -3448,7 +3393,7 @@
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4055,7 +4000,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4101,7 +4046,7 @@
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
       "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -4296,7 +4241,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -5221,7 +5166,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cron": {
@@ -5496,7 +5441,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -9322,7 +9267,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -11921,7 +11866,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -12282,7 +12227,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12358,7 +12303,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -12460,7 +12405,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -12551,53 +12496,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/webpack": {
-      "version": "5.107.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
-      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.0",
-        "es-module-lexer": "^2.1.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.2",
-        "mime-db": "^1.54.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.5.0",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.5.0"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-node-externals": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-3.0.0.tgz",
@@ -12615,105 +12513,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -12984,7 +12783,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/src/verification/metadata/stellar/__tests__/metadata-verifier.service.spec.ts
+++ b/src/verification/metadata/stellar/__tests__/metadata-verifier.service.spec.ts
@@ -1,0 +1,289 @@
+import { MetadataVerifier } from '../metadata-verifier.service';
+import type {
+  AssetMetadataRecord,
+  ProviderMetadataRecord,
+} from '../metadata-verifier.types';
+
+describe('MetadataVerifier', () => {
+  const validAsset: AssetMetadataRecord = {
+    assetCode: 'USDC',
+    issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5ZG34M6656Y',
+    decimals: 7,
+    symbol: 'USDC',
+    source: 'horizon',
+    retrievedAt: 1000,
+  };
+
+  const validProvider: ProviderMetadataRecord = {
+    providerId: 'soroswap',
+    providerName: 'SoroSwap',
+    endpoint: 'https://soroswap.io',
+    network: 'mainnet',
+    version: '1.0.0',
+    supportedAssets: ['XLM', 'USDC'],
+    status: 'active',
+    createdAt: 100,
+    updatedAt: 200,
+  };
+
+  let verifier: MetadataVerifier;
+
+  beforeEach(() => {
+    verifier = new MetadataVerifier();
+  });
+
+  describe('validateAssetMetadata', () => {
+    it('passes valid asset metadata', () => {
+      const result = verifier.validateAssetMetadata(validAsset);
+      expect(result.isValid).toBe(true);
+      expect(result.fieldErrors).toHaveLength(0);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('fails on missing assetCode', () => {
+      const result = verifier.validateAssetMetadata({ ...validAsset, assetCode: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].field).toBe('assetCode');
+    });
+
+    it('fails on invalid assetCode format', () => {
+      const result = verifier.validateAssetMetadata({ ...validAsset, assetCode: 'TOO_LONG_ASSET_CODE_123' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].type).toBe('invalid_format');
+    });
+
+    it('fails on missing issuer', () => {
+      const result = verifier.validateAssetMetadata({ ...validAsset, issuer: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].field).toBe('issuer');
+    });
+
+    it('fails on invalid issuer format', () => {
+      const result = verifier.validateAssetMetadata({ ...validAsset, issuer: 'not-a-valid-key' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].type).toBe('invalid_format');
+    });
+
+    it('fails on missing decimals', () => {
+      const result = verifier.validateAssetMetadata({ ...validAsset, decimals: undefined as unknown as number });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.some((e) => e.field === 'decimals')).toBe(true);
+    });
+
+    it('fails on negative decimals', () => {
+      const result = verifier.validateAssetMetadata({ ...validAsset, decimals: -1 });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].field).toBe('decimals');
+    });
+
+    it('warns on unusually high decimals', () => {
+      const result = verifier.validateAssetMetadata({ ...validAsset, decimals: 18 });
+      expect(result.isValid).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0].field).toBe('decimals');
+    });
+
+    it('fails on missing symbol', () => {
+      const result = verifier.validateAssetMetadata({ ...validAsset, symbol: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.some((e) => e.field === 'symbol')).toBe(true);
+    });
+
+    it('returns all field errors for completely empty asset', () => {
+      const result = verifier.validateAssetMetadata({
+        assetCode: '',
+        issuer: '',
+        decimals: undefined as unknown as number,
+        symbol: '',
+        source: '',
+        retrievedAt: 0,
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+
+  describe('validateProviderMetadata', () => {
+    it('passes valid provider metadata', () => {
+      const result = verifier.validateProviderMetadata(validProvider);
+      expect(result.isValid).toBe(true);
+      expect(result.fieldErrors).toHaveLength(0);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('fails on missing providerId', () => {
+      const result = verifier.validateProviderMetadata({ ...validProvider, providerId: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.some((e) => e.field === 'providerId')).toBe(true);
+    });
+
+    it('fails on missing providerName', () => {
+      const result = verifier.validateProviderMetadata({ ...validProvider, providerName: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.some((e) => e.field === 'providerName')).toBe(true);
+    });
+
+    it('fails on missing endpoint', () => {
+      const result = verifier.validateProviderMetadata({ ...validProvider, endpoint: '' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.some((e) => e.field === 'endpoint')).toBe(true);
+    });
+
+    it('fails on invalid endpoint URL', () => {
+      const result = verifier.validateProviderMetadata({ ...validProvider, endpoint: 'not-a-url' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].type).toBe('invalid_format');
+    });
+
+    it('fails on invalid network', () => {
+      const result = verifier.validateProviderMetadata({ ...validProvider, network: 'unknown' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].type).toBe('invalid_network');
+    });
+
+    it('warns on non-semver version', () => {
+      const result = verifier.validateProviderMetadata({ ...validProvider, version: 'v1.0' });
+      expect(result.isValid).toBe(true);
+      expect(result.warnings.some((e) => e.type === 'version_mismatch')).toBe(true);
+    });
+
+    it('fails on empty supportedAssets', () => {
+      const result = verifier.validateProviderMetadata({ ...validProvider, supportedAssets: [] });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.some((e) => e.field === 'supportedAssets')).toBe(true);
+    });
+
+    it('fails on invalid status', () => {
+      const result = verifier.validateProviderMetadata({ ...validProvider, status: 'unknown' as 'active' });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].type).toBe('invalid_status');
+    });
+
+    it('fails when updatedAt is before createdAt', () => {
+      const result = verifier.validateProviderMetadata({
+        ...validProvider,
+        createdAt: 200,
+        updatedAt: 100,
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors[0].type).toBe('timestamp_anomaly');
+    });
+  });
+
+  describe('compareAssetMetadata', () => {
+    const target: AssetMetadataRecord = {
+      assetCode: 'USDC',
+      issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5ZG34M6656Y',
+      decimals: 7,
+      symbol: 'USDC',
+      source: 'provider',
+      retrievedAt: 2000,
+    };
+
+    it('returns match for identical metadata', () => {
+      const result = verifier.compareAssetMetadata(validAsset, { ...target });
+      expect(result.matches).toBe(true);
+      expect(result.inconsistencies).toHaveLength(0);
+    });
+
+    it('detects assetCode mismatch', () => {
+      const result = verifier.compareAssetMetadata(validAsset, { ...target, assetCode: 'USDT' });
+      expect(result.matches).toBe(false);
+      expect(result.inconsistencies[0].type).toBe('asset_code_mismatch');
+    });
+
+    it('detects issuer mismatch', () => {
+      const result = verifier.compareAssetMetadata(validAsset, {
+        ...target,
+        issuer: 'GBSTRH4QOTWNSVA6E4HFJRPTD5EPPA6G5CJ3LJ4Z6XJZJ6XJZJ6XJZJ6',
+      });
+      expect(result.matches).toBe(false);
+      expect(result.inconsistencies[0].type).toBe('issuer_mismatch');
+    });
+
+    it('detects decimals mismatch', () => {
+      const result = verifier.compareAssetMetadata(validAsset, { ...target, decimals: 6 });
+      expect(result.matches).toBe(false);
+      expect(result.inconsistencies[0].type).toBe('decimals_mismatch');
+    });
+
+    it('detects symbol mismatch', () => {
+      const result = verifier.compareAssetMetadata(validAsset, { ...target, symbol: 'USD Coin' });
+      expect(result.matches).toBe(false);
+      expect(result.inconsistencies[0].type).toBe('symbol_mismatch');
+    });
+
+    it('reports all mismatches when nothing matches', () => {
+      const result = verifier.compareAssetMetadata(validAsset, {
+        ...target,
+        assetCode: 'BTC',
+        issuer: 'GABC',
+        decimals: 8,
+        symbol: 'BITCOIN',
+      });
+      expect(result.matches).toBe(false);
+      expect(result.inconsistencies).toHaveLength(4);
+    });
+  });
+
+  describe('generateReport', () => {
+    it('generates a correct report with valid results', () => {
+      const assetResult = verifier.validateAssetMetadata(validAsset);
+      const providerResult = verifier.validateProviderMetadata(validProvider);
+      const comparison = verifier.compareAssetMetadata(validAsset, validAsset);
+
+      const report = verifier.generateReport(
+        [assetResult],
+        [providerResult],
+        [comparison],
+      );
+
+      expect(report.totalVerified).toBe(3);
+      expect(report.totalValid).toBe(3);
+      expect(report.totalInvalid).toBe(0);
+      expect(report.totalWarnings).toBe(0);
+      expect(report.totalInconsistencies).toBe(0);
+    });
+
+    it('generates a correct report with invalid results', () => {
+      const badAsset = verifier.validateAssetMetadata({ ...validAsset, assetCode: '' });
+      const badProvider = verifier.validateProviderMetadata({ ...validProvider, network: 'bad' });
+      const badComparison = verifier.compareAssetMetadata(
+        validAsset,
+        { ...validAsset, assetCode: 'DIFF' },
+      );
+
+      const report = verifier.generateReport(
+        [badAsset],
+        [badProvider],
+        [badComparison],
+      );
+
+      expect(report.totalVerified).toBe(3);
+      expect(report.totalValid).toBe(0);
+      expect(report.totalInvalid).toBe(3);
+      expect(report.totalWarnings).toBe(0);
+      expect(report.totalInconsistencies).toBe(1);
+    });
+
+    it('sets verifiedAt timestamp', () => {
+      const report = verifier.generateReport([], [], []);
+      expect(report.verifiedAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe('constructor', () => {
+    it('accepts custom config', () => {
+      const custom = new MetadataVerifier({
+        allowedNetworks: ['customnet'],
+        maxAssetCodeLength: 4,
+      });
+      const result = custom.validateProviderMetadata({
+        ...validProvider,
+        network: 'customnet',
+        supportedAssets: ['ABCDE'],
+      });
+      expect(result.isValid).toBe(true);
+    });
+  });
+});

--- a/src/verification/metadata/stellar/index.ts
+++ b/src/verification/metadata/stellar/index.ts
@@ -1,0 +1,13 @@
+export { MetadataVerifier } from './metadata-verifier.service';
+export type {
+  AssetMetadataRecord,
+  ProviderMetadataRecord,
+  AssetMetadataVerificationResult,
+  ProviderMetadataVerificationResult,
+  MetadataComparisonResult,
+  MetadataInconsistency,
+  MetadataInconsistencyType,
+  MetadataVerifierConfig,
+  MetadataVerificationReport,
+} from './metadata-verifier.types';
+export { MetadataInconsistencyType as MetadataInconsistencyTypeEnum } from './metadata-verifier.types';

--- a/src/verification/metadata/stellar/metadata-verifier.service.ts
+++ b/src/verification/metadata/stellar/metadata-verifier.service.ts
@@ -1,0 +1,442 @@
+import {
+  AssetMetadataRecord,
+  ProviderMetadataRecord,
+  AssetMetadataVerificationResult,
+  ProviderMetadataVerificationResult,
+  MetadataComparisonResult,
+  MetadataInconsistency,
+  MetadataInconsistencyType,
+  MetadataVerifierConfig,
+  MetadataVerificationReport,
+} from './metadata-verifier.types';
+
+const STELLAR_ISSUER_REGEX = /^G[A-Z2-7]{55}$/;
+const SEMVER_REGEX = /^\d+\.\d+\.\d+$/;
+const STELLAR_ASSET_CODE_REGEX = /^[A-Za-z0-9]{1,12}$/;
+const URL_REGEX = /^https?:\/\/.+/;
+
+const DEFAULT_CONFIG: MetadataVerifierConfig = {
+  allowedNetworks: ['mainnet', 'testnet'],
+  maxAssetCodeLength: 12,
+  minAssetCodeLength: 1,
+  allowedStatuses: ['active', 'inactive', 'deprecated'] as const,
+};
+
+export class MetadataVerifier {
+  private readonly config: MetadataVerifierConfig;
+
+  constructor(config: Partial<MetadataVerifierConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  validateAssetMetadata(
+    asset: AssetMetadataRecord,
+  ): AssetMetadataVerificationResult {
+    const fieldErrors: MetadataInconsistency[] = [];
+    const warnings: MetadataInconsistency[] = [];
+
+    if (!asset.assetCode) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Asset code is required',
+          'assetCode',
+        ),
+      );
+    } else if (!STELLAR_ASSET_CODE_REGEX.test(asset.assetCode)) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_FORMAT,
+          'critical',
+          `Asset code "${asset.assetCode}" is invalid. Must be 1-12 alphanumeric characters`,
+          'assetCode',
+          '1-12 alphanumeric string',
+          asset.assetCode,
+        ),
+      );
+    }
+
+    if (!asset.issuer) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Issuer is required',
+          'issuer',
+        ),
+      );
+    } else if (!STELLAR_ISSUER_REGEX.test(asset.issuer)) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_FORMAT,
+          'critical',
+          `Issuer "${asset.issuer}" is not a valid Stellar public key`,
+          'issuer',
+          'G followed by 55 alphanumeric characters',
+          asset.issuer,
+        ),
+      );
+    }
+
+    if (asset.decimals === undefined || asset.decimals === null) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Decimals field is required',
+          'decimals',
+        ),
+      );
+    } else if (!Number.isInteger(asset.decimals) || asset.decimals < 0) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_FORMAT,
+          'critical',
+          `Decimals must be a non-negative integer, got ${asset.decimals}`,
+          'decimals',
+          'non-negative integer',
+          asset.decimals,
+        ),
+      );
+    } else if (asset.decimals > 7) {
+      warnings.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_FORMAT,
+          'warning',
+          `Decimals ${asset.decimals} is unusually high for a Stellar asset (max 7)`,
+          'decimals',
+          '0-7',
+          asset.decimals,
+        ),
+      );
+    }
+
+    if (!asset.symbol) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Symbol is required',
+          'symbol',
+        ),
+      );
+    }
+
+    if (asset.retrievedAt && asset.retrievedAt <= 0) {
+      warnings.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_FORMAT,
+          'warning',
+          'retrievedAt timestamp is not positive',
+          'retrievedAt',
+          'positive number',
+          asset.retrievedAt,
+        ),
+      );
+    }
+
+    return {
+      asset,
+      isValid: fieldErrors.length === 0,
+      fieldErrors,
+      warnings,
+    };
+  }
+
+  validateProviderMetadata(
+    provider: ProviderMetadataRecord,
+  ): ProviderMetadataVerificationResult {
+    const fieldErrors: MetadataInconsistency[] = [];
+    const warnings: MetadataInconsistency[] = [];
+
+    if (!provider.providerId) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Provider ID is required',
+          'providerId',
+        ),
+      );
+    }
+
+    if (!provider.providerName) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Provider name is required',
+          'providerName',
+        ),
+      );
+    }
+
+    if (!provider.endpoint) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Endpoint URL is required',
+          'endpoint',
+        ),
+      );
+    } else if (!URL_REGEX.test(provider.endpoint)) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_FORMAT,
+          'critical',
+          `Endpoint "${provider.endpoint}" is not a valid URL`,
+          'endpoint',
+          'valid http(s) URL',
+          provider.endpoint,
+        ),
+      );
+    }
+
+    if (!provider.network) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Network is required',
+          'network',
+        ),
+      );
+    } else if (!this.config.allowedNetworks.includes(provider.network)) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_NETWORK,
+          'critical',
+          `Network "${provider.network}" is not allowed. Allowed: ${this.config.allowedNetworks.join(', ')}`,
+          'network',
+          this.config.allowedNetworks.join(' | '),
+          provider.network,
+        ),
+      );
+    }
+
+    if (!provider.version) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'Version is required',
+          'version',
+        ),
+      );
+    } else if (!SEMVER_REGEX.test(provider.version)) {
+      warnings.push(
+        this.makeError(
+          MetadataInconsistencyType.VERSION_MISMATCH,
+          'warning',
+          `Version "${provider.version}" does not follow semver (x.y.z)`,
+          'version',
+          'semver x.y.z',
+          provider.version,
+        ),
+      );
+    }
+
+    if (!provider.supportedAssets || provider.supportedAssets.length === 0) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.MISSING_REQUIRED_FIELD,
+          'critical',
+          'At least one supported asset is required',
+          'supportedAssets',
+        ),
+      );
+    } else {
+      for (const asset of provider.supportedAssets) {
+        if (!STELLAR_ASSET_CODE_REGEX.test(asset)) {
+          warnings.push(
+            this.makeError(
+              MetadataInconsistencyType.INVALID_FORMAT,
+              'warning',
+              `Supported asset "${asset}" is not a valid Stellar asset code`,
+              'supportedAssets',
+              '1-12 alphanumeric characters',
+              asset,
+            ),
+          );
+        }
+      }
+    }
+
+    if (!this.config.allowedStatuses.includes(provider.status)) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_STATUS,
+          'critical',
+          `Status "${provider.status}" is not valid`,
+          'status',
+          this.config.allowedStatuses.join(' | '),
+          provider.status,
+        ),
+      );
+    }
+
+    if (provider.createdAt && provider.createdAt <= 0) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_FORMAT,
+          'critical',
+          'createdAt must be a positive timestamp',
+          'createdAt',
+          'positive number',
+          provider.createdAt,
+        ),
+      );
+    }
+
+    if (provider.updatedAt && provider.updatedAt <= 0) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.INVALID_FORMAT,
+          'critical',
+          'updatedAt must be a positive timestamp',
+          'updatedAt',
+          'positive number',
+          provider.updatedAt,
+        ),
+      );
+    }
+
+    if (
+      provider.createdAt &&
+      provider.updatedAt &&
+      provider.updatedAt < provider.createdAt
+    ) {
+      fieldErrors.push(
+        this.makeError(
+          MetadataInconsistencyType.TIMESTAMP_ANOMALY,
+          'critical',
+          'updatedAt is before createdAt',
+          'updatedAt',
+          provider.createdAt,
+          provider.updatedAt,
+        ),
+      );
+    }
+
+    return {
+      provider,
+      isValid: fieldErrors.length === 0,
+      fieldErrors,
+      warnings,
+    };
+  }
+
+  compareAssetMetadata(
+    source: AssetMetadataRecord,
+    target: AssetMetadataRecord,
+  ): MetadataComparisonResult {
+    const inconsistencies: MetadataInconsistency[] = [];
+
+    if (source.assetCode !== target.assetCode) {
+      inconsistencies.push(
+        this.makeError(
+          MetadataInconsistencyType.ASSET_CODE_MISMATCH,
+          'critical',
+          `Asset code mismatch: "${source.assetCode}" vs "${target.assetCode}"`,
+          'assetCode',
+          source.assetCode,
+          target.assetCode,
+        ),
+      );
+    }
+
+    if (source.issuer !== target.issuer) {
+      inconsistencies.push(
+        this.makeError(
+          MetadataInconsistencyType.ISSUER_MISMATCH,
+          'critical',
+          `Issuer mismatch: "${source.issuer}" vs "${target.issuer}"`,
+          'issuer',
+          source.issuer,
+          target.issuer,
+        ),
+      );
+    }
+
+    if (source.decimals !== target.decimals) {
+      inconsistencies.push(
+        this.makeError(
+          MetadataInconsistencyType.DECIMALS_MISMATCH,
+          'warning',
+          `Decimals mismatch: ${source.decimals} vs ${target.decimals}`,
+          'decimals',
+          source.decimals,
+          target.decimals,
+        ),
+      );
+    }
+
+    if (source.symbol !== target.symbol) {
+      inconsistencies.push(
+        this.makeError(
+          MetadataInconsistencyType.SYMBOL_MISMATCH,
+          'info',
+          `Symbol mismatch: "${source.symbol}" vs "${target.symbol}"`,
+          'symbol',
+          source.symbol,
+          target.symbol,
+        ),
+      );
+    }
+
+    return {
+      source,
+      target,
+      matches: inconsistencies.length === 0,
+      inconsistencies,
+    };
+  }
+
+  generateReport(
+    assetResults: AssetMetadataVerificationResult[],
+    providerResults: ProviderMetadataVerificationResult[],
+    comparisons: MetadataComparisonResult[],
+  ): MetadataVerificationReport {
+    const allWarnings = [
+      ...assetResults.flatMap((r) => r.warnings),
+      ...providerResults.flatMap((r) => r.warnings),
+    ];
+
+    const allInconsistencies = comparisons.flatMap((c) => c.inconsistencies);
+
+    const totalVerified =
+      assetResults.length + providerResults.length + comparisons.length;
+
+    const totalValid =
+      assetResults.filter((r) => r.isValid).length +
+      providerResults.filter((r) => r.isValid).length +
+      comparisons.filter((c) => c.matches).length;
+
+    const totalInvalid = totalVerified - totalValid;
+
+    return {
+      assetResults,
+      providerResults,
+      comparisons,
+      totalVerified,
+      totalValid,
+      totalInvalid,
+      totalWarnings: allWarnings.length,
+      totalInconsistencies: allInconsistencies.length,
+      verifiedAt: Date.now(),
+    };
+  }
+
+  private makeError(
+    type: MetadataInconsistencyType,
+    severity: MetadataInconsistency['severity'],
+    description: string,
+    field?: string,
+    expectedValue?: unknown,
+    actualValue?: unknown,
+  ): MetadataInconsistency {
+    return { type, severity, description, field, expectedValue, actualValue };
+  }
+}

--- a/src/verification/metadata/stellar/metadata-verifier.types.ts
+++ b/src/verification/metadata/stellar/metadata-verifier.types.ts
@@ -1,0 +1,87 @@
+export interface AssetMetadataRecord {
+  assetCode: string;
+  issuer: string;
+  decimals: number;
+  symbol: string;
+  name?: string;
+  logoURI?: string;
+  homeDomain?: string;
+  source: string;
+  retrievedAt: number;
+}
+
+export interface ProviderMetadataRecord {
+  providerId: string;
+  providerName: string;
+  endpoint: string;
+  network: string;
+  version: string;
+  supportedAssets: string[];
+  status: 'active' | 'inactive' | 'deprecated';
+  createdAt: number;
+  updatedAt: number;
+}
+
+export enum MetadataInconsistencyType {
+  MISSING_REQUIRED_FIELD = 'missing_required_field',
+  INVALID_FORMAT = 'invalid_format',
+  ASSET_CODE_MISMATCH = 'asset_code_mismatch',
+  ISSUER_MISMATCH = 'issuer_mismatch',
+  DECIMALS_MISMATCH = 'decimals_mismatch',
+  SYMBOL_MISMATCH = 'symbol_mismatch',
+  INVALID_NETWORK = 'invalid_network',
+  INVALID_STATUS = 'invalid_status',
+  TIMESTAMP_ANOMALY = 'timestamp_anomaly',
+  UNSUPPORTED_ASSET = 'unsupported_asset',
+  VERSION_MISMATCH = 'version_mismatch',
+  ASSET_NOT_FOUND_ON_CHAIN = 'asset_not_found_on_chain',
+}
+
+export interface MetadataInconsistency {
+  type: MetadataInconsistencyType;
+  severity: 'critical' | 'warning' | 'info';
+  description: string;
+  field?: string;
+  expectedValue?: unknown;
+  actualValue?: unknown;
+}
+
+export interface AssetMetadataVerificationResult {
+  asset: AssetMetadataRecord;
+  isValid: boolean;
+  fieldErrors: MetadataInconsistency[];
+  warnings: MetadataInconsistency[];
+}
+
+export interface ProviderMetadataVerificationResult {
+  provider: ProviderMetadataRecord;
+  isValid: boolean;
+  fieldErrors: MetadataInconsistency[];
+  warnings: MetadataInconsistency[];
+}
+
+export interface MetadataComparisonResult {
+  source: AssetMetadataRecord;
+  target: AssetMetadataRecord;
+  matches: boolean;
+  inconsistencies: MetadataInconsistency[];
+}
+
+export interface MetadataVerifierConfig {
+  allowedNetworks: string[];
+  maxAssetCodeLength: number;
+  minAssetCodeLength: number;
+  allowedStatuses: readonly string[];
+}
+
+export interface MetadataVerificationReport {
+  assetResults: AssetMetadataVerificationResult[];
+  providerResults: ProviderMetadataVerificationResult[];
+  comparisons: MetadataComparisonResult[];
+  totalVerified: number;
+  totalValid: number;
+  totalInvalid: number;
+  totalWarnings: number;
+  totalInconsistencies: number;
+  verifiedAt: number;
+}


### PR DESCRIPTION
 Implemented src/verification/metadata/stellar/ — a MetadataVerifier service that validates asset and provider metadata fields, detects cross-source inconsistencies, and generates verification reports. Three core capabilities:
validateAssetMetadata() — Validates Stellar asset codes (1-12 alphanum), issuer keys (G...), decimals range (0-7), and required fields validateProviderMetadata() — Validates provider ID, URL endpoint, network (mainnet/testnet), semver version, supported assets, status enum, and timestamp ordering compareAssetMetadata() + generateReport() — Cross-references two metadata sources and aggregates results into a report with valid/invalid/warning/inconsistency counts Follows the same patterns as the existing SorobanSettlementVerifier. 30 unit tests, all passing; lint clean.

Closed #607