### PR TITLE
feat: implement Soroban route eligibility rules framework

### DIFF
--- a/src/rules/routes/stellar/index.ts
+++ b/src/rules/routes/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './route-eligibility-rules';

--- a/src/rules/routes/stellar/route-eligibility-rules.spec.ts
+++ b/src/rules/routes/stellar/route-eligibility-rules.spec.ts
@@ -1,0 +1,94 @@
+import { StellarRouteEligibilityRulesFramework } from './route-eligibility-rules';
+import { RouteRule, RouteContext } from './types';
+
+const denyUnsupportedChain: RouteRule = {
+  id: 'deny-unsupported',
+  name: 'Deny unsupported source chains',
+  description: 'Only Stellar and Ethereum are supported as source chains.',
+  conditions: [{ field: 'sourceChain', operator: 'not_in', value: ['stellar', 'ethereum'] }],
+  action: 'deny',
+  priority: 100,
+  enabled: true,
+};
+
+const allowStellarUsdc: RouteRule = {
+  id: 'allow-stellar-usdc',
+  name: 'Allow Stellar USDC routes',
+  description: 'Allow all USDC transfers from Stellar.',
+  conditions: [
+    { field: 'sourceChain', operator: 'equals', value: 'stellar' },
+    { field: 'asset', operator: 'equals', value: 'USDC' },
+  ],
+  action: 'allow',
+  priority: 50,
+  enabled: true,
+};
+
+const stellarUsdcContext: RouteContext = {
+  sourceChain: 'stellar',
+  destinationChain: 'ethereum',
+  asset: 'USDC',
+  amount: '100',
+};
+
+const unsupportedContext: RouteContext = {
+  sourceChain: 'solana',
+  destinationChain: 'ethereum',
+  asset: 'USDC',
+  amount: '100',
+};
+
+describe('StellarRouteEligibilityRulesFramework', () => {
+  let framework: StellarRouteEligibilityRulesFramework;
+
+  beforeEach(() => {
+    framework = new StellarRouteEligibilityRulesFramework();
+  });
+
+  it('allows by default with no rules', () => {
+    const result = framework.evaluate(stellarUsdcContext);
+    expect(result.eligible).toBe(true);
+    expect(result.evaluatedRules).toBe(0);
+  });
+
+  it('denies when a deny rule matches', () => {
+    framework.addRule(denyUnsupportedChain);
+    const result = framework.evaluate(unsupportedContext);
+    expect(result.eligible).toBe(false);
+    expect(result.appliedRule?.id).toBe('deny-unsupported');
+  });
+
+  it('allows when an allow rule matches', () => {
+    framework.addRule(denyUnsupportedChain);
+    framework.addRule(allowStellarUsdc);
+    const result = framework.evaluate(stellarUsdcContext);
+    expect(result.eligible).toBe(true);
+  });
+
+  it('evaluates in priority order', () => {
+    framework.addRule(allowStellarUsdc);
+    framework.addRule(denyUnsupportedChain);
+    const { result, log } = framework.evaluateWithLog(unsupportedContext);
+    expect(result.eligible).toBe(false);
+    expect(log[0]!.ruleId).toBe('deny-unsupported');
+  });
+
+  it('skips disabled rules', () => {
+    framework.addRule({ ...denyUnsupportedChain, enabled: false });
+    const result = framework.evaluate(unsupportedContext);
+    expect(result.eligible).toBe(true);
+  });
+
+  it('removes a rule', () => {
+    framework.addRule(denyUnsupportedChain);
+    expect(framework.removeRule('deny-unsupported')).toBe(true);
+    expect(framework.getRules()).toHaveLength(0);
+  });
+
+  it('updates a rule', () => {
+    framework.addRule(denyUnsupportedChain);
+    expect(framework.updateRule('deny-unsupported', { enabled: false })).toBe(true);
+    const result = framework.evaluate(unsupportedContext);
+    expect(result.eligible).toBe(true);
+  });
+});

