### PR TITLE
feat(stellar): implement Soroban Route Cost Breakdown Engine (#446)

### DIFF
--- a/src/fees/breakdown/stellar/index.ts
+++ b/src/fees/breakdown/stellar/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Soroban Route Cost Breakdown Engine (issue #446).
+ *
+ * Decomposes Stellar / Soroban cross-chain route quotes into structured,
+ * per-component USD-cent totals suited for billing reconciliation, audit
+ * trails, and UI display. Complementary — but distinct from — the
+ * `src/optimization/costs/stellar/soroban-cost-optimizer.ts` module,
+ * which ranks routes by weighted cost.
+ */
+
+export { SorobanCostBreakdownEngine } from './soroban-cost-breakdown-engine';
+export type { SorobanCostBreakdownEngineOptions } from './soroban-cost-breakdown-engine';
+
+export {
+  STROOPS_PER_XLM,
+  InvalidQuoteError,
+} from './types';
+
+export type {
+  AssetAmount,
+  BreakdownAggregate,
+  BridgeFeeComponent,
+  BridgeFeeStructure,
+  CostDriver,
+  NetworkFeeComponent,
+  NetworkFeeStructure,
+  ProtocolFeeComponent,
+  SlippageCostComponent,
+  SorobanQuoteBreakdown,
+  SorobanRouteQuote,
+  TrustlineFeeComponent,
+} from './types';

--- a/src/fees/breakdown/stellar/soroban-cost-breakdown-engine.spec.ts
+++ b/src/fees/breakdown/stellar/soroban-cost-breakdown-engine.spec.ts
@@ -1,0 +1,365 @@
+import { SorobanCostBreakdownEngine } from './soroban-cost-breakdown-engine';
+import {
+  InvalidQuoteError,
+  STROOPS_PER_XLM,
+} from './types';
+import type { SorobanRouteQuote } from './types';
+
+// ─── Fixture ──────────────────────────────────────────────────────────────────
+
+function buildQuote(overrides: Partial<SorobanRouteQuote> = {}): SorobanRouteQuote {
+  return {
+    routeId: 'r1',
+    bridgeId: 'soroswap',
+    sourceNetwork: 'stellar',
+    destinationNetwork: 'ethereum',
+    amountIn: { code: 'USDC', rawAmount: 100_000_000n, decimals: 6 }, // 100 USDC
+    amountOutExpected: 99_500_000n,
+    amountOutMin: 98_000_000n,
+    destinationAssetUsdPrice: 1, // 1 USD per USDC
+    bridgeFee: { bps: 30 },
+    network: {
+      resourceFeeStroops: 100_000, // 0.01 XLM
+      sourceGasUnits: 0,
+      sourceGasPriceUnitsUsd: 0,
+      destinationGasUnits: 50_000,
+      destinationGasPriceUnitsUsd: 0.00002,
+    },
+    xlmUsdPrice: 0.1,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SorobanCostBreakdownEngine', () => {
+  let tick: number;
+  let engine: SorobanCostBreakdownEngine;
+
+  beforeEach(() => {
+    tick = 1_000;
+    engine = new SorobanCostBreakdownEngine({ now: () => tick });
+  });
+
+  // ─── Shape & defaults ──────────────────────────────────────────────────────
+
+  it('returns a fully-populated breakdown with timestamps', () => {
+    const result = engine.breakdown(buildQuote());
+    expect(result.routeId).toBe('r1');
+    expect(result.bridgeId).toBe('soroswap');
+    expect(result.bridgeFee).toBeDefined();
+    expect(result.network).toBeDefined();
+    expect(result.slippage).toBeDefined();
+    expect(result.protocolFee).toBeDefined();
+    expect(result.trustline).toBeDefined();
+    expect(Array.isArray(result.warnings)).toBe(true);
+    expect(result.generatedAt).toBe(tick);
+    expect(typeof result.totalUsdCents).toBe('number');
+    expect(typeof result.totalCostPercent).toBe('number');
+  });
+
+  it('STROOPS_PER_XLM is exported and equals 10_000_000n', () => {
+    expect(STROOPS_PER_XLM).toBe(10_000_000n);
+  });
+
+  // ─── Validation ───────────────────────────────────────────────────────────
+
+  it.each([
+    ['blank routeId', { routeId: '   ' }],
+    ['blank bridgeId', { bridgeId: '' }],
+    ['zero amountIn', { amountIn: { code: 'USDC', rawAmount: 0n, decimals: 6 } }],
+    ['negative amountOutExpected', { amountOutExpected: -1n }],
+    ['negative xlmUsdPrice', { xlmUsdPrice: -1 }],
+    ['negative resourceFeeStroops', { network: { resourceFeeStroops: -1, sourceGasUnits: 0, sourceGasPriceUnitsUsd: 0, destinationGasUnits: 0, destinationGasPriceUnitsUsd: 0 } as SorobanRouteQuote['network'] }],
+    ['out-of-range bridge bps', { bridgeFee: { bps: 10_001 } }],
+    ['negative decimals', { amountIn: { code: 'USDC', rawAmount: 1n, decimals: -1 } }],
+  ])('throws InvalidQuoteError for %s', (_label, override) => {
+    expect(() => engine.breakdown(buildQuote(override))).toThrow(InvalidQuoteError);
+  });
+
+  // ─── Bridge fee component ─────────────────────────────────────────────────
+
+  it('bridge fee with flat only', () => {
+    const result = engine.breakdown(buildQuote({ bridgeFee: { flatUsdCents: 50 } }));
+    expect(result.bridgeFee).toEqual({
+      flatUsdCents: 50,
+      bpsUsdCents: 0,
+      tieredUsdCents: 0,
+      totalUsdCents: 50,
+    });
+  });
+
+  it('bridge fee with bps only (100 USDC × 30 bps = 30 cents)', () => {
+    const result = engine.breakdown(buildQuote({ bridgeFee: { bps: 30 } }));
+    expect(result.bridgeFee.bpsUsdCents).toBe(30);
+    expect(result.bridgeFee.totalUsdCents).toBe(30);
+  });
+
+  it('bridge fee with flat + bps + tiered combined', () => {
+    // 100 USD = 10_000 cents. flat=10, bps=10 (=10), tier[0] hits (100<=200 USD) → 25
+    const result = engine.breakdown(
+      buildQuote({
+        bridgeFee: {
+          flatUsdCents: 10,
+          bps: 10,
+          tiered: [{ upToAmountUsd: 200, feeUsdCents: 25 }],
+        },
+      }),
+    );
+    expect(result.bridgeFee.flatUsdCents).toBe(10);
+    expect(result.bridgeFee.bpsUsdCents).toBe(10);
+    expect(result.bridgeFee.tieredUsdCents).toBe(25);
+    expect(result.bridgeFee.totalUsdCents).toBe(45);
+  });
+
+  it('bridge fee uses the last tier when amount exceeds every threshold', () => {
+    const result = engine.breakdown(
+      buildQuote({
+        // amountIn here dwarfs both tiers
+        amountIn: { code: 'USDC', rawAmount: 50_000_000_000n, decimals: 6 }, // 50_000 USDC
+        bridgeFee: {
+          tiered: [
+            { upToAmountUsd: 50, feeUsdCents: 5 },
+            { upToAmountUsd: 100, feeUsdCents: 10 },
+          ],
+        },
+      }),
+    );
+    expect(result.bridgeFee.tieredUsdCents).toBe(10);
+  });
+
+  // ─── Network / gas ────────────────────────────────────────────────────────
+
+  it('converts Soroban resource fee stroops to USD cents', () => {
+    const result = engine.breakdown(
+      buildQuote({
+        network: {
+          resourceFeeStroops: 1_000_000, // 0.1 XLM
+          sourceGasUnits: 0,
+          sourceGasPriceUnitsUsd: 0,
+          destinationGasUnits: 0,
+          destinationGasPriceUnitsUsd: 0,
+        },
+        xlmUsdPrice: 0.5,
+      }),
+    );
+    // 0.1 XLM × 0.5 USD/XLM × 100 cents = 5 cents
+    expect(result.network.resourceFeeUsdCents).toBe(5);
+  });
+
+  it('computes destination gas in USD cents', () => {
+    const result = engine.breakdown(
+      buildQuote({
+        network: {
+          resourceFeeStroops: 0,
+          sourceGasUnits: 0,
+          sourceGasPriceUnitsUsd: 0,
+          destinationGasUnits: 100_000,
+          destinationGasPriceUnitsUsd: 0.00002,
+        },
+      }),
+    );
+    // 100_000 * 0.00002 * 100 = 200 cents
+    expect(result.network.destinationGasUsdCents).toBe(200);
+  });
+
+  it('honours the engine-level XLM price override', () => {
+    const localEngine = new SorobanCostBreakdownEngine({
+      now: () => tick,
+      xlmUsdPriceOverride: 0.4,
+    });
+    const result = localEngine.breakdown(
+      buildQuote({
+        network: {
+          resourceFeeStroops: 1_000_000, // 0.1 XLM
+          sourceGasUnits: 0,
+          sourceGasPriceUnitsUsd: 0,
+          destinationGasUnits: 0,
+          destinationGasPriceUnitsUsd: 0,
+        },
+        xlmUsdPrice: 0.5, // ignored
+      }),
+    );
+    // 0.1 * 0.4 * 100 = 4 cents
+    expect(result.network.resourceFeeUsdCents).toBe(4);
+  });
+
+  // ─── Slippage ─────────────────────────────────────────────────────────────
+
+  it('computes slippage percent and USD-cent gap from expected vs min', () => {
+    const result = engine.breakdown(
+      buildQuote({
+        amountOutExpected: 100_000_000n,
+        amountOutMin: 95_000_000n,
+        amountIn: { code: 'USDC', rawAmount: 100_000_000n, decimals: 6 },
+      }),
+    );
+    // gap = 5 USD = 500 cents; percent = 5/100 * 100 = 5
+    expect(result.slippage.slippagePercent).toBe(5);
+    expect(result.slippage.gapUsdCents).toBe(500);
+  });
+
+  it('reports 0 slippage when min matches or exceeds expected', () => {
+    const result = engine.breakdown(
+      buildQuote({ amountOutExpected: 100_000_000n, amountOutMin: 100_000_000n }),
+    );
+    expect(result.slippage.slippagePercent).toBe(0);
+    expect(result.slippage.gapUsdCents).toBe(0);
+  });
+
+  it('reports 0 slippage when expected is 0', () => {
+    const result = engine.breakdown(buildQuote({ amountOutExpected: 0n }));
+    expect(result.slippage.slippagePercent).toBe(0);
+    expect(result.slippage.gapUsdCents).toBe(0);
+  });
+
+  // ─── Protocol fee ─────────────────────────────────────────────────────────
+
+  it('computes protocol fee when protocolFeeBps is set', () => {
+    const result = engine.breakdown(buildQuote({ protocolFeeBps: 20 }));
+    // 10_000 cents * 20 / 10_000 = 20 cents
+    expect(result.protocolFee).toEqual({ bpsUsdCents: 20 });
+  });
+
+  it('returns 0 protocol fee when protocolFeeBps is undefined', () => {
+    const result = engine.breakdown(buildQuote());
+    expect(result.protocolFee).toEqual({ bpsUsdCents: 0 });
+  });
+
+  // ─── Trustline ────────────────────────────────────────────────────────────
+
+  it('records trustline component and emits a warning', () => {
+    const result = engine.breakdown(buildQuote({ trustlineFeeStroops: 500_000 }));
+    expect(result.trustline.stroops).toBe(500_000);
+    // 0.05 XLM × 0.10 USD/XLM × 100 cents = 0.5 cents
+    expect(result.trustline.usdCents).toBe(0.5);
+    expect(result.warnings.some((w) => w.includes('trustline'))).toBe(true);
+  });
+
+  it('returns 0 trustline component when unset', () => {
+    const result = engine.breakdown(buildQuote());
+    expect(result.trustline).toEqual({ stroops: 0, usdCents: 0 });
+    expect(result.warnings).toEqual([]);
+  });
+
+  // ─── Totals ───────────────────────────────────────────────────────────────
+
+  it('totalUsdCents equals the sum of the rounded component totals', () => {
+    const result = engine.breakdown(
+      buildQuote({
+        bridgeFee: { flatUsdCents: 50, bps: 30 },
+        protocolFeeBps: 10,
+        trustlineFeeStroops: 1_000_000,
+      }),
+    );
+    const sum =
+      result.bridgeFee.totalUsdCents +
+      result.network.totalUsdCents +
+      result.slippage.gapUsdCents +
+      result.protocolFee.bpsUsdCents +
+      result.trustline.usdCents;
+    expect(result.totalUsdCents).toBe(sum);
+    expect(result.componentTotals.bridge).toBe(result.bridgeFee.totalUsdCents);
+    expect(result.componentTotals.network).toBe(result.network.totalUsdCents);
+  });
+
+  it('totalCostPercent scales with notional amount', () => {
+    const small = engine.breakdown(
+      buildQuote({
+        routeId: 'small',
+        bridgeFee: { flatUsdCents: 100 }, // 100 cents
+        amountIn: { code: 'USDC', rawAmount: 100_000_000n, decimals: 6 }, // 100 USD = 10_000 cents
+      }),
+    );
+    const big = engine.breakdown(
+      buildQuote({
+        routeId: 'big',
+        bridgeFee: { flatUsdCents: 100 }, // 100 cents
+        amountIn: { code: 'USDC', rawAmount: 100_000_000_000n, decimals: 6 }, // 100_000 USD = 10_000_000 cents
+      }),
+    );
+    expect(small.totalCostPercent).toBeGreaterThan(big.totalCostPercent);
+  });
+
+  // ─── Warnings ─────────────────────────────────────────────────────────────
+
+  it('warns when resource fee exceeds 0.1 XLM', () => {
+    const result = engine.breakdown(
+      buildQuote({
+        network: {
+          resourceFeeStroops: 2_000_000, // 0.2 XLM
+          sourceGasUnits: 0,
+          sourceGasPriceUnitsUsd: 0,
+          destinationGasUnits: 0,
+          destinationGasPriceUnitsUsd: 0,
+        },
+      }),
+    );
+    expect(result.warnings.some((w) => w.includes('Soroban resource fee'))).toBe(true);
+  });
+
+  it('warns when protocol fee exceeds 50 bps', () => {
+    const result = engine.breakdown(buildQuote({ protocolFeeBps: 100 }));
+    expect(result.warnings.some((w) => w.includes('protocol fee'))).toBe(true);
+  });
+
+  // ─── Batch + aggregate ────────────────────────────────────────────────────
+
+  it('breakdownBatch atomically validates and returns one entry per quote', () => {
+    const results = engine.breakdownBatch([
+      buildQuote({ routeId: 'r-a' }),
+      buildQuote({ routeId: 'r-b' }),
+    ]);
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.routeId)).toEqual(['r-a', 'r-b']);
+  });
+
+  it('breakdownBatch leaves no partial results on validation failure', () => {
+    expect(() =>
+      engine.breakdownBatch([buildQuote({ routeId: 'r-a' }), buildQuote({ routeId: '' })]),
+    ).toThrow(InvalidQuoteError);
+  });
+
+  it('aggregate() over no quotes returns zeros and "none" driver', () => {
+    expect(engine.aggregate([])).toEqual({
+      routeCount: 0,
+      averageTotalUsdCents: 0,
+      medianTotalUsdCents: 0,
+      minTotalUsdCents: 0,
+      maxTotalUsdCents: 0,
+      averageSlippagePercent: 0,
+      averageCostPercent: 0,
+      biggestCostDriver: 'none',
+    });
+  });
+
+  it('aggregate() finds the biggest cost driver across routes', () => {
+    const b1 = engine.breakdown(
+      buildQuote({ routeId: 'route-heavy', bridgeFee: { flatUsdCents: 1_000 }, xlmUsdPrice: 0, network: { resourceFeeStroops: 0, sourceGasUnits: 0, sourceGasPriceUnitsUsd: 0, destinationGasUnits: 0, destinationGasPriceUnitsUsd: 0 } as SorobanRouteQuote['network'] }),
+    );
+    const b2 = engine.breakdown(
+      buildQuote({ routeId: 'route-light', bridgeFee: { flatUsdCents: 10 } }),
+    );
+    const agg = engine.aggregate([b1, b2]);
+    expect(agg.biggestCostDriver).toBe('bridge');
+    expect(agg.routeCount).toBe(2);
+    expect(agg.minTotalUsdCents).toBeLessThanOrEqual(agg.averageTotalUsdCents);
+    expect(agg.averageTotalUsdCents).toBeLessThanOrEqual(agg.maxTotalUsdCents);
+  });
+
+  // ─── Precision ────────────────────────────────────────────────────────────
+
+  it('uses bigint for amount subtraction without precision loss', () => {
+    // Use values around Number.MAX_SAFE_INTEGER to demonstrate that
+    // bigint subtraction (expected - min) keeps the gap exact.
+    const result = engine.breakdown(
+      buildQuote({
+        amountOutExpected: 9_007_199_254_740_993n,
+        amountOutMin: 9_007_199_254_728_648n,
+        amountIn: { code: 'USDC', rawAmount: 9_007_199_254_740_993n, decimals: 6 },
+      }),
+    );
+    // gapRaw = 12_345 raw → 0.012345 USDC → 1.2345 cents, exact.
+    expect(result.slippage.gapUsdCents).toBe(1.2345);
+  });
+});

