### PR TITLE
feat: implement Soroban cross-chain asset relationship engine

### DIFF
--- a/src/assets/relationships/cross-chain/asset-relationship-engine.spec.ts
+++ b/src/assets/relationships/cross-chain/asset-relationship-engine.spec.ts
@@ -1,0 +1,87 @@
+import { CrossChainAssetRelationshipEngine } from './asset-relationship-engine';
+import { NativeAsset, WrappedAsset } from './types';
+
+const USDC_NATIVE: NativeAsset = {
+  chain: 'stellar',
+  code: 'USDC',
+  issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  decimals: 7,
+};
+
+const USDC_ETH: WrappedAsset = {
+  chain: 'ethereum',
+  code: 'USDC',
+  contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  decimals: 6,
+  bridgeProtocol: 'Allbridge',
+};
+
+const USDC_POLYGON: WrappedAsset = {
+  chain: 'polygon',
+  code: 'USDC',
+  contractAddress: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+  decimals: 6,
+  bridgeProtocol: 'Allbridge',
+};
+
+describe('CrossChainAssetRelationshipEngine', () => {
+  let engine: CrossChainAssetRelationshipEngine;
+
+  beforeEach(() => {
+    engine = new CrossChainAssetRelationshipEngine();
+  });
+
+  it('registers an asset relationship', () => {
+    const rel = engine.register(USDC_NATIVE, [USDC_ETH], 'USDC');
+    expect(rel.canonicalSymbol).toBe('USDC');
+    expect(rel.native.code).toBe('USDC');
+    expect(rel.wrapped).toHaveLength(1);
+  });
+
+  it('looks up by native asset', () => {
+    engine.register(USDC_NATIVE, [USDC_ETH], 'USDC');
+    const result = engine.lookupByNative('stellar', 'USDC', USDC_NATIVE.issuer);
+    expect(result.found).toBe(true);
+    expect(result.matchedOn).toBe('native');
+  });
+
+  it('looks up by wrapped asset', () => {
+    engine.register(USDC_NATIVE, [USDC_ETH], 'USDC');
+    const result = engine.lookupByWrapped('ethereum', USDC_ETH.contractAddress);
+    expect(result.found).toBe(true);
+    expect(result.matchedOn).toBe('wrapped');
+  });
+
+  it('looks up by symbol', () => {
+    engine.register(USDC_NATIVE, [USDC_ETH], 'USDC');
+    const results = engine.lookupBySymbol('usdc');
+    expect(results).toHaveLength(1);
+  });
+
+  it('merges wrapped assets on re-registration', () => {
+    engine.register(USDC_NATIVE, [USDC_ETH], 'USDC');
+    engine.register(USDC_NATIVE, [USDC_POLYGON], 'USDC');
+    const result = engine.lookupByNative('stellar', 'USDC', USDC_NATIVE.issuer);
+    expect(result.relationship?.wrapped).toHaveLength(2);
+  });
+
+  it('returns not found for unknown asset', () => {
+    const result = engine.lookupByNative('stellar', 'EURC');
+    expect(result.found).toBe(false);
+    expect(result.matchedOn).toBeNull();
+  });
+
+  it('reports stats correctly', () => {
+    engine.register(USDC_NATIVE, [USDC_ETH, USDC_POLYGON], 'USDC');
+    const stats = engine.stats();
+    expect(stats.totalRelationships).toBe(1);
+    expect(stats.wrappedAssetCount).toBe(2);
+    expect(stats.chainCoverage).toContain('stellar');
+  });
+
+  it('removes a relationship', () => {
+    const rel = engine.register(USDC_NATIVE, [USDC_ETH], 'USDC');
+    expect(engine.remove(rel.id)).toBe(true);
+    expect(engine.getAll()).toHaveLength(0);
+  });
+});

