### PR TITLE
feat: Implement Stellar Provider Latency Observatory

### DIFF
--- a/src/observability/latency/providers/stellar/index.ts
+++ b/src/observability/latency/providers/stellar/index.ts
@@ -1,0 +1,11 @@
+export { StellarLatencyObservatory } from './stellar-latency-observatory';
+export { computePercentiles, computePercentile, detectTrend, generateReportId } from './latency-utils';
+export type {
+  LatencySample,
+  LatencyPercentiles,
+  ProviderLatencyMetrics,
+  DegradationAlert,
+  LatencyObservatoryConfig,
+  LatencyReport,
+  LatencyBucket,
+} from './types';

--- a/src/observability/latency/providers/stellar/latency-utils.ts
+++ b/src/observability/latency/providers/stellar/latency-utils.ts
@@ -1,0 +1,56 @@
+import type { LatencySample, LatencyPercentiles } from './types';
+
+export function computePercentile(sortedValues: number[], p: number): number {
+  if (sortedValues.length === 0) return 0;
+  const idx = (p / 100) * (sortedValues.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sortedValues[lo];
+  return sortedValues[lo] * (1 - (idx % 1)) + sortedValues[hi] * (idx % 1);
+}
+
+export function computePercentiles(samples: LatencySample[]): LatencyPercentiles {
+  const latencies = samples
+    .filter((s) => s.success)
+    .map((s) => s.latencyMs)
+    .sort((a, b) => a - b);
+
+  if (latencies.length === 0) {
+    return { p50: 0, p75: 0, p90: 0, p95: 0, p99: 0, min: 0, max: 0, mean: 0 };
+  }
+
+  const mean = latencies.reduce((a, b) => a + b, 0) / latencies.length;
+  return {
+    p50: computePercentile(latencies, 50),
+    p75: computePercentile(latencies, 75),
+    p90: computePercentile(latencies, 90),
+    p95: computePercentile(latencies, 95),
+    p99: computePercentile(latencies, 99),
+    min: latencies[0],
+    max: latencies[latencies.length - 1],
+    mean,
+  };
+}
+
+export function detectTrend(
+  recent: LatencySample[],
+  older: LatencySample[],
+): 'improving' | 'stable' | 'degraded' {
+  const recentMean = meanLatency(recent);
+  const olderMean = meanLatency(older);
+  if (olderMean === 0) return 'stable';
+  const change = (recentMean - olderMean) / olderMean;
+  if (change < -0.05) return 'improving';
+  if (change > 0.1) return 'degraded';
+  return 'stable';
+}
+
+function meanLatency(samples: LatencySample[]): number {
+  const valid = samples.filter((s) => s.success);
+  if (valid.length === 0) return 0;
+  return valid.reduce((a, b) => a + b.latencyMs, 0) / valid.length;
+}
+
+export function generateReportId(): string {
+  return `lat-rpt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/src/observability/latency/providers/stellar/stellar-latency-observatory.ts
+++ b/src/observability/latency/providers/stellar/stellar-latency-observatory.ts
@@ -1,0 +1,135 @@
+import { EventEmitter } from 'events';
+import type {
+  LatencySample,
+  ProviderLatencyMetrics,
+  DegradationAlert,
+  LatencyObservatoryConfig,
+  LatencyReport,
+} from './types';
+import { computePercentiles, detectTrend, generateReportId } from './latency-utils';
+
+const DEFAULTS = {
+  windowSizeMs: 5 * 60 * 1000,
+  degradationThresholdPercent: 25,
+  criticalThresholdPercent: 75,
+  minSamplesForAlert: 10,
+};
+
+export class StellarLatencyObservatory extends EventEmitter {
+  private readonly cfg: typeof DEFAULTS & { onDegradation?: (alert: DegradationAlert) => void };
+  private readonly samples = new Map<string, LatencySample[]>();
+  private readonly baselines = new Map<string, number>();
+
+  constructor(config: LatencyObservatoryConfig = {}) {
+    super();
+    this.cfg = { ...DEFAULTS, ...config };
+  }
+
+  record(sample: LatencySample): void {
+    const list = this.samples.get(sample.providerId) ?? [];
+    list.push(sample);
+    this.samples.set(sample.providerId, list);
+    this.pruneWindow(sample.providerId);
+    this.checkDegradation(sample.providerId);
+  }
+
+  setBaseline(providerId: string, p95Ms: number): void {
+    this.baselines.set(providerId, p95Ms);
+  }
+
+  getMetrics(providerId: string): ProviderLatencyMetrics | null {
+    const all = this.windowSamples(providerId);
+    if (all.length === 0) return null;
+
+    const mid = Math.floor(all.length / 2);
+    const percentiles = computePercentiles(all);
+    const trend = detectTrend(all.slice(mid), all.slice(0, mid));
+    const now = new Date();
+
+    return {
+      providerId,
+      sampleCount: all.length,
+      successCount: all.filter((s) => s.success).length,
+      failureCount: all.filter((s) => !s.success).length,
+      percentiles,
+      trend,
+      degradationAlerts: this.buildAlerts(providerId, percentiles.p95),
+      windowStartTime: new Date(now.getTime() - this.cfg.windowSizeMs),
+      windowEndTime: now,
+    };
+  }
+
+  generateReport(): LatencyReport {
+    const providers: ProviderLatencyMetrics[] = [];
+    for (const id of this.samples.keys()) {
+      const m = this.getMetrics(id);
+      if (m) providers.push(m);
+    }
+    providers.sort((a, b) => a.percentiles.p95 - b.percentiles.p95);
+
+    return {
+      reportId: generateReportId(),
+      generatedAt: new Date(),
+      windowMs: this.cfg.windowSizeMs,
+      providers,
+      bestProvider: providers[0]?.providerId ?? null,
+      worstProvider: providers[providers.length - 1]?.providerId ?? null,
+    };
+  }
+
+  clearProvider(providerId: string): void {
+    this.samples.delete(providerId);
+    this.baselines.delete(providerId);
+  }
+
+  private windowSamples(providerId: string): LatencySample[] {
+    const cutoff = Date.now() - this.cfg.windowSizeMs;
+    return (this.samples.get(providerId) ?? []).filter(
+      (s) => s.timestamp.getTime() >= cutoff,
+    );
+  }
+
+  private pruneWindow(providerId: string): void {
+    this.samples.set(providerId, this.windowSamples(providerId));
+  }
+
+  private checkDegradation(providerId: string): void {
+    const samples = this.windowSamples(providerId);
+    if (samples.length < this.cfg.minSamplesForAlert) return;
+    const baseline = this.baselines.get(providerId);
+    if (baseline === undefined) return;
+
+    const { p95 } = computePercentiles(samples);
+    const deviation = ((p95 - baseline) / baseline) * 100;
+    if (deviation < this.cfg.degradationThresholdPercent) return;
+
+    const alert: DegradationAlert = {
+      providerId,
+      detectedAt: new Date(),
+      currentP95Ms: p95,
+      baselineP95Ms: baseline,
+      deviationPercent: deviation,
+      severity: deviation >= this.cfg.criticalThresholdPercent ? 'critical' : 'warning',
+    };
+
+    this.emit('degradation', alert);
+    this.cfg.onDegradation?.(alert);
+  }
+
+  private buildAlerts(providerId: string, p95: number): DegradationAlert[] {
+    const baseline = this.baselines.get(providerId);
+    if (!baseline) return [];
+    const deviation = ((p95 - baseline) / baseline) * 100;
+    if (deviation < this.cfg.degradationThresholdPercent) return [];
+    return [
+      {
+        providerId,
+        detectedAt: new Date(),
+        currentP95Ms: p95,
+        baselineP95Ms: baseline,
+        deviationPercent: deviation,
+        severity: deviation >= this.cfg.criticalThresholdPercent ? 'critical' : 'warning',
+      },
+    ];
+  }
+}

--- a/src/observability/latency/providers/stellar/types.ts
+++ b/src/observability/latency/providers/stellar/types.ts
@@ -1,0 +1,58 @@
+export type LatencyBucket = 'p50' | 'p75' | 'p90' | 'p95' | 'p99';
+
+export interface LatencySample {
+  timestamp: Date;
+  providerId: string;
+  latencyMs: number;
+  success: boolean;
+  errorMessage?: string;
+}
+
+export interface LatencyPercentiles {
+  p50: number;
+  p75: number;
+  p90: number;
+  p95: number;
+  p99: number;
+  min: number;
+  max: number;
+  mean: number;
+}
+
+export interface ProviderLatencyMetrics {
+  providerId: string;
+  sampleCount: number;
+  successCount: number;
+  failureCount: number;
+  percentiles: LatencyPercentiles;
+  trend: 'improving' | 'stable' | 'degraded';
+  degradationAlerts: DegradationAlert[];
+  windowStartTime: Date;
+  windowEndTime: Date;
+}
+
+export interface DegradationAlert {
+  providerId: string;
+  detectedAt: Date;
+  currentP95Ms: number;
+  baselineP95Ms: number;
+  deviationPercent: number;
+  severity: 'warning' | 'critical';
+}
+
+export interface LatencyObservatoryConfig {
+  windowSizeMs?: number;
+  degradationThresholdPercent?: number;
+  criticalThresholdPercent?: number;
+  minSamplesForAlert?: number;
+  onDegradation?: (alert: DegradationAlert) => void;
+}
+
+export interface LatencyReport {
+  reportId: string;
+  generatedAt: Date;
+  windowMs: number;
+  providers: ProviderLatencyMetrics[];
+  worstProvider: string | null;
+  bestProvider: string | null;
+}


### PR DESCRIPTION
## Summary

Implements the Stellar Provider Latency Observatory as described in the issue.

- Rolling-window latency sample collection per provider
- Percentile computation (p50 / p75 / p90 / p95 / p99), min, max, mean
- Trend detection (improving / stable / degraded) via split-window comparison
- Degradation alerts with configurable warning and critical thresholds
- `EventEmitter`-based notifications for real-time degradation events
- `generateReport()` producing a ranked snapshot of all providers

**Files added:** `src/observability/latency/providers/stellar/`

closes #617