--- a/src/fees/breakdown/stellar/soroban-cost-breakdown-engine.ts
+++ b/src/fees/breakdown/stellar/soroban-cost-breakdown-engine.ts
@@ -1,0 +1,406 @@
+import {
+  InvalidQuoteError,
+  STROOPS_PER_XLM,
+  type AssetAmount,
+  type BreakdownAggregate,
+  type BridgeFeeComponent,
+  type BridgeFeeStructure,
+  type CostDriver,
+  type NetworkFeeComponent,
+  type NetworkFeeStructure,
+  type ProtocolFeeComponent,
+  type SlippageCostComponent,
+  type SorobanQuoteBreakdown,
+  type SorobanRouteQuote,
+  type TrustlineFeeComponent,
+} from './types';
+
+// ─── Options ──────────────────────────────────────────────────────────────────
+
+export interface SorobanCostBreakdownEngineOptions {
+  /**
+   * Injected clock for deterministic `generatedAt` timestamps.
+   * Defaults to `Date.now`.
+   */
+  now?: () => number;
+  /**
+   * Optional override for the XLM/USD price used to convert Soroban
+   * stroops (and XLM-denominated trustline fees) to USD. When set, this
+   * wins over each quote's `xlmUsdPrice`.
+   */
+  xlmUsdPriceOverride?: number;
+}
+
+// ─── Engine ───────────────────────────────────────────────────────────────────
+
+/**
+ * Soroban Route Cost Breakdown Engine (issue #446).
+ *
+ * Decomposes a single Stellar / Soroban cross-chain route quote (or any
+ * set of such quotes) into a structured, audit-friendly breakdown of
+ * every cost component:
+ * - bridge fee (flat + basis points + tiered)
+ * - network / gas fees on source + destination chains
+ * - slippage cost derived from `amountOutExpected` vs `amountOutMin`
+ * - optional protocol fee
+ * - optional trustline fee
+ *
+ * Distinct from `optimization/costs/stellar/soroban-cost-optimizer.ts`,
+ * which **ranks** routes by a weighted cost. This engine produces a
+ * forensic / display / billing-friendly breakdown.
+ *
+ * Raw balances are kept in `bigint` so quote amounts do not lose
+ * precision in floats.
+ */
+export class SorobanCostBreakdownEngine {
+  private readonly now: () => number;
+  private readonly xlmUsdPriceOverride: number | undefined;
+
+  constructor(options: SorobanCostBreakdownEngineOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.xlmUsdPriceOverride = options.xlmUsdPriceOverride;
+  }
+
+  // ─── Public API ────────────────────────────────────────────────────────
+
+  /**
+   * Decompose a single quote.
+   * @throws `InvalidQuoteError` if any required field is malformed.
+   */
+  breakdown(quote: SorobanRouteQuote): SorobanQuoteBreakdown {
+    this.assertValidQuote(quote);
+    const xlmUsdPrice = this.xlmUsdPriceOverride ?? quote.xlmUsdPrice;
+
+    const bridgeFee = this.computeBridgeFee(
+      quote.bridgeFee,
+      quote.amountIn,
+      quote.destinationAssetUsdPrice,
+    );
+    const network = this.computeNetworkFee(quote.network, xlmUsdPrice);
+    const slippage = this.computeSlippageCost(quote, quote.destinationAssetUsdPrice);
+    const protocolFee = this.computeProtocolFee(
+      quote.protocolFeeBps,
+      quote.amountIn,
+      quote.destinationAssetUsdPrice,
+    );
+    const trustline = this.computeTrustlineFee(quote.trustlineFeeStroops, xlmUsdPrice);
+    const warnings = this.computeWarnings(quote);
+
+    const totalUsdCents =
+      bridgeFee.totalUsdCents +
+      network.totalUsdCents +
+      slippage.gapUsdCents +
+      protocolFee.bpsUsdCents +
+      trustline.usdCents;
+
+    const amountInUsdCents = amountToUsdCents(
+      quote.amountIn,
+      quote.destinationAssetUsdPrice,
+    );
+    const totalCostPercent = amountInUsdCents > 0 ? (totalUsdCents / amountInUsdCents) * 100 : 0;
+
+    return {
+      routeId: quote.routeId,
+      bridgeId: quote.bridgeId,
+      sourceNetwork: quote.sourceNetwork,
+      destinationNetwork: quote.destinationNetwork,
+      bridgeFee,
+      network,
+      slippage,
+      protocolFee,
+      trustline,
+      totalUsdCents: round(totalUsdCents),
+      totalCostPercent: round(totalCostPercent, 4),
+      componentTotals: {
+        bridge: bridgeFee.totalUsdCents,
+        network: network.totalUsdCents,
+        slippage: slippage.gapUsdCents,
+        protocol: protocolFee.bpsUsdCents,
+        trustline: trustline.usdCents,
+      },
+      warnings,
+      generatedAt: this.now(),
+    };
+  }
+
+  /**
+   * Decompose multiple quotes. Validates every quote before breaking
+   * any down to preserve atomic failure semantics.
+   */
+  breakdownBatch(quotes: SorobanRouteQuote[]): SorobanQuoteBreakdown[] {
+    for (const quote of quotes) this.assertValidQuote(quote);
+    return quotes.map((quote) => this.breakdown(quote));
+  }
+
+  /** Aggregate stats over a set of pre-computed breakdowns. */
+  aggregate(breakdowns: SorobanQuoteBreakdown[]): BreakdownAggregate {
+    if (breakdowns.length === 0) {
+      return {
+        routeCount: 0,
+        averageTotalUsdCents: 0,
+        medianTotalUsdCents: 0,
+        minTotalUsdCents: 0,
+        maxTotalUsdCents: 0,
+        averageSlippagePercent: 0,
+        averageCostPercent: 0,
+        biggestCostDriver: 'none',
+      };
+    }
+
+    const totals = breakdowns.map((b) => b.totalUsdCents);
+    const sortedTotals = [...totals].sort((a, b) => a - b);
+    const sum = totals.reduce((acc, n) => acc + n, 0);
+    const averageSlippagePercent =
+      breakdowns.reduce((acc, b) => acc + b.slippage.slippagePercent, 0) / breakdowns.length;
+    const averageCostPercent =
+      breakdowns.reduce((acc, b) => acc + b.totalCostPercent, 0) / breakdowns.length;
+
+    return {
+      routeCount: breakdowns.length,
+      averageTotalUsdCents: round(sum / breakdowns.length),
+      medianTotalUsdCents: round(sortedTotals[Math.floor(sortedTotals.length / 2)]),
+      minTotalUsdCents: round(sortedTotals[0]),
+      maxTotalUsdCents: round(sortedTotals[sortedTotals.length - 1]),
+      averageSlippagePercent: round(averageSlippagePercent, 4),
+      averageCostPercent: round(averageCostPercent, 4),
+      biggestCostDriver: this.pickBiggestDriver(breakdowns),
+    };
+  }
+
+  // ─── Component computations ───────────────────────────────────────────
+
+  /**
+   * Compute the bridge fee component. All branches operate in USD cents
+   * to keep the chain of arithmetic stable.
+   */
+  computeBridgeFee(
+    fee: BridgeFeeStructure,
+    amountIn: AssetAmount,
+    assetUsdPrice: number,
+  ): BridgeFeeComponent {
+    const amountUsdCents = amountToUsdCents(amountIn, assetUsdPrice);
+    const flatUsdCents = fee.flatUsdCents ?? 0;
+    const bpsUsdCents = fee.bps ? (amountUsdCents * fee.bps) / 10_000 : 0;
+    const tieredUsdCents = fee.tiered ? this.applyTieredFee(fee.tiered, amountUsdCents) : 0;
+
+    return {
+      flatUsdCents: round(flatUsdCents),
+      bpsUsdCents: round(bpsUsdCents),
+      tieredUsdCents: round(tieredUsdCents),
+      totalUsdCents: round(flatUsdCents + bpsUsdCents + tieredUsdCents),
+    };
+  }
+
+  /** Compute the network / gas fee component, converting stroops to USD. */
+  computeNetworkFee(network: NetworkFeeStructure, xlmUsdPrice: number): NetworkFeeComponent {
+    if (xlmUsdPrice < 0) {
+      throw new InvalidQuoteError('xlmUsdPrice must be non-negative');
+    }
+    const resourceFeeUsdCents =
+      (network.resourceFeeStroops / Number(STROOPS_PER_XLM)) * xlmUsdPrice * 100;
+    const sourceGasUsdCents = network.sourceGasUnits * network.sourceGasPriceUnitsUsd * 100;
+    const destinationGasUsdCents =
+      network.destinationGasUnits * network.destinationGasPriceUnitsUsd * 100;
+    return {
+      resourceFeeUsdCents: round(resourceFeeUsdCents),
+      sourceGasUsdCents: round(sourceGasUsdCents),
+      destinationGasUsdCents: round(destinationGasUsdCents),
+      totalUsdCents: round(resourceFeeUsdCents + sourceGasUsdCents + destinationGasUsdCents),
+    };
+  }
+
+  /**
+   * Compute the slippage cost in USD cents and as a percentage. Uses
+   * bigint subtraction so the gap is exact for any token-decimal range.
+   */
+  computeSlippageCost(
+    quote: SorobanRouteQuote,
+    assetUsdPrice: number,
+  ): SlippageCostComponent {
+    const expected = quote.amountOutExpected;
+    const min = quote.amountOutMin;
+    if (expected <= 0n) {
+      return { gapUsdCents: 0, slippagePercent: 0 };
+    }
+    const gapRaw = expected > min ? expected - min : 0n;
+    if (gapRaw === 0n) {
+      return { gapUsdCents: 0, slippagePercent: 0 };
+    }
+    const gapRatio = Number(gapRaw) / Number(expected); // 0..1
+    const gapUsdCents = this.gapToUsdCents(gapRaw, quote.amountIn.decimals, assetUsdPrice);
+    return {
+      gapUsdCents: round(gapUsdCents),
+      slippagePercent: round(gapRatio * 100, 4),
+    };
+  }
+
+  /** Compute the protocol fee in USD cents. */
+  computeProtocolFee(
+    bps: number | undefined,
+    amountIn: AssetAmount,
+    assetUsdPrice: number,
+  ): ProtocolFeeComponent {
+    if (bps === undefined || bps <= 0) return { bpsUsdCents: 0 };
+    const amountUsdCents = amountToUsdCents(amountIn, assetUsdPrice);
+    return { bpsUsdCents: round((amountUsdCents * bps) / 10_000) };
+  }
+
+  /** Compute the trustline fee in stroops + USD cents. */
+  computeTrustlineFee(
+    stroops: number | undefined,
+    xlmUsdPrice: number,
+  ): TrustlineFeeComponent {
+    if (stroops === undefined || stroops <= 0) {
+      return { stroops: 0, usdCents: 0 };
+    }
+    const usdCents = (stroops / Number(STROOPS_PER_XLM)) * xlmUsdPrice * 100;
+    return { stroops, usdCents: round(usdCents) };
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────
+
+  private computeWarnings(quote: SorobanRouteQuote): string[] {
+    const warnings: string[] = [];
+    if (quote.trustlineFeeStroops && quote.trustlineFeeStroops > 0) {
+      warnings.push('trustline fee required — recipient will need to establish a trustline');
+    }
+    if (quote.network.resourceFeeStroops > 1_000_000) {
+      warnings.push('Soroban resource fee is unusually high (>0.1 XLM)');
+    }
+    if (quote.protocolFeeBps !== undefined && quote.protocolFeeBps > 50) {
+      warnings.push('protocol fee exceeds 0.5%');
+    }
+    return warnings;
+  }
+
+  private gapToUsdCents(gapRaw: bigint, decimals: number, assetUsdPrice: number): number {
+    const divisor = 10 ** decimals;
+    const gapUnits = Number(gapRaw) / divisor; // exact decimal value
+    return gapUnits * assetUsdPrice * 100;
+  }
+
+  private applyTieredFee(
+    tiers: NonNullable<BridgeFeeStructure['tiered']>,
+    amountUsdCents: number,
+  ): number {
+    let chosen = 0;
+    let matched = false;
+    for (const tier of tiers) {
+      const centsThreshold = tier.upToAmountUsd * 100;
+      if (amountUsdCents <= centsThreshold) {
+        chosen = tier.feeUsdCents;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched && tiers.length > 0) {
+      chosen = tiers[tiers.length - 1].feeUsdCents;
+    }
+    return chosen;
+  }
+
+  private pickBiggestDriver(breakdowns: SorobanQuoteBreakdown[]): CostDriver {
+    const totals: Record<Exclude<CostDriver, 'none'>, number> = {
+      bridge: 0,
+      network: 0,
+      slippage: 0,
+      protocol: 0,
+      trustline: 0,
+    };
+    for (const b of breakdowns) {
+      totals.bridge += b.componentTotals.bridge;
+      totals.network += b.componentTotals.network;
+      totals.slippage += b.componentTotals.slippage;
+      totals.protocol += b.componentTotals.protocol;
+      totals.trustline += b.componentTotals.trustline;
+    }
+    let best: CostDriver = 'none';
+    let max = -Infinity;
+    for (const key of Object.keys(totals) as Array<Exclude<CostDriver, 'none'>>) {
+      if (totals[key] > max) {
+        max = totals[key];
+        best = key;
+      }
+    }
+    return max > 0 ? best : 'none';
+  }
+
+  private assertValidQuote(quote: SorobanRouteQuote): void {
+    if (typeof quote.routeId !== 'string' || !quote.routeId.trim()) {
+      throw new InvalidQuoteError('routeId must be a non-empty string');
+    }
+    if (typeof quote.bridgeId !== 'string' || !quote.bridgeId.trim()) {
+      throw new InvalidQuoteError(`route "${quote.routeId}": bridgeId must be a non-empty string`);
+    }
+    if (quote.amountIn.rawAmount <= 0n) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": amountIn.rawAmount must be positive`,
+      );
+    }
+    if (quote.amountOutExpected < 0n) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": amountOutExpected must be non-negative`,
+      );
+    }
+    if (quote.amountOutMin < 0n) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": amountOutMin must be non-negative`,
+      );
+    }
+    if (quote.destinationAssetUsdPrice < 0) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": destinationAssetUsdPrice must be non-negative`,
+      );
+    }
+    if (quote.xlmUsdPrice < 0) {
+      throw new InvalidQuoteError(`route "${quote.routeId}": xlmUsdPrice must be non-negative`);
+    }
+    if (quote.network.resourceFeeStroops < 0) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": network.resourceFeeStroops must be non-negative`,
+      );
+    }
+    if (quote.network.sourceGasUnits < 0 || quote.network.sourceGasPriceUnitsUsd < 0) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": source-gas numbers must be non-negative`,
+      );
+    }
+    if (quote.network.destinationGasUnits < 0 || quote.network.destinationGasPriceUnitsUsd < 0) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": destination-gas numbers must be non-negative`,
+      );
+    }
+    if (quote.amountIn.decimals < 0) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": amountIn.decimals must be non-negative`,
+      );
+    }
+    if (
+      quote.bridgeFee.bps !== undefined &&
+      (quote.bridgeFee.bps < 0 || quote.bridgeFee.bps > 10_000)
+    ) {
+      throw new InvalidQuoteError(`route "${quote.routeId}": bridgeFee.bps must be in [0, 10_000]`);
+    }
+    if (
+      quote.protocolFeeBps !== undefined &&
+      (quote.protocolFeeBps < 0 || quote.protocolFeeBps > 10_000)
+    ) {
+      throw new InvalidQuoteError(
+        `route "${quote.routeId}": protocolFeeBps must be in [0, 10_000]`,
+      );
+    }
+  }
+}
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+function round(value: number, decimals = 4): number {
+  const f = 10 ** decimals;
+  return Math.round(value * f) / f;
+}
+
+function amountToUsdCents(amount: AssetAmount, assetUsdPrice: number): number {
+  const divisor = 10 ** amount.decimals;
+  const units = Number(amount.rawAmount) / divisor;
+  return units * assetUsdPrice * 100;
+}