--- a/src/assets/relationships/cross-chain/asset-relationship-engine.ts
+++ b/src/assets/relationships/cross-chain/asset-relationship-engine.ts
@@ -1,0 +1,120 @@
+import {
+  AssetRelationship,
+  AssetRef,
+  AssetLookupResult,
+  NativeAsset,
+  WrappedAsset,
+  RelationshipMetadata,
+  RelationshipEngineStats,
+  AssetChain,
+} from './types';
+
+export class CrossChainAssetRelationshipEngine {
+  private readonly relationships = new Map<string, AssetRelationship>();
+
+  register(
+    native: NativeAsset,
+    wrapped: WrappedAsset[],
+    canonicalSymbol: string,
+    metadata: Partial<RelationshipMetadata> = {},
+  ): AssetRelationship {
+    const id = `${native.chain}:${native.code}${native.issuer ? `:${native.issuer}` : ''}`;
+    const now = new Date().toISOString();
+    const existing = this.relationships.get(id);
+
+    const relationship: AssetRelationship = {
+      id,
+      native,
+      wrapped: existing ? this.mergeWrapped(existing.wrapped, wrapped) : wrapped,
+      canonicalSymbol,
+      metadata: {
+        priceFeedId: metadata.priceFeedId,
+        coingeckoId: metadata.coingeckoId,
+        logoUrl: metadata.logoUrl,
+        description: metadata.description,
+        createdAt: existing?.metadata.createdAt ?? now,
+        updatedAt: now,
+      },
+    };
+
+    this.relationships.set(id, relationship);
+    return relationship;
+  }
+
+  lookupByNative(chain: AssetChain, code: string, issuer?: string): AssetLookupResult {
+    const id = `${chain}:${code}${issuer ? `:${issuer}` : ''}`;
+    const relationship = this.relationships.get(id);
+
+    if (relationship) {
+      return { found: true, relationship, matchedOn: 'native' };
+    }
+
+    // Attempt partial match (no issuer)
+    for (const rel of this.relationships.values()) {
+      if (rel.native.chain === chain && rel.native.code === code) {
+        return { found: true, relationship: rel, matchedOn: 'native' };
+      }
+    }
+
+    return { found: false, matchedOn: null };
+  }
+
+  lookupByWrapped(chain: AssetChain, contractAddress: string): AssetLookupResult {
+    for (const relationship of this.relationships.values()) {
+      const match = relationship.wrapped.find(
+        (w) => w.chain === chain && w.contractAddress.toLowerCase() === contractAddress.toLowerCase(),
+      );
+      if (match) {
+        return { found: true, relationship, matchedOn: 'wrapped' };
+      }
+    }
+    return { found: false, matchedOn: null };
+  }
+
+  lookupBySymbol(symbol: string): AssetRelationship[] {
+    const upper = symbol.toUpperCase();
+    return Array.from(this.relationships.values()).filter(
+      (r) => r.canonicalSymbol.toUpperCase() === upper || r.native.code.toUpperCase() === upper,
+    );
+  }
+
+  getAll(): AssetRelationship[] {
+    return Array.from(this.relationships.values());
+  }
+
+  remove(id: string): boolean {
+    return this.relationships.delete(id);
+  }
+
+  stats(): RelationshipEngineStats {
+    const rels = this.getAll();
+    const chains = new Set<AssetChain>();
+
+    for (const rel of rels) {
+      chains.add(rel.native.chain);
+      for (const w of rel.wrapped) {
+        chains.add(w.chain);
+      }
+    }
+
+    const wrappedCount = rels.reduce((sum, r) => sum + r.wrapped.length, 0);
+
+    return {
+      totalRelationships: rels.length,
+      chainCoverage: Array.from(chains),
+      nativeAssetCount: rels.length,
+      wrappedAssetCount: wrappedCount,
+    };
+  }
+
+  private mergeWrapped(existing: WrappedAsset[], incoming: WrappedAsset[]): WrappedAsset[] {
+    const map = new Map<string, WrappedAsset>();
+    for (const w of existing) {
+      map.set(`${w.chain}:${w.contractAddress.toLowerCase()}`, w);
+    }
+    for (const w of incoming) {
+      map.set(`${w.chain}:${w.contractAddress.toLowerCase()}`, w);
+    }
+    return Array.from(map.values());
+  }
+}

--- a/src/assets/relationships/cross-chain/index.ts
+++ b/src/assets/relationships/cross-chain/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './asset-relationship-engine';

--- a/src/assets/relationships/cross-chain/types.ts
+++ b/src/assets/relationships/cross-chain/types.ts
@@ -1,0 +1,48 @@
+export type AssetChain = 'stellar' | 'ethereum' | 'polygon' | 'arbitrum' | 'base' | 'solana';
+
+export interface NativeAsset {
+  chain: AssetChain;
+  code: string;
+  issuer?: string;
+  decimals: number;
+}
+
+export interface WrappedAsset {
+  chain: AssetChain;
+  code: string;
+  contractAddress: string;
+  decimals: number;
+  bridgeProtocol: string;
+}
+
+export type AssetRef = NativeAsset | WrappedAsset;
+
+export interface AssetRelationship {
+  id: string;
+  native: NativeAsset;
+  wrapped: WrappedAsset[];
+  canonicalSymbol: string;
+  metadata: RelationshipMetadata;
+}
+
+export interface RelationshipMetadata {
+  priceFeedId?: string;
+  coingeckoId?: string;
+  logoUrl?: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AssetLookupResult {
+  found: boolean;
+  relationship?: AssetRelationship;
+  matchedOn: 'native' | 'wrapped' | 'symbol' | null;
+}
+
+export interface RelationshipEngineStats {
+  totalRelationships: number;
+  chainCoverage: AssetChain[];
+  nativeAssetCount: number;
+  wrappedAssetCount: number;
+}


### PR DESCRIPTION
## Summary

Tracks relationships between native and wrapped assets across chains, enabling structured asset lookups and cross-chain identity resolution.

**Changes:**
- New `src/assets/relationships/cross-chain/types.ts` — `NativeAsset`, `WrappedAsset`, `AssetRelationship`, `RelationshipMetadata`, `AssetLookupResult`, `RelationshipEngineStats` interfaces
- New `src/assets/relationships/cross-chain/asset-relationship-engine.ts` — `CrossChainAssetRelationshipEngine` class with register, lookup (by native, wrapped, symbol), stats, and merge-on-re-register logic
- New `src/assets/relationships/cross-chain/asset-relationship-engine.spec.ts` — 8 unit tests covering all core paths
- New `src/assets/relationships/cross-chain/index.ts` — barrel export

## Features

- **`register(native, wrapped[], symbol)`** — stores a relationship; re-registration merges wrapped assets rather than overwriting
- **`lookupByNative(chain, code, issuer?)`** — fast map lookup with issuer-agnostic fallback
- **`lookupByWrapped(chain, contractAddress)`** — case-insensitive contract address matching
- **`lookupBySymbol(symbol)`** — returns all relationships matching a canonical symbol
- **`stats()`** — chain coverage, native/wrapped counts
- **`remove(id)`** — removes a relationship by ID

## Test Plan

- [ ] All 8 unit tests pass (`pnpm test`)
- [ ] `lookupByNative` finds USDC by Stellar chain and issuer
- [ ] `lookupByWrapped` finds USDC by Ethereum contract address
- [ ] Re-registering merges wrapped assets (no duplicates)
- [ ] `stats()` reports correct chain coverage and counts

closes #625