### PR TITLE
feat: implement Soroban route latency predictor and Stellar asset tru…

### DIFF
--- a/src/predictions/latency/stellar/index.ts
+++ b/src/predictions/latency/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './latency-predictor.types';
+export * from './latency-predictor.service';

--- a/src/predictions/latency/stellar/latency-predictor.service.spec.ts
+++ b/src/predictions/latency/stellar/latency-predictor.service.spec.ts
@@ -1,0 +1,53 @@
+import { clearHistory, predictLatency, recordLatency } from './latency-predictor.service';
+
+beforeEach(() => clearHistory());
+
+describe('predictLatency', () => {
+  it('returns null when no history exists for route', () => {
+    expect(predictLatency('route-1')).toBeNull();
+  });
+
+  it('returns null when only failed records exist', () => {
+    recordLatency({ routeId: 'route-1', durationMs: 500, executedAt: new Date(), success: false });
+    expect(predictLatency('route-1')).toBeNull();
+  });
+
+  it('returns a prediction for a route with successful records', () => {
+    recordLatency({ routeId: 'route-1', durationMs: 400, executedAt: new Date(), success: true });
+    recordLatency({ routeId: 'route-1', durationMs: 600, executedAt: new Date(), success: true });
+
+    const result = predictLatency('route-1');
+    expect(result).not.toBeNull();
+    expect(result!.routeId).toBe('route-1');
+    expect(result!.estimatedMs).toBeGreaterThan(0);
+    expect(result!.sampleCount).toBe(2);
+  });
+
+  it('assigns low confidence with fewer than 3 samples', () => {
+    recordLatency({ routeId: 'route-1', durationMs: 500, executedAt: new Date(), success: true });
+    expect(predictLatency('route-1')!.confidence).toBe(0.3);
+  });
+
+  it('assigns medium confidence with 3-9 samples', () => {
+    for (let i = 0; i < 5; i++) {
+      recordLatency({ routeId: 'route-1', durationMs: 300 + i * 10, executedAt: new Date(), success: true });
+    }
+    expect(predictLatency('route-1')!.confidence).toBe(0.6);
+  });
+
+  it('assigns high confidence with 10+ samples', () => {
+    for (let i = 0; i < 10; i++) {
+      recordLatency({ routeId: 'route-1', durationMs: 200 + i * 5, executedAt: new Date(), success: true });
+    }
+    expect(predictLatency('route-1')!.confidence).toBe(0.9);
+  });
+
+  it('isolates predictions per route', () => {
+    recordLatency({ routeId: 'route-A', durationMs: 100, executedAt: new Date(), success: true });
+    recordLatency({ routeId: 'route-B', durationMs: 1000, executedAt: new Date(), success: true });
+
+    const a = predictLatency('route-A')!;
+    const b = predictLatency('route-B')!;
+    expect(a.estimatedMs).toBeLessThan(b.estimatedMs);
+  });
+});

--- a/src/predictions/latency/stellar/latency-predictor.service.ts
+++ b/src/predictions/latency/stellar/latency-predictor.service.ts
@@ -1,0 +1,47 @@
+import { LatencyPrediction, RouteLatencyRecord } from './latency-predictor.types';
+
+const MIN_SAMPLES_FOR_HIGH_CONFIDENCE = 10;
+const MIN_SAMPLES_FOR_MEDIUM_CONFIDENCE = 3;
+
+const history: RouteLatencyRecord[] = [];
+
+export function recordLatency(record: RouteLatencyRecord): void {
+  history.push(record);
+}
+
+export function predictLatency(routeId: string): LatencyPrediction | null {
+  const records = history.filter(r => r.routeId === routeId && r.success);
+
+  if (records.length === 0) {
+    return null;
+  }
+
+  const durations = records.map(r => r.durationMs);
+  const mean = durations.reduce((a, b) => a + b, 0) / durations.length;
+
+  // Weight recent records more heavily (exponential moving average)
+  const ema = durations.reduce((acc, val, i) => {
+    const alpha = 2 / (durations.length + 1);
+    return i === 0 ? val : acc * (1 - alpha) + val * alpha;
+  }, 0);
+
+  const estimatedMs = Math.round((mean * 0.4 + ema * 0.6));
+
+  const confidence = records.length >= MIN_SAMPLES_FOR_HIGH_CONFIDENCE
+    ? 0.9
+    : records.length >= MIN_SAMPLES_FOR_MEDIUM_CONFIDENCE
+    ? 0.6
+    : 0.3;
+
+  return {
+    routeId,
+    estimatedMs,
+    confidence,
+    sampleCount: records.length,
+    predictedAt: new Date(),
+  };
+}
+
+export function clearHistory(): void {
+  history.length = 0;
+}