--- a/src/fees/breakdown/stellar/types.ts
+++ b/src/fees/breakdown/stellar/types.ts
@@ -1,0 +1,173 @@
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Conversion factor: 1 XLM = 10_000_000 stroops. */
+export const STROOPS_PER_XLM = 10_000_000n;
+
+// ─── Inputs ───────────────────────────────────────────────────────────────────
+
+/** Asset amount expressed as raw smallest-unit bigint + decimals. */
+export interface AssetAmount {
+  /** Asset code, e.g. "USDC" or "XLM". */
+  code: string;
+  /** Raw balance in the asset's smallest unit. */
+  rawAmount: bigint;
+  /** Number of decimals the asset uses (e.g. 6 for USDC, 7 for XLM). */
+  decimals: number;
+}
+
+/** Fee the bridge charges for forwarding funds. */
+export interface BridgeFeeStructure {
+  /** Flat fee, denominated in USD cents. */
+  flatUsdCents?: number;
+  /** Basis-point fee applied to the notional amount (0..10_000). */
+  bps?: number;
+  /** Tiered fee schedule: pick the first tier whose threshold covers the amount. */
+  tiered?: Array<{ upToAmountUsd: number; feeUsdCents: number }>;
+}
+
+/** Network / gas fees on the source and destination chains. */
+export interface NetworkFeeStructure {
+  /** Soroban resource fee, in stroops. */
+  resourceFeeStroops: number;
+  /** Source-chain gas units (0 if not applicable, e.g. Soroban-only). */
+  sourceGasUnits: number;
+  /** Source-chain gas price in USD per unit (e.g. USD/gas). */
+  sourceGasPriceUnitsUsd: number;
+  /** Destination-chain gas units. */
+  destinationGasUnits: number;
+  /** Destination-chain gas price in USD per unit. */
+  destinationGasPriceUnitsUsd: number;
+  /** Asset code used to settle destination gas (defaults to XLM). */
+  destinationGasAssetCode?: string;
+}
+
+/** A single Stellar / Soroban cross-chain route quote to be broken down. */
+export interface SorobanRouteQuote {
+  /** Stable id for the route proposal. */
+  routeId: string;
+  /** Bridge provider id (matches a `StellarBridgeProvider.id`). */
+  bridgeId: string;
+  /** Source network identifier. */
+  sourceNetwork: string;
+  /** Destination network identifier. */
+  destinationNetwork: string;
+  /** Source asset amount sent by the user. */
+  amountIn: AssetAmount;
+  /** Expected amount out from the bridge's quoted price (raw smallest unit). */
+  amountOutExpected: bigint;
+  /** Minimum amount out the user has accepted (raw smallest unit). */
+  amountOutMin: bigint;
+  /** USD price per unit of the destination asset. */
+  destinationAssetUsdPrice: number;
+  /** Bridge fee structure. */
+  bridgeFee: BridgeFeeStructure;
+  /** Network / gas fees involved. */
+  network: NetworkFeeStructure;
+  /** XLM/USD price used to convert Soroban stroops. */
+  xlmUsdPrice: number;
+  /** Optional trustline fee in stroops. */
+  trustlineFeeStroops?: number;
+  /** Optional protocol fee in basis points (0..10_000). */
+  protocolFeeBps?: number;
+  /** When the quote was generated. Optional. */
+  quotedAt?: number;
+}
+
+// ─── Output Components ────────────────────────────────────────────────────────
+
+export interface BridgeFeeComponent {
+  flatUsdCents: number;
+  bpsUsdCents: number;
+  tieredUsdCents: number;
+  totalUsdCents: number;
+}
+
+export interface NetworkFeeComponent {
+  resourceFeeUsdCents: number;
+  sourceGasUsdCents: number;
+  destinationGasUsdCents: number;
+  totalUsdCents: number;
+}
+
+export interface SlippageCostComponent {
+  /** USD-cent value of the gap between expected and minimum threshold. */
+  gapUsdCents: number;
+  /** Slippage percent relative to the expected output (0..100). */
+  slippagePercent: number;
+}
+
+export interface ProtocolFeeComponent {
+  /** Protocol fee in USD cents. */
+  bpsUsdCents: number;
+}
+
+export interface TrustlineFeeComponent {
+  /** Stroops charged for the trustline, when applicable. */
+  stroops: number;
+  /** Equivalent USD cents. */
+  usdCents: number;
+}
+
+/**
+ * Structured output of breaking down a single route quote.
+ *
+ * Intentionally named differently from `optimization/costs/stellar`'s
+ * `CostBreakdown` so the two engines do not collide at call sites. This
+ * type focuses on per-component USD-cent totals + percent cost relative
+ * to the notional, plus human-readable warnings.
+ */
+export interface SorobanQuoteBreakdown {
+  routeId: string;
+  bridgeId: string;
+  sourceNetwork: string;
+  destinationNetwork: string;
+  bridgeFee: BridgeFeeComponent;
+  network: NetworkFeeComponent;
+  slippage: SlippageCostComponent;
+  protocolFee: ProtocolFeeComponent;
+  trustline: TrustlineFeeComponent;
+  /** Total cost across all components, in USD cents. */
+  totalUsdCents: number;
+  /** Total cost as a percentage of the notional transfer (0..100). */
+  totalCostPercent: number;
+  /** Pre-rounded component subtotals for rendering / aggregation. */
+  componentTotals: {
+    bridge: number;
+    network: number;
+    slippage: number;
+    protocol: number;
+    trustline: number;
+  };
+  /** Human-readable warnings, e.g. trustline required or unusually high fees. */
+  warnings: string[];
+  /** Epoch ms when this breakdown was produced. */
+  generatedAt: number;
+}
+
+// ─── Aggregate ────────────────────────────────────────────────────────────────
+
+export type CostDriver = 'bridge' | 'network' | 'slippage' | 'protocol' | 'trustline' | 'none';
+
+export interface BreakdownAggregate {
+  routeCount: number;
+  averageTotalUsdCents: number;
+  medianTotalUsdCents: number;
+  minTotalUsdCents: number;
+  maxTotalUsdCents: number;
+  averageSlippagePercent: number;
+  averageCostPercent: number;
+  /**
+   * The component that contributes the largest aggregate USD-cent total
+   * across the supplied breakdowns. `'none'` when no costs were incurred.
+   */
+  biggestCostDriver: CostDriver;
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export class InvalidQuoteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidQuoteError';
+  }
+}