--- a/src/rules/routes/stellar/route-eligibility-rules.ts
+++ b/src/rules/routes/stellar/route-eligibility-rules.ts
@@ -1,0 +1,123 @@
+import {
+  RouteRule,
+  RouteContext,
+  EligibilityResult,
+  RuleCondition,
+  RuleEvaluationLog,
+} from './types';
+
+export class StellarRouteEligibilityRulesFramework {
+  private rules: RouteRule[] = [];
+
+  addRule(rule: RouteRule): void {
+    this.rules.push(rule);
+    this.rules.sort((a, b) => b.priority - a.priority);
+  }
+
+  removeRule(id: string): boolean {
+    const before = this.rules.length;
+    this.rules = this.rules.filter((r) => r.id !== id);
+    return this.rules.length < before;
+  }
+
+  getRules(): RouteRule[] {
+    return [...this.rules];
+  }
+
+  updateRule(id: string, patch: Partial<RouteRule>): boolean {
+    const idx = this.rules.findIndex((r) => r.id === id);
+    if (idx === -1) return false;
+    this.rules[idx] = { ...this.rules[idx]!, ...patch };
+    this.rules.sort((a, b) => b.priority - a.priority);
+    return true;
+  }
+
+  evaluate(context: RouteContext): EligibilityResult {
+    const enabledRules = this.rules.filter((r) => r.enabled);
+
+    for (const rule of enabledRules) {
+      if (this.matchesAll(rule.conditions, context)) {
+        return {
+          eligible: rule.action === 'allow',
+          appliedRule: rule,
+          reason: rule.action === 'allow'
+            ? `Allowed by rule: ${rule.name}`
+            : `Denied by rule: ${rule.name} — ${rule.description}`,
+          evaluatedRules: enabledRules.indexOf(rule) + 1,
+        };
+      }
+    }
+
+    return {
+      eligible: true,
+      reason: 'No matching deny rule found; default allow.',
+      evaluatedRules: enabledRules.length,
+    };
+  }
+
+  evaluateWithLog(context: RouteContext): { result: EligibilityResult; log: RuleEvaluationLog[] } {
+    const enabledRules = this.rules.filter((r) => r.enabled);
+    const log: RuleEvaluationLog[] = [];
+    let finalResult: EligibilityResult | null = null;
+
+    for (const rule of enabledRules) {
+      const matched = this.matchesAll(rule.conditions, context);
+      log.push({ ruleId: rule.id, ruleName: rule.name, matched, action: rule.action });
+
+      if (matched && !finalResult) {
+        finalResult = {
+          eligible: rule.action === 'allow',
+          appliedRule: rule,
+          reason: rule.action === 'allow'
+            ? `Allowed by rule: ${rule.name}`
+            : `Denied by rule: ${rule.name} — ${rule.description}`,
+          evaluatedRules: log.length,
+        };
+      }
+    }
+
+    const result = finalResult ?? {
+      eligible: true,
+      reason: 'No matching rule; default allow.',
+      evaluatedRules: log.length,
+    };
+
+    return { result, log };
+  }
+
+  private matchesAll(conditions: RuleCondition[], context: RouteContext): boolean {
+    return conditions.every((cond) => this.matchesCondition(cond, context));
+  }
+
+  private matchesCondition(cond: RuleCondition, context: RouteContext): boolean {
+    const ctxValue = this.resolveField(cond.field, context);
+    if (ctxValue === undefined) return false;
+
+    switch (cond.operator) {
+      case 'equals':
+        return ctxValue === cond.value;
+      case 'not_equals':
+        return ctxValue !== cond.value;
+      case 'greater_than':
+        return typeof ctxValue === 'number' && typeof cond.value === 'number' && ctxValue > cond.value;
+      case 'less_than':
+        return typeof ctxValue === 'number' && typeof cond.value === 'number' && ctxValue < cond.value;
+      case 'in':
+        return Array.isArray(cond.value) && cond.value.includes(ctxValue);
+      case 'not_in':
+        return Array.isArray(cond.value) && !cond.value.includes(ctxValue);
+      default:
+        return false;
+    }
+  }
+
+  private resolveField(field: string, context: RouteContext): unknown {
+    const parts = field.split('.');
+    let current: unknown = context;
+    for (const part of parts) {
+      if (current === null || typeof current !== 'object') return undefined;
+      current = (current as Record<string, unknown>)[part];
+    }
+    return current;
+  }
+}

--- a/src/rules/routes/stellar/types.ts
+++ b/src/rules/routes/stellar/types.ts
@@ -1,0 +1,42 @@
+export type RuleOperator = 'equals' | 'not_equals' | 'greater_than' | 'less_than' | 'in' | 'not_in';
+
+export interface RuleCondition {
+  field: string;
+  operator: RuleOperator;
+  value: unknown;
+}
+
+export interface RouteRule {
+  id: string;
+  name: string;
+  description: string;
+  conditions: RuleCondition[];
+  action: 'allow' | 'deny';
+  priority: number;
+  enabled: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RouteContext {
+  sourceChain: string;
+  destinationChain: string;
+  asset: string;
+  amount: string;
+  senderAddress?: string;
+  recipientAddress?: string;
+  attributes?: Record<string, unknown>;
+}
+
+export interface EligibilityResult {
+  eligible: boolean;
+  appliedRule?: RouteRule;
+  reason: string;
+  evaluatedRules: number;
+}
+
+export interface RuleEvaluationLog {
+  ruleId: string;
+  ruleName: string;
+  matched: boolean;
+  action: 'allow' | 'deny';
+}


### PR DESCRIPTION
## Summary

Provides a configurable, priority-ordered rules framework for evaluating route eligibility across Stellar integrations. Supports custom rule conditions, allow/deny actions, and detailed evaluation logging.

**Changes:**
- New `src/rules/routes/stellar/types.ts` — `RouteRule`, `RuleCondition`, `RouteContext`, `EligibilityResult`, `RuleEvaluationLog` interfaces
- New `src/rules/routes/stellar/route-eligibility-rules.ts` — `StellarRouteEligibilityRulesFramework` class
- New `src/rules/routes/stellar/route-eligibility-rules.spec.ts` — 7 unit tests
- New `src/rules/routes/stellar/index.ts` — barrel export

## Features

- **`addRule(rule)`** — registers a rule; rules auto-sort by `priority` (higher = evaluated first)
- **`evaluate(context)`** — returns the first matching rule's action; defaults to `allow` if no rule matches
- **`evaluateWithLog(context)`** — same as `evaluate` but also returns a per-rule evaluation log for debugging
- **`updateRule(id, patch)`** — partial update with re-sort
- **`removeRule(id)`** — removes a rule by ID
- **Operators:** `equals`, `not_equals`, `greater_than`, `less_than`, `in`, `not_in`
- **Nested field access** — conditions can reference `attributes.someField` via dot notation
- Disabled rules (`enabled: false`) are skipped silently

## Test Plan

- [ ] All 7 unit tests pass (`pnpm test`)
- [ ] Default allow with no rules
- [ ] Deny rule fires for unsupported source chain
- [ ] Priority ordering: higher-priority rule is evaluated first
- [ ] Disabled rules are skipped
- [ ] `evaluateWithLog` returns full rule trace in correct order

closes #621