### PR TITLE
feat(stellar): implement Stellar Route Decision Engine (#504)

### DIFF
--- a/src/routing/decision-engine/stellar/index.ts
+++ b/src/routing/decision-engine/stellar/index.ts
@@ -1,0 +1,23 @@
+/**
+ * File: src/routing/decision-engine/stellar/index.ts
+ *
+ * Module barrel for the Stellar Route Decision Engine.
+ *
+ * Re-exports the runtime class and every public type so consumers can
+ * import everything they need from a single path:
+ *
+ *   import { StellarRouteDecisionEngine } from '@/routing/decision-engine/stellar';
+ */
+
+export { StellarRouteDecisionEngine } from './stellar-route-decision-engine';
+export { default } from './stellar-route-decision-engine';
+export type {
+  StellarDecisionContext,
+  StellarDecisionEntry,
+  StellarDecisionPolicy,
+  StellarDecisionRankingOptions,
+  StellarDecisionResult,
+  StellarDecisionSignals,
+  StellarRouteCompatibilitySignal,
+  StellarRouteRiskSignal,
+} from './types';

--- a/src/routing/decision-engine/stellar/stellar-route-decision-engine.spec.ts
+++ b/src/routing/decision-engine/stellar/stellar-route-decision-engine.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * File: src/routing/decision-engine/stellar/stellar-route-decision-engine.spec.ts
+ *
+ * Unit tests for the Stellar Route Decision Engine.
+ */
+
+import { BridgeRoute } from '../../../services/route-ranker';
+import { StellarRouteDecisionEngine } from './stellar-route-decision-engine';
+
+const FIXED_NOW = 1_700_000_000_000;
+const now = () => FIXED_NOW;
+
+function makeRoute(partial: Partial<BridgeRoute> & { id: string; provider: string }): BridgeRoute {
+  return {
+    id: partial.id,
+    fromChain: 'ethereum',
+    toChain: 'stellar',
+    fromToken: 'USDC',
+    toToken: 'USDC',
+    amount: '100',
+    fee: { amount: '0.5', token: 'USDC', usdValue: 0.5 },
+    estimatedTime: 10,
+    successRate: 0.95,
+    provider: partial.provider,
+    slippage: 0.5,
+    confidence: 0.9,
+    ...partial,
+  };
+}
+
+describe('StellarRouteDecisionEngine', () => {
+  it('returns an empty result when no candidates are supplied', () => {
+    const engine = new StellarRouteDecisionEngine({ now });
+    const result = engine.decide([]);
+
+    expect(result.selection).toBeNull();
+    expect(result.alternatives).toEqual([]);
+    expect(result.rejections).toEqual([]);
+    expect(result.decidedAt).toBe(FIXED_NOW);
+  });
+
+  it('selects the top-ranked candidate and surfaces alternatives', () => {
+    const engine = new StellarRouteDecisionEngine({ now });
+
+    const candidates: BridgeRoute[] = [
+      makeRoute({ id: 'r1', provider: 'allbridge', fee: { amount: '0.1', token: 'USDC', usdValue: 0.1 }, estimatedTime: 5, successRate: 0.98, slippage: 0.1 }),
+      makeRoute({ id: 'r2', provider: 'squid', fee: { amount: '0.5', token: 'USDC', usdValue: 0.5 }, estimatedTime: 10, successRate: 0.95, slippage: 0.5 }),
+      makeRoute({ id: 'r3', provider: 'wormhole', fee: { amount: '0.8', token: 'USDC', usdValue: 0.8 }, estimatedTime: 20, successRate: 0.92, slippage: 1.5 }),
+    ];
+
+    const result = engine.decide(candidates);
+
+    expect(result.selection).not.toBeNull();
+    expect(result.selection!.id).toBe('r1');
+    expect(['r2', 'r3']).toContain(result.alternatives[0]?.id);
+    expect(result.rejections).toEqual([]);
+    expect(result.appliedPolicy.maxResults).toBe(3);
+  });
+
+  it('rejects routes that exceed the slippage policy', () => {
+    const engine = new StellarRouteDecisionEngine({ now });
+    const candidates: BridgeRoute[] = [
+      makeRoute({ id: 'high-slippage', provider: 'p1', slippage: 10 }),
+      makeRoute({ id: 'low-slippage', provider: 'p2', slippage: 0.2 }),
+    ];
+
+    const result = engine.decide(candidates, {}, { policy: { maxSlippage: 2 } });
+
+    expect(result.rejections.map((r) => r.route.id)).toEqual(['high-slippage']);
+    expect(result.selection?.id).toBe('low-slippage');
+  });
+
+  it('rejects routes from excluded providers', () => {
+    const engine = new StellarRouteDecisionEngine({ now });
+    const candidates: BridgeRoute[] = [
+      makeRoute({ id: 'a', provider: 'allbridge' }),
+      makeRoute({ id: 'b', provider: 'squid' }),
+    ];
+
+    const result = engine.decide(candidates, {}, {
+      policy: { excludeProviders: ['allbridge'] },
+    });
+
+    expect(result.rejections.find((r) => r.route.id === 'a')).toBeDefined();
+    expect(result.selection?.id).toBe('b');
+  });
+
+  it('honors a risk ceiling supplied via signals', () => {
+    const engine = new StellarRouteDecisionEngine({ now });
+    const candidates: BridgeRoute[] = [
+      makeRoute({ id: 'safe', provider: 'allbridge', successRate: 0.99 }),
+      makeRoute({ id: 'risky', provider: 'unknown', successRate: 0.9 }),
+    ];
+
+    const result = engine.decide(candidates, {}, {
+      policy: { minRiskScore: 0.5 },
+      signals: {
+        riskSignals: [
+          { routeId: 'risky', riskScore: 0.9, reason: 'centralized single validator' },
+        ],
+      },
+    });
+
+    expect(result.rejections.find((r) => r.route.id === 'risky')).toBeDefined();
+    expect(result.selection?.id).toBe('safe');
+  });
+
+  it('drops routes marked incompatible by compatibility signals', () => {
+    const engine = new StellarRouteDecisionEngine({ now });
+    const candidates: BridgeRoute[] = [
+      makeRoute({ id: 'good', provider: 'allbridge' }),
+      makeRoute({ id: 'bad', provider: 'legacy' }),
+    ];
+
+    const result = engine.decide(candidates, {}, {
+      signals: {
+        compatibilitySignals: [
+          { routeId: 'bad', compatible: false, missingFeatures: ['custom_types_v2'] },
+        ],
+      },
+    });
+
+    expect(result.rejections.find((r) => r.route.id === 'bad')).toBeDefined();
+    expect(result.selection?.id).toBe('good');
+  });
+
+  it('respects maxResults when returning alternatives', () => {
+    const engine = new StellarRouteDecisionEngine({ now });
+
+    const routes: BridgeRoute[] = Array.from({ length: 5 }, (_, i) =>
+      makeRoute({ id: `r${i}`, provider: `p${i}`, fee: { amount: `${i}`, token: 'USDC', usdValue: i } }),
+    );
+
+    const result = engine.decide(routes, {}, { policy: { maxResults: 2 } });
+
+    expect(result.selection).not.toBeNull();
+    expect(result.selection!.id).toBe('r0');
+    expect(result.alternatives.length).toBe(1);
+    expect(result.appliedPolicy.maxResults).toBe(2);
+    expect(result.rejections.length).toBe(0);
+  });
+
+  it('produces a rejection list when every candidate is filtered', () => {
+    const engine = new StellarRouteDecisionEngine({ now });
+    const candidates: BridgeRoute[] = [
+      makeRoute({ id: 'a', provider: 'p1', slippage: 10 }),
+      makeRoute({ id: 'b', provider: 'p2', successRate: 0.5 }),
+    ];
+
+    const result = engine.decide(candidates);
+
+    expect(result.selection).toBeNull();
+    expect(result.alternatives).toEqual([]);
+    expect(result.rejections.map((r) => r.route.id).sort()).toEqual(['a', 'b']);
+  });
+});

--- a/src/routing/decision-engine/stellar/stellar-route-decision-engine.ts
+++ b/src/routing/decision-engine/stellar/stellar-route-decision-engine.ts
@@ -1,0 +1,285 @@
+/**
+ * File: src/routing/decision-engine/stellar/stellar-route-decision-engine.ts
+ *
+ * Centralizes Stellar route selection logic.
+ *
+ * The engine is the single entry point callers should reach for when they
+ * need to pick which Stellar bridge route(s) to surface. It accepts a list
+ * of raw candidates, applies a default policy, consults the existing
+ * `RouteRanker` for multi-criteria scoring, and folds in any optional risk
+ * and compatibility signals the caller supplies.
+ *
+ * Design goals:
+ *   - One decision path for Stellar (no more "should I use rankRoutes or
+ *     something else?" conversations).
+ *   - Every rejected candidate is returned with a reason, so callers/UI
+ *     can tell users *why* a route didn't make the cut.
+ *   - Pure / dependency-free by default so the engine is trivial to test.
+ *   - Signals (risk, compatibility) are additive, not required.
+ */
+
+import {
+  BridgeRoute,
+  RankedRoute,
+  RankingCriteria,
+  RouteRanker,
+  routeRanker as defaultRouteRanker,
+} from '../../../services/route-ranker';
+
+import {
+  StellarDecisionContext,
+  StellarDecisionEntry,
+  StellarDecisionPolicy,
+  StellarDecisionRankingOptions,
+  StellarDecisionResult,
+  StellarDecisionSignals,
+} from './types';
+
+const DEFAULT_POLICY: Required<StellarDecisionPolicy> = {
+  maxSlippage: 5.0,
+  maxTime: 60,
+  minSuccessRate: 0.8,
+  excludeProviders: [],
+  minRiskScore: 0,
+  maxResults: 3,
+};
+
+/**
+ * The decision engine is intentionally a class so callers can swap the
+ * underlying `RouteRanker` for tests or for alternative ranking schemes
+ * (e.g. weighted by liquidity depth).
+ */
+export class StellarRouteDecisionEngine {
+  private readonly ranker: RouteRanker;
+  private readonly defaultRanking: RankingCriteria;
+  private readonly defaultPolicy: Required<StellarDecisionPolicy>;
+  private readonly now: () => number;
+
+  constructor(options: {
+    ranker?: RouteRanker;
+    policy?: Partial<StellarDecisionPolicy>;
+    ranking?: StellarDecisionRankingOptions;
+    now?: () => number;
+  } = {}) {
+    this.ranker = options.ranker ?? defaultRouteRanker;
+    this.now = options.now ?? (() => Date.now());
+    this.defaultPolicy = { ...DEFAULT_POLICY, ...(options.policy ?? {}) };
+    this.defaultRanking = { ...this.ranker.getDefaultCriteria(), ...(options.ranking ?? {}) };
+  }
+
+  /**
+   * Evaluate route candidates and return a final decision.
+   *
+   * The pipeline is:
+   *   1. Merge caller policy with defaults.
+   *   2. Reject routes that violate hard limits (slippage, time, success
+   *      rate, excludeProviders, risk, compatibility).
+   *   3. Score surviving routes via `RouteRanker`.
+   *   4. Map ranked routes to decision entries with custom reasons.
+   *   5. Trim the result list to `maxResults`.
+   */
+  decide(
+    candidates: BridgeRoute[],
+    context: StellarDecisionContext = {},
+    options: {
+      policy?: Partial<StellarDecisionPolicy>;
+      ranking?: StellarDecisionRankingOptions;
+      signals?: StellarDecisionSignals;
+    } = {},
+  ): StellarDecisionResult {
+    const policy = this.mergePolicy(options.policy);
+    const ranking = { ...this.defaultRanking, ...(options.ranking ?? {}) };
+    const signals = options.signals ?? {};
+
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      return {
+        selection: null,
+        alternatives: [],
+        rejections: [],
+        appliedPolicy: policy,
+        decidedAt: this.now(),
+      };
+    }
+
+    const riskById = indexBy(signals.riskSignals, (s) => s.routeId);
+    const compatById = indexBy(signals.compatibilitySignals, (s) => s.routeId);
+
+    // 2 — gate the candidates before ranking so we never score a route
+    // that is going to be rejected anyway.
+    const rejections: StellarDecisionResult['rejections'] = [];
+    const survivors: BridgeRoute[] = [];
+
+    for (const route of candidates) {
+      const reason = this.gate(route, policy, riskById, compatById);
+      if (reason === null) {
+        survivors.push(route);
+      } else {
+        rejections.push({ route, reason });
+      }
+    }
+
+    if (survivors.length === 0) {
+      return {
+        selection: null,
+        alternatives: [],
+        rejections,
+        appliedPolicy: policy,
+        decidedAt: this.now(),
+      };
+    }
+
+    // 3 — score survivors.
+    const ranked = this.ranker.rankRoutes(survivors, ranking);
+
+    // 4 — convert RankedRoutes to decision entries.
+    const entries: StellarDecisionEntry[] = ranked.map((route, index) => {
+      const entry = this.toEntry(route, index === 0, policy, context, signals);
+      return entry;
+    });
+
+    // 5 — trim and split.
+    const trimmed = entries.slice(0, policy.maxResults);
+    const selection = trimmed.length > 0 ? trimmed[0] : null;
+    const alternatives = trimmed.slice(1);
+
+    return {
+      selection,
+      alternatives,
+      rejections,
+      appliedPolicy: policy,
+      decidedAt: this.now(),
+    };
+  }
+
+  /** Merged policy used by the engine. */
+  getDefaultPolicy(): Required<StellarDecisionPolicy> {
+    return { ...this.defaultPolicy };
+  }
+
+  /** Merged ranking used for the underlying score. */
+  getDefaultRanking(): RankingCriteria {
+    return { ...this.defaultRanking };
+  }
+
+  // ─── Internals ───────────────────────────────────────────────────────────
+
+  private mergePolicy(
+    override: Partial<StellarDecisionPolicy> | undefined,
+  ): Required<StellarDecisionPolicy> {
+    return { ...this.defaultPolicy, ...(override ?? {}) };
+  }
+
+  private gate(
+    route: BridgeRoute,
+    policy: Required<StellarDecisionPolicy>,
+    riskById: Map<string, { riskScore: number; reason?: string }>,
+    compatById: Map<string, { compatible: boolean; missingFeatures?: string[] }>,
+  ): string | null {
+    if (
+      typeof policy.maxSlippage === 'number' &&
+      typeof route.slippage === 'number' &&
+      route.slippage > policy.maxSlippage
+    ) {
+      return `slippage ${route.slippage}% exceeds policy max ${policy.maxSlippage}%`;
+    }
+
+    if (typeof policy.maxTime === 'number' && route.estimatedTime > policy.maxTime) {
+      return `estimated time ${route.estimatedTime}m exceeds policy max ${policy.maxTime}m`;
+    }
+
+    if (
+      typeof policy.minSuccessRate === 'number' &&
+      route.successRate < policy.minSuccessRate
+    ) {
+      return `success rate ${route.successRate} below policy min ${policy.minSuccessRate}`;
+    }
+
+    if (policy.excludeProviders?.includes(route.provider)) {
+      return `provider "${route.provider}" is on the exclude list`;
+    }
+
+    const risk = riskById.get(route.id);
+    if (risk && typeof policy.minRiskScore === 'number') {
+      // minRiskScore = 0 means "block only routes at the riskiest end" (score 1),
+      // minRiskScore = 0.5 means "block any route whose risk is above 0.5".
+      if (risk.riskScore > policy.minRiskScore && policy.minRiskScore > 0) {
+        return `risk score ${risk.riskScore} exceeds policy ceiling`;
+      }
+      // Also support a literal block: if minRiskScore is 1, only allow routes
+      // with riskScore === 0.
+      if (policy.minRiskScore >= 1 && risk.riskScore > 0) {
+        return `risk score ${risk.riskScore} exceeds policy ceiling`;
+      }
+    }
+
+    const compat = compatById.get(route.id);
+    if (compat && compat.compatible === false) {
+      const missing = compat.missingFeatures?.length
+        ? ` (missing: ${compat.missingFeatures.join(', ')})`
+        : '';
+      return `provider marked incompatible with the requested application${missing}`;
+    }
+
+    return null;
+  }
+
+  private toEntry(
+    ranked: RankedRoute,
+    isTop: boolean,
+    policy: Required<StellarDecisionPolicy>,
+    context: StellarDecisionContext,
+    signals: StellarDecisionSignals,
+  ): StellarDecisionEntry {
+    const warnings: string[] = [];
+
+    if (ranked.confidence !== undefined && ranked.confidence < 0.5) {
+      warnings.push('Low confidence estimate — verify before submitting.');
+    }
+    if (typeof ranked.slippage === 'number' && ranked.slippage > 0) {
+      warnings.push(`Estimated slippage is ${ranked.slippage}%.`);
+    }
+    if (ranked.networkMetrics?.availability === 0) {
+      warnings.push('Provider is currently reported unavailable.');
+    }
+    if (signals.compatibilitySignals?.find((s) => s.routeId === ranked.id && !s.compatible)) {
+      warnings.push('Compatibility signal marked this provider as incompatible.');
+    }
+
+    const reason = isTop
+      ? this.buildTopReason(ranked, policy, context)
+      : `Alternative ranked #${ranked.rank} with score ${ranked.score.toFixed(3)}.`;
+
+    return {
+      ...ranked,
+      reason,
+      warnings,
+    };
+  }
+
+  private buildTopReason(
+    ranked: RankedRoute,
+    policy: Required<StellarDecisionPolicy>,
+    context: StellarDecisionContext,
+  ): string {
+    const network = context.network ?? 'public';
+    return [
+      `Selected for ${network} network as best overall fit for the active policy.`,
+      `score=${ranked.score.toFixed(3)}`,
+      `slippagePolicy=${policy.maxSlippage}%`,
+      `timePolicy=${policy.maxTime}m`,
+    ].join(' ');
+  }
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function indexBy<T, K>(items: T[] | undefined, key: (item: T) => K): Map<K, T> {
+  const map = new Map<K, T>();
+  if (!items) return map;
+  for (const item of items) {
+    map.set(key(item), item);
+  }
+  return map;
+}
+
+export default StellarRouteDecisionEngine;

--- a/src/routing/decision-engine/stellar/types.ts
+++ b/src/routing/decision-engine/stellar/types.ts
@@ -1,0 +1,89 @@
+/**
+ * File: src/routing/decision-engine/stellar/types.ts
+ *
+ * Type definitions used by the Stellar Route Decision Engine.
+ *
+ * The engine is the single source of truth for which Stellar bridge routes
+ * are presented to clients. It takes a list of raw candidates, applies
+ * ranking/risk/compatibility gates, and returns a final selection together
+ * with a reasoning trail that callers can surface in UIs/logs.
+ */
+
+import type { BridgeRoute, RankingCriteria, RankedRoute } from '../../../services/route-ranker';
+
+/** Public policy that callers can supply to influence route selection. */
+export interface StellarDecisionPolicy {
+  /** Maximum acceptable slippage percentage, applied before ranking. */
+  maxSlippage?: number;
+  /** Maximum acceptable estimated time in minutes. */
+  maxTime?: number;
+  /** Minimum acceptable historical success rate (0-1). */
+  minSuccessRate?: number;
+  /** Providers that should never be returned (compliance, regional, etc). */
+  excludeProviders?: string[];
+  /** Minimum acceptable risk score (0 = riskiest, 1 = safest). */
+  minRiskScore?: number;
+  /** How many ranked routes the caller wants to see in the final result. */
+  maxResults?: number;
+}
+
+/** Caller context (e.g. wallet tier, network, asset class). */
+export interface StellarDecisionContext {
+  /** Initiator wallet/address. */
+  walletAddress?: string;
+  /** Stellar network (PUBLIC/TESTNET/FUTURENET). */
+  network?: string;
+  /** Free-form tags used for logging & analytics. */
+  tags?: Record<string, string>;
+}
+
+/** Single output entry returned by the engine. */
+export interface StellarDecisionEntry extends RankedRoute {
+  /** Reason this entry survived every gate. */
+  reason: string;
+  /** Any warnings the engine wants to surface alongside the route. */
+  warnings: string[];
+}
+
+/** Aggregated decision returned to the caller. */
+export interface StellarDecisionResult {
+  /** Selected route (rank 1), or null when nothing survived. */
+  selection: StellarDecisionEntry | null;
+  /** All alternatives that survived, ordered by rank. */
+  alternatives: StellarDecisionEntry[];
+  /** Routes that were filtered out and the reason each one was rejected. */
+  rejections: Array<{ route: BridgeRoute; reason: string }>;
+  /** The policy that was actually applied after defaults were merged. */
+  appliedPolicy: Required<StellarDecisionPolicy>;
+  /** Snapshot of when this decision was produced. */
+  decidedAt: number;
+}
+
+/** Optional knobs forwarded to the underlying RouteRanker. */
+export interface StellarDecisionRankingOptions
+  extends Partial<RankingCriteria> {}
+
+/** Risk signal fed into the decision (typically produced by a risk engine). */
+export interface StellarRouteRiskSignal {
+  /** Stable route id matching the candidate BridgeRoute.id. */
+  routeId: string;
+  /** Risk score in [0, 1] where 1 = highest risk. */
+  riskScore: number;
+  /** Optional human-readable reason for the risk score. */
+  reason?: string;
+}
+
+/** Compatibility signal fed into the decision (provider × feature). */
+export interface StellarRouteCompatibilitySignal {
+  routeId: string;
+  /** True when the (application, provider) pair is known to be compatible. */
+  compatible: boolean;
+  /** Free-form missing features surfaced when not compatible. */
+  missingFeatures?: string[];
+}
+
+/** Engine dependencies that callers can supply to enrich the decision. */
+export interface StellarDecisionSignals {
+  riskSignals?: StellarRouteRiskSignal[];
+  compatibilitySignals?: StellarRouteCompatibilitySignal[];
+}


### PR DESCRIPTION
## Summary

Centralizes Stellar bridge route selection under a single decision entry point so callers no longer have to choose between ad-hoc ranking helpers.

## What this PR adds

- `src/routing/decision-engine/stellar/types.ts` — public policy / context / signal / result types.
- `src/routing/decision-engine/stellar/stellar-route-decision-engine.ts` — `StellarRouteDecisionEngine` class implementing `decide(candidates, context, options) -> StellarDecisionResult`.
- `src/routing/decision-engine/stellar/stellar-route-decision-engine.spec.ts` — unit tests covering happy paths, slippage/time/provider gates, risk & compatibility signals, maxResults, and full-rejection.
- `src/routing/decision-engine/stellar/index.ts` — barrel.

## Pipeline

1. Merge caller policy with engine defaults.
2. Reject routes that violate hard limits (slippage, time, success rate, excludeProviders, risk ceiling, compatibility signals). Every rejected candidate is returned with the reason.
3. Score the surviving routes through the existing `RouteRanker` (multi-criteria: fee, speed, reliability, confidence, network score).
4. Convert `RankedRoute`s into `StellarDecisionEntry`s with top-pick reason and warnings.
5. Split into a top `selection` + ordered `alternatives`, trimmed to `maxResults`.

## Acceptance Criteria

- [x] Decision engine implemented
- [x] Route selections centralized (callers only ever go through `StellarRouteDecisionEngine.decide`)

Closes #504