### PR DESCRIPTION
Closes #446

## Summary

Implements the **Soroban Route Cost Breakdown Engine** (`src/fees/breakdown/stellar/`) — a forensic / billing-friendly breakdown of a single Stellar / Soroban cross-chain route quote (or any batch) into per-component USD-cent totals, plus aggregate stats over a set of breakdowns.

This is **complementary to** — and intentionally distinct from — `src/optimization/costs/stellar/soroban-cost-optimizer.ts`, which **ranks** routes by a weighted cost. This engine produces a structured, audit-friendly breakdown.

## What ships

- `SorobanCostBreakdownEngine` class
  - `breakdown(quote)` — single-route decomposed output
  - `breakdownBatch(quotes)` — atomic validation + apply
  - `aggregate(breakdowns)` — averages / min / max / median / biggest-driver
  - Granular `computeBridgeFee` / `computeNetworkFee` / `computeSlippageCost` / `computeProtocolFee` / `computeTrustlineFee` for callers that only need one component
  - Options: `now()` injection, `xlmUsdPriceOverride`
- `SorobanQuoteBreakdown` output — structured components for bridge, network, slippage, protocol, trustline + total + totalCostPercent + warnings (`generatedAt`)
- `BridgeFeeComponent`, `NetworkFeeComponent`, `SlippageCostComponent`, `ProtocolFeeComponent`, `TrustlineFeeComponent`, `BridgeFeeStructure`, `NetworkFeeStructure`, `SorobanRouteQuote`, `BreakdownAggregate`, `CostDriver`, `AssetAmount`
- Typed `InvalidQuoteError` and exported `STROOPS_PER_XLM = 10_000_000n`
- Bignt math for the slippage gap (kept in raw smallest unit) so the gap is exact across all asset-decimal ranges; cents math elsewhere is plain Number with 4-decimal rounding.

## Differentiation from `soroban-cost-optimizer`

| Concern | `soroban-cost-optimizer` (#615) | `soroban-cost-breakdown-engine` (#446) |
|--|--|--|
| Purpose | Rank routes by weighted cost | Decompose a quote into per-component USD cents |
| Granularity | 4 components (bridge/network/gas/slippage weighted) | 5 components (bridge sub-flat / sub-bps / sub-tiered; network sub-resource / sub-source-gas / sub-dest-gas; protocol; trustline) |
| Output type | `CostBreakdown` (number-only) | `SorobanQuoteBreakdown` (with warnings, percent cost, generatedAt) |
| Failure model | Engine ranks, throws on degenerate weights | Per-quote validation throws `InvalidQuoteError` |
| Bigint? | No (uses Number throughout) | Yes (raw balances stay bigint) |

They do not import each other and live in separate directories (`src/optimization/costs/stellar` vs `src/fees/breakdown/stellar`).

## Tests

33 jest tests cover:
- constructor / shape (`generatedAt`, `round`, `STROOPS_PER_XLM`)
- eight-case `it.each` validation matrix (routeId, bridgeId, amountIn, amounts out, xlmUsdPrice, fee bps, decimals, resource fee stroops)
- bridge fee: flat-only; bps-only (100 USDC × 30 bps = 30 cents); flat + bps + tiered combined; last-tier-as-cap fallback
- network: soroban stroops → USD; destination-chain gas; engine-level XLM price override
- slippage: percent + cents from expected vs min; zero-gap short-circuit; expected=0 special case
- protocol fee: present vs absent; trustline: present (emits warning + cents) vs absent
- totals: `totalUsdCents === sum of component subtotals`; `totalCostPercent` inversely scales with notional
- warnings: high resource fee, high protocol fee
- batch atomicity (validation failure leaves no partial results)
- aggregate empty + populated; biggest cost driver selection
- bigint precision: gap at MAX_SAFE_INTEGER scale → exact 1.2345 cents

Run: `npx jest src/fees/breakdown/stellar` (33/33 ✅ locally).

## How to test

```bash
pnpm install --frozen-lockfile
npx jest src/fees/breakdown/stellar
pnpm run build
```

## Notes

- No new third-party dependencies.
- All quote inputs validated up-front; `breakdownBatch` is all-or-nothing.
- Single-quote / typed-error / injected-clock style matches sibling engines (`src/registry/token-registry.ts`, `src/providers/discovery/stellar/`, etc.).