--- a/src/predictions/latency/stellar/latency-predictor.types.ts
+++ b/src/predictions/latency/stellar/latency-predictor.types.ts
@@ -1,0 +1,14 @@
+export interface RouteLatencyRecord {
+  routeId: string;
+  durationMs: number;
+  executedAt: Date;
+  success: boolean;
+}
+
+export interface LatencyPrediction {
+  routeId: string;
+  estimatedMs: number;
+  confidence: number; // 0-1
+  sampleCount: number;
+  predictedAt: Date;
+}

--- a/src/scoring/assets/stellar/asset-trust-score.service.spec.ts
+++ b/src/scoring/assets/stellar/asset-trust-score.service.spec.ts
@@ -1,0 +1,74 @@
+import { calculateTrustScore, scoreAssets } from './asset-trust-score.service';
+import { IssuerReputation, StellarAsset } from './asset-trust-score.types';
+
+const asset: StellarAsset = { code: 'USDC', issuer: 'GISSUER1' };
+
+const goodReputation: IssuerReputation = {
+  issuer: 'GISSUER1',
+  verified: true,
+  blacklisted: false,
+  liquidityUsd: 1_000_000,
+  agedays: 365,
+};
+
+describe('calculateTrustScore', () => {
+  it('returns score of 100 for fully trusted asset', () => {
+    const result = calculateTrustScore(asset, goodReputation);
+    expect(result.score).toBe(100);
+    expect(result.flags).toHaveLength(0);
+    expect(result.suspicious).toBe(false);
+  });
+
+  it('returns score 0 and suspicious=true for blacklisted issuer', () => {
+    const result = calculateTrustScore(asset, { ...goodReputation, blacklisted: true });
+    expect(result.score).toBe(0);
+    expect(result.flags).toContain('blacklisted');
+    expect(result.suspicious).toBe(true);
+  });
+
+  it('deducts 30 points for unverified issuer', () => {
+    const result = calculateTrustScore(asset, { ...goodReputation, verified: false });
+    expect(result.score).toBe(70);
+    expect(result.flags).toContain('unverified_issuer');
+  });
+
+  it('deducts 25 points for low liquidity', () => {
+    const result = calculateTrustScore(asset, { ...goodReputation, liquidityUsd: 5_000 });
+    expect(result.score).toBe(75);
+    expect(result.flags).toContain('low_liquidity');
+  });
+
+  it('deducts 20 points for new asset', () => {
+    const result = calculateTrustScore(asset, { ...goodReputation, agedays: 10 });
+    expect(result.score).toBe(80);
+    expect(result.flags).toContain('new_asset');
+  });
+
+  it('marks suspicious when score below 40', () => {
+    const result = calculateTrustScore(asset, { ...goodReputation, verified: false, liquidityUsd: 0, agedays: 0 });
+    expect(result.score).toBeLessThan(40);
+    expect(result.suspicious).toBe(true);
+  });
+
+  it('score does not go below 0', () => {
+    const result = calculateTrustScore(asset, { ...goodReputation, verified: false, blacklisted: false, liquidityUsd: 0, agedays: 0 });
+    expect(result.score).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('scoreAssets', () => {
+  it('scores multiple assets using reputation map', () => {
+    const assets: StellarAsset[] = [
+      { code: 'USDC', issuer: 'GISSUER1' },
+      { code: 'XYZ', issuer: 'GUNKNOWN' },
+    ];
+    const reputations = new Map<string, IssuerReputation>([['GISSUER1', goodReputation]]);
+
+    const results = scoreAssets(assets, reputations);
+    expect(results).toHaveLength(2);
+    expect(results[0].score).toBe(100);
+    // Unknown issuer falls back to defaults: unverified, 0 liquidity, 0 age
+    expect(results[1].score).toBeLessThan(40);
+    expect(results[1].suspicious).toBe(true);
+  });
+});

--- a/src/scoring/assets/stellar/asset-trust-score.service.ts
+++ b/src/scoring/assets/stellar/asset-trust-score.service.ts
@@ -1,0 +1,60 @@
+import { AssetTrustScore, IssuerReputation, StellarAsset, TrustFlag } from './asset-trust-score.types';
+
+const SUSPICIOUS_THRESHOLD = 40;
+const MIN_LIQUIDITY_USD = 10_000;
+const MIN_ASSET_AGE_DAYS = 30;
+
+export function calculateTrustScore(
+  asset: StellarAsset,
+  reputation: IssuerReputation,
+): AssetTrustScore {
+  let score = 100;
+  const flags: TrustFlag[] = [];
+
+  if (reputation.blacklisted) {
+    score = 0;
+    flags.push('blacklisted');
+    return { asset, score, flags, suspicious: true, evaluatedAt: new Date() };
+  }
+
+  if (!reputation.verified) {
+    score -= 30;
+    flags.push('unverified_issuer');
+  }
+
+  if (reputation.liquidityUsd < MIN_LIQUIDITY_USD) {
+    score -= 25;
+    flags.push('low_liquidity');
+  }
+
+  if (reputation.agedays < MIN_ASSET_AGE_DAYS) {
+    score -= 20;
+    flags.push('new_asset');
+  }
+
+  score = Math.max(0, score);
+
+  return {
+    asset,
+    score,
+    flags,
+    suspicious: score < SUSPICIOUS_THRESHOLD,
+    evaluatedAt: new Date(),
+  };
+}
+
+export function scoreAssets(
+  assets: StellarAsset[],
+  reputations: Map<string, IssuerReputation>,
+): AssetTrustScore[] {
+  return assets.map(asset => {
+    const reputation = reputations.get(asset.issuer) ?? {
+      issuer: asset.issuer,
+      verified: false,
+      blacklisted: false,
+      liquidityUsd: 0,
+      agedays: 0,
+    };
+    return calculateTrustScore(asset, reputation);
+  });
+}

--- a/src/scoring/assets/stellar/asset-trust-score.types.ts
+++ b/src/scoring/assets/stellar/asset-trust-score.types.ts
@@ -1,0 +1,22 @@
+export interface StellarAsset {
+  code: string;
+  issuer: string;
+}
+
+export type TrustFlag = 'unverified_issuer' | 'low_liquidity' | 'blacklisted' | 'new_asset';
+
+export interface AssetTrustScore {
+  asset: StellarAsset;
+  score: number; // 0-100
+  flags: TrustFlag[];
+  suspicious: boolean;
+  evaluatedAt: Date;
+}
+
+export interface IssuerReputation {
+  issuer: string;
+  verified: boolean;
+  blacklisted: boolean;
+  liquidityUsd: number;
+  agedays: number;
+}

--- a/src/scoring/assets/stellar/index.ts
+++ b/src/scoring/assets/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './asset-trust-score.types';
+export * from './asset-trust-score.service';


### PR DESCRIPTION
…st score engine

- Add SorobanRouteLatencyPredictor at src/predictions/latency/stellar/
  - Analyzes historical route execution data
  - Estimates completion times using EMA-weighted mean
  - Confidence scoring: low (1-2 samples), medium (3-9), high (10+)

- Add StellarAssetTrustScoreEngine at src/scoring/assets/stellar/
  - Evaluates issuer reputation (verified, blacklisted, age, liquidity)
  - Calculates 0-100 trust scores with flag breakdown
  - Flags suspicious assets (score < 40) and blacklisted issuers instantly

Closes #466 
Closes #467 