### PR TITLE
feat(stellar): implement Soroban Bridge Intelligence Dashboard (#505)

### DIFF
--- a/apps/dashboard/intelligence/stellar/SorobanBridgeIntelligenceDashboard.test.tsx
+++ b/apps/dashboard/intelligence/stellar/SorobanBridgeIntelligenceDashboard.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * File: apps/dashboard/intelligence/stellar/SorobanBridgeIntelligenceDashboard.test.tsx
+ *
+ * Lightweight smoke + interaction tests for the Soroban Bridge
+ * Intelligence Dashboard. Tests rely on react-testing-library which the
+ * root jest config already supports.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SorobanBridgeIntelligenceDashboard } from './SorobanBridgeIntelligenceDashboard';
+import { round, trendDirection } from './metrics';
+
+describe('metrics helpers', () => {
+  it('rounds to the requested precision', () => {
+    expect(round(1.23456, 2)).toBe(1.23);
+    expect(round(1.235, 2)).toBe(1.24);
+    expect(round(NaN, 2)).toBe(0);
+  });
+
+  it('returns flat when there are fewer than two trend points', () => {
+    expect(trendDirection([]).direction).toBe('flat');
+    expect(trendDirection([{ timestamp: 0, value: 1 }]).direction).toBe('flat');
+  });
+
+  it('detects up vs down trend correctly', () => {
+    const points = [
+      { timestamp: 0, value: 100 },
+      { timestamp: 1, value: 110 },
+    ];
+    expect(trendDirection(points).direction).toBe('up');
+    expect(
+      trendDirection([
+        { timestamp: 0, value: 110 },
+        { timestamp: 1, value: 100 },
+      ]).direction,
+    ).toBe('down');
+  });
+});
+
+describe('SorobanBridgeIntelligenceDashboard', () => {
+  it('renders headline metrics from the default mock snapshot', () => {
+    render(<SorobanBridgeIntelligenceDashboard />);
+
+    // The headline card always renders the four metrics. Titles in CAPS.
+    expect(screen.getByText(/Network Health/i)).toBeInTheDocument();
+    expect(screen.getByText(/Total Volume/i)).toBeInTheDocument();
+    expect(screen.getByText(/Avg Success Rate/i)).toBeInTheDocument();
+    expect(screen.getByText(/Avg Latency/i)).toBeInTheDocument();
+  });
+
+  it('renders all three metric groups', () => {
+    render(<SorobanBridgeIntelligenceDashboard />);
+    expect(screen.getByLabelText(/Route metrics/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Provider metrics/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Asset metrics/i)).toBeInTheDocument();
+  });
+
+  it('opens the drill-down panel when a route row is clicked', () => {
+    render(<SorobanBridgeIntelligenceDashboard />);
+    const button = screen.getByRole('button', {
+      name: /Drill down on ETH/i,
+    });
+    fireEvent.click(button);
+    expect(screen.getByTestId('drill-down-panel')).toBeInTheDocument();
+  });
+
+  it('fires the onDrillDown callback when a row is clicked', () => {
+    const onDrillDown = jest.fn();
+    render(
+      <SorobanBridgeIntelligenceDashboard onDrillDown={onDrillDown} />,
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Drill down on Squid/i }),
+    );
+    expect(onDrillDown).toHaveBeenCalledWith({
+      kind: 'provider',
+      id: 'squid',
+    });
+  });
+});

--- a/apps/dashboard/intelligence/stellar/SorobanBridgeIntelligenceDashboard.tsx
+++ b/apps/dashboard/intelligence/stellar/SorobanBridgeIntelligenceDashboard.tsx
@@ -1,0 +1,441 @@
+/**
+ * File: apps/dashboard/intelligence/stellar/SorobanBridgeIntelligenceDashboard.tsx
+ *
+ * Main React component for the Soroban Bridge Intelligence Dashboard.
+ *
+ * Renders three metric groups (routes / providers / assets), a headline
+ * "network health" call-out, and a drill-down side panel that updates as
+ * the user selects rows. State is intentionally local — the dashboard
+ * is a leaf component with no global selectors.
+ */
+
+import React, { useMemo, useState } from 'react';
+
+import { round, trendDirection } from './metrics';
+import {
+  EMPTY_SNAPSHOT,
+  SorobanIntelligenceInput,
+  useSorobanIntelligence,
+} from './useSorobanIntelligence';
+import type { DrillDownTarget } from './types';
+
+const palette = {
+  bg: '#0b1020',
+  panel: '#11182f',
+  border: 'rgba(255,255,255,0.08)',
+  text: '#e6edf3',
+  muted: '#9aa6b2',
+  accent: '#7dd3fc',
+  danger: '#fb7185',
+  warn: '#fbbf24',
+  good: '#34d399',
+};
+
+const layoutStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr',
+  gap: 24,
+  padding: 24,
+  background: palette.bg,
+  color: palette.text,
+  fontFamily: 'system-ui, sans-serif',
+};
+
+const cardStyle: React.CSSProperties = {
+  background: palette.panel,
+  border: `1px solid ${palette.border}`,
+  borderRadius: 12,
+  padding: 16,
+};
+
+const headingStyle: React.CSSProperties = {
+  fontSize: 14,
+  letterSpacing: 1.2,
+  textTransform: 'uppercase',
+  color: palette.muted,
+  marginBottom: 8,
+};
+
+const metricValueStyle: React.CSSProperties = {
+  fontSize: 28,
+  fontWeight: 600,
+  color: palette.text,
+};
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 13,
+};
+
+const headerCellStyle: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '8px 10px',
+  borderBottom: `1px solid ${palette.border}`,
+  color: palette.muted,
+  fontWeight: 500,
+};
+
+const rowCellStyle: React.CSSProperties = {
+  padding: '10px',
+  borderBottom: `1px solid ${palette.border}`,
+};
+
+const buttonRowStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: `1px solid ${palette.border}`,
+  borderRadius: 6,
+  padding: '6px 10px',
+  color: palette.accent,
+  cursor: 'pointer',
+};
+
+const gridTwoColStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+  gap: 16,
+};
+
+export interface SorobanBridgeIntelligenceDashboardProps {
+  /**
+   * Optional inputs to inject real data; falls back to mock snapshots.
+   * Useful for parent apps that want to wire the live API in later.
+   */
+  input?: SorobanIntelligenceInput;
+  /**
+   * Optional drill-down callback that fires when the user clicks a row.
+   * Useful when embedding the dashboard inside a larger navigation system.
+   */
+  onDrillDown?: (target: DrillDownTarget) => void;
+  /**
+   * Optional initial drill-down selection, useful for deep-linking.
+   */
+  initialSelection?: DrillDownTarget | null;
+}
+
+export function SorobanBridgeIntelligenceDashboard({
+  input,
+  onDrillDown,
+  initialSelection = null,
+}: SorobanBridgeIntelligenceDashboardProps) {
+  const snapshot = useSorobanIntelligence(input);
+  const [selected, setSelected] = useState<DrillDownTarget | null>(
+    initialSelection,
+  );
+
+  const handleDrillDown = (target: DrillDownTarget) => {
+    setSelected(target);
+    if (onDrillDown) onDrillDown(target);
+  };
+
+  const detail = useMemo(() => {
+    if (!selected) return null;
+    switch (selected.kind) {
+      case 'route':
+        return snapshot.routes.find((r) => r.routeId === selected.id) ?? null;
+      case 'provider':
+        return (
+          snapshot.providers.find((p) => p.providerId === selected.id) ?? null
+        );
+      case 'asset':
+        return snapshot.assets.find((a) => a.asset === selected.id) ?? null;
+    }
+  }, [snapshot, selected]);
+
+  if (snapshot === EMPTY_SNAPSHOT) {
+    return (
+      <div style={layoutStyle} data-testid="soroban-intel-empty">
+        <p>No intelligence data available.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={layoutStyle} data-testid="soroban-intel-dashboard">
+      <HeadlineCard
+        networkHealth={snapshot.derived.networkHealth}
+        totalVolumeUsd={snapshot.derived.totalVolumeUsd}
+        averageSuccessRate={snapshot.derived.averageSuccessRate}
+        averageLatencySeconds={snapshot.derived.averageLatencySeconds}
+      />
+
+      <div style={gridTwoColStyle}>
+        <RouteTable
+          routes={snapshot.routes}
+          onSelect={(id) => handleDrillDown({ kind: 'route', id })}
+        />
+        <ProviderTable
+          providers={snapshot.providers}
+          tiers={snapshot.derived.reliabilityTiers}
+          onSelect={(id) => handleDrillDown({ kind: 'provider', id })}
+        />
+      </div>
+
+      <AssetTable
+        assets={snapshot.assets}
+        onSelect={(asset) => handleDrillDown({ kind: 'asset', id: asset })}
+      />
+
+      <DrillDownPanel
+        target={selected}
+        detail={detail}
+        onClear={() => setSelected(null)}
+      />
+    </div>
+  );
+}
+
+interface HeadlineProps {
+  networkHealth: number;
+  totalVolumeUsd: number;
+  averageSuccessRate: number;
+  averageLatencySeconds: number;
+}
+
+function HeadlineCard({
+  networkHealth,
+  totalVolumeUsd,
+  averageSuccessRate,
+  averageLatencySeconds,
+}: HeadlineProps) {
+  return (
+    <section style={cardStyle} aria-label="Network headline">
+      <div style={gridTwoColStyle}>
+        <Metric
+          label="Network Health"
+          value={`${(round(networkHealth, 2) * 100).toFixed(0)}%`}
+        />
+        <Metric label="Total Volume (USD)" value={`$${round(totalVolumeUsd, 0).toLocaleString()}`} />
+        <Metric
+          label="Avg Success Rate"
+          value={`${(round(averageSuccessRate * 100, 2))}%`}
+        />
+        <Metric
+          label="Avg Latency (s)"
+          value={`${round(averageLatencySeconds, 0)}s`}
+        />
+      </div>
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p style={headingStyle}>{label}</p>
+      <p style={metricValueStyle}>{value}</p>
+    </div>
+  );
+}
+
+interface RouteTableProps {
+  routes: ReturnType<typeof useSorobanIntelligence>['routes'];
+  onSelect: (routeId: string) => void;
+}
+
+function RouteTable({ routes, onSelect }: RouteTableProps) {
+  return (
+    <section style={cardStyle} aria-label="Route metrics">
+      <p style={headingStyle}>Routes</p>
+      <table style={tableStyle}>
+        <thead>
+          <tr>
+            <th style={headerCellStyle}>Route</th>
+            <th style={headerCellStyle}>Volume</th>
+            <th style={headerCellStyle}>Success</th>
+            <th style={headerCellStyle}>Latency</th>
+            <th style={headerCellStyle}>Trend</th>
+            <th style={headerCellStyle} />
+          </tr>
+        </thead>
+        <tbody>
+          {routes.map((route) => {
+            const trend = trendDirection(route.trend);
+            const trendColor =
+              trend.direction === 'up'
+                ? palette.good
+                : trend.direction === 'down'
+                ? palette.danger
+                : palette.muted;
+            return (
+              <tr key={route.routeId} data-testid={`route-row-${route.routeId}`}>
+                <td style={rowCellStyle}>{route.routeLabel}</td>
+                <td style={rowCellStyle}>${route.totalVolumeUsd.toLocaleString()}</td>
+                <td style={rowCellStyle}>{(route.successRate * 100).toFixed(1)}%</td>
+                <td style={rowCellStyle}>{route.averageLatencySeconds}s</td>
+                <td style={{ ...rowCellStyle, color: trendColor }}>
+                  {trend.direction} ({trend.delta > 0 ? '+' : ''}
+                  {trend.delta}%)
+                </td>
+                <td style={rowCellStyle}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(route.routeId)}
+                    style={buttonRowStyle}
+                    aria-label={`Drill down on ${route.routeLabel}`}
+                  >
+                    Drill down
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+interface ProviderTableProps {
+  providers: ReturnType<typeof useSorobanIntelligence>['providers'];
+  tiers: Record<string, 'excellent' | 'good' | 'fair' | 'poor'>;
+  onSelect: (providerId: string) => void;
+}
+
+function ProviderTable({ providers, tiers, onSelect }: ProviderTableProps) {
+  return (
+    <section style={cardStyle} aria-label="Provider metrics">
+      <p style={headingStyle}>Providers</p>
+      <table style={tableStyle}>
+        <thead>
+          <tr>
+            <th style={headerCellStyle}>Provider</th>
+            <th style={headerCellStyle}>Volume</th>
+            <th style={headerCellStyle}>Reliability</th>
+            <th style={headerCellStyle}>Incidents</th>
+            <th style={headerCellStyle} />
+          </tr>
+        </thead>
+        <tbody>
+          {providers.map((provider) => {
+            const tier = tiers[provider.providerId] ?? 'fair';
+            const tierColor =
+              tier === 'excellent'
+                ? palette.good
+                : tier === 'good'
+                ? palette.accent
+                : tier === 'fair'
+                ? palette.warn
+                : palette.danger;
+            return (
+              <tr
+                key={provider.providerId}
+                data-testid={`provider-row-${provider.providerId}`}
+              >
+                <td style={rowCellStyle}>{provider.providerName}</td>
+                <td style={rowCellStyle}>
+                  ${provider.totalVolumeUsd.toLocaleString()}
+                </td>
+                <td style={{ ...rowCellStyle, color: tierColor }}>
+                  {(provider.reliabilityScore * 100).toFixed(1)}% ({tier})
+                </td>
+                <td style={rowCellStyle}>{provider.incidentCount}</td>
+                <td style={rowCellStyle}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(provider.providerId)}
+                    style={buttonRowStyle}
+                    aria-label={`Drill down on ${provider.providerName}`}
+                  >
+                    Drill down
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function AssetTable({
+  assets,
+  onSelect,
+}: {
+  assets: ReturnType<typeof useSorobanIntelligence>['assets'];
+  onSelect: (asset: string) => void;
+}) {
+  return (
+    <section style={cardStyle} aria-label="Asset metrics">
+      <p style={headingStyle}>Assets</p>
+      <table style={tableStyle}>
+        <thead>
+          <tr>
+            <th style={headerCellStyle}>Asset</th>
+            <th style={headerCellStyle}>Liquidity</th>
+            <th style={headerCellStyle}>Bridges</th>
+            <th style={headerCellStyle}>Avg Fee</th>
+            <th style={headerCellStyle} />
+          </tr>
+        </thead>
+        <tbody>
+          {assets.map((asset) => (
+            <tr key={asset.asset} data-testid={`asset-row-${asset.asset}`}>
+              <td style={rowCellStyle}>{asset.asset}</td>
+              <td style={rowCellStyle}>
+                ${asset.totalLiquidityUsd.toLocaleString()}
+              </td>
+              <td style={rowCellStyle}>{asset.bridgesUsed.join(', ')}</td>
+              <td style={rowCellStyle}>${asset.averageBridgeFeeUsd}</td>
+              <td style={rowCellStyle}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(asset.asset)}
+                  style={buttonRowStyle}
+                  aria-label={`Drill down on ${asset.asset}`}
+                >
+                  Drill down
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+interface DrillDownPanelProps {
+  target: DrillDownTarget | null;
+  detail: unknown;
+  onClear: () => void;
+}
+
+function DrillDownPanel({ target, detail, onClear }: DrillDownPanelProps) {
+  if (!target) {
+    return (
+      <section style={cardStyle} aria-label="Drill-down empty">
+        <p style={headingStyle}>Click any row to drill down.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section style={cardStyle} aria-label={`Drill-down ${target.kind}`} data-testid="drill-down-panel">
+      <p style={headingStyle}>
+        Drill-down · {target.kind} · {target.id}
+      </p>
+      <pre
+        style={{
+          whiteSpace: 'pre-wrap',
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          fontSize: 12,
+          color: palette.text,
+        }}
+      >
+        {JSON.stringify(detail, null, 2)}
+      </pre>
+      <button
+        type="button"
+        onClick={onClear}
+        style={{ ...buttonRowStyle, marginTop: 8 }}
+        aria-label="Clear drill-down selection"
+      >
+        Close
+      </button>
+    </section>
+  );
+}
+
+export default SorobanBridgeIntelligenceDashboard;

--- a/apps/dashboard/intelligence/stellar/data.ts
+++ b/apps/dashboard/intelligence/stellar/data.ts
@@ -1,0 +1,111 @@
+/**
+ * File: apps/dashboard/intelligence/stellar/data.ts
+ *
+ * Mock data sources for the Soroban Bridge Intelligence Dashboard.
+ *
+ * In production, the parent app would inject real-time data via the hook
+ * (`useSorobanIntelligence`). For the standalone demo / Storybook, we
+ * ship a deterministic mock so the dashboard renders consistently.
+ */
+
+import type { AssetMetric, ProviderMetric, RouteMetric } from './types';
+
+function makeTrend(start: number, step: number, count: number, baseTime: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    timestamp: baseTime + index * 3_600_000,
+    value: round(start + index * step),
+  }));
+}
+
+const baseTime = Date.UTC(2026, 5, 20, 12, 0, 0);
+
+export const DEFAULT_ROUTE_METRICS: RouteMetric[] = [
+  {
+    routeId: 'eth-xlm-usdc-allbridge',
+    routeLabel: 'ETH ↔ XLM (USDC) via Allbridge',
+    providerId: 'allbridge',
+    totalVolumeUsd: 1_245_300,
+    successRate: 0.978,
+    averageLatencySeconds: 78,
+    averageFeeUsd: 0.42,
+    trend: makeTrend(78_200, 4_500, 8, baseTime),
+  },
+  {
+    routeId: 'eth-xlm-usdc-squid',
+    routeLabel: 'ETH ↔ XLM (USDC) via Squid',
+    providerId: 'squid',
+    totalVolumeUsd: 982_410,
+    successRate: 0.961,
+    averageLatencySeconds: 92,
+    averageFeeUsd: 0.55,
+    trend: makeTrend(63_400, 3_100, 8, baseTime),
+  },
+  {
+    routeId: 'bsc-xlm-usdt-wormhole',
+    routeLabel: 'BSC ↔ XLM (USDT) via Wormhole',
+    providerId: 'wormhole',
+    totalVolumeUsd: 712_880,
+    successRate: 0.942,
+    averageLatencySeconds: 118,
+    averageFeeUsd: 0.61,
+    trend: makeTrend(45_100, 2_900, 8, baseTime),
+  },
+];
+
+export const DEFAULT_PROVIDER_METRICS: ProviderMetric[] = [
+  {
+    providerId: 'allbridge',
+    providerName: 'Allbridge',
+    supportedRoutes: 14,
+    totalVolumeUsd: 4_210_000,
+    reliabilityScore: 0.967,
+    incidentCount: 1,
+    trend: makeTrend(520_000, 14_000, 8, baseTime),
+  },
+  {
+    providerId: 'squid',
+    providerName: 'Squid',
+    supportedRoutes: 11,
+    totalVolumeUsd: 3_120_000,
+    reliabilityScore: 0.948,
+    incidentCount: 2,
+    trend: makeTrend(390_000, 11_000, 8, baseTime),
+  },
+  {
+    providerId: 'wormhole',
+    providerName: 'Wormhole',
+    supportedRoutes: 9,
+    totalVolumeUsd: 1_980_000,
+    reliabilityScore: 0.911,
+    incidentCount: 4,
+    trend: makeTrend(245_000, 8_000, 8, baseTime),
+  },
+];
+
+export const DEFAULT_ASSET_METRICS: AssetMetric[] = [
+  {
+    asset: 'USDC',
+    totalLiquidityUsd: 6_700_000,
+    bridgesUsed: ['allbridge', 'squid'],
+    averageBridgeFeeUsd: 0.45,
+    trend: makeTrend(820_000, 18_000, 8, baseTime),
+  },
+  {
+    asset: 'USDT',
+    totalLiquidityUsd: 2_140_000,
+    bridgesUsed: ['wormhole'],
+    averageBridgeFeeUsd: 0.62,
+    trend: makeTrend(265_000, 4_500, 8, baseTime),
+  },
+  {
+    asset: 'XLM',
+    totalLiquidityUsd: 980_000,
+    bridgesUsed: ['allbridge', 'squid', 'wormhole'],
+    averageBridgeFeeUsd: 0.18,
+    trend: makeTrend(120_000, 2_000, 8, baseTime),
+  },
+];
+
+function round(value: number) {
+  return Math.round(value * 100) / 100;
+}

--- a/apps/dashboard/intelligence/stellar/index.ts
+++ b/apps/dashboard/intelligence/stellar/index.ts
@@ -1,0 +1,48 @@
+/**
+ * File: apps/dashboard/intelligence/stellar/index.ts
+ *
+ * Module barrel for the Soroban Bridge Intelligence Dashboard.
+ *
+ * Consumers (e.g. Next.js pages) can import the public surface from a
+ * single path:
+ *
+ *   import {
+ *     SorobanBridgeIntelligenceDashboard,
+ *     useSorobanIntelligence,
+ *   } from '@bridgewise/dashboard/intelligence/stellar';
+ */
+
+export { SorobanBridgeIntelligenceDashboard } from './SorobanBridgeIntelligenceDashboard';
+export { default } from './SorobanBridgeIntelligenceDashboard';
+export { useSorobanIntelligence, EMPTY_SNAPSHOT } from './useSorobanIntelligence';
+export {
+  computeNetworkHealth,
+  percentageChange,
+  reliabilityTier,
+  round,
+  sumVolume,
+  trendDirection,
+} from './metrics';
+export {
+  DEFAULT_ASSET_METRICS,
+  DEFAULT_PROVIDER_METRICS,
+  DEFAULT_ROUTE_METRICS,
+} from './data';
+
+export type {
+  AssetMetric,
+  DashboardDrillDownContext,
+  DrillDownResolver,
+  DrillDownTarget,
+  MetricTrend,
+  ProviderMetric,
+  RouteMetric,
+  TrendPoint,
+} from './types';
+
+export type {
+  SorobanIntelligenceInput,
+  SorobanIntelligenceSnapshot,
+} from './useSorobanIntelligence';
+
+export type { SorobanBridgeIntelligenceDashboardProps } from './SorobanBridgeIntelligenceDashboard';

--- a/apps/dashboard/intelligence/stellar/metrics.ts
+++ b/apps/dashboard/intelligence/stellar/metrics.ts
@@ -1,0 +1,89 @@
+/**
+ * File: apps/dashboard/intelligence/stellar/metrics.ts
+ *
+ * Pure helpers used by the Soroban Bridge Intelligence Dashboard.
+ *
+ * The dashboard leans on small, testable helpers so that the visual layer
+ * never has to do arbitrary math inline. Every helper is side-effect free
+ * and easy to plug into a Storybook story or a future CLI renderer.
+ */
+
+import type { TrendPoint } from './types';
+
+/** Round to a fixed precision (defaults to 2 decimals) for display. */
+export function round(value: number, precision = 2): number {
+  if (!Number.isFinite(value)) return 0;
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * Compute a percentage change between two values. Returns 0 when the
+ * previous value is zero so the UI never shows `NaN%` or `Infinity%`.
+ */
+export function percentageChange(
+  previous: number,
+  current: number,
+): number {
+  if (!Number.isFinite(previous) || !Number.isFinite(current)) return 0;
+  if (previous === 0) return current === 0 ? 0 : 100;
+  return round(((current - previous) / previous) * 100, 2);
+}
+
+/**
+ * Compare the most recent two points of a trend and return the direction
+ * plus the percentage delta. Uses `percentageChange` internally.
+ */
+export function trendDirection(points: TrendPoint[]): {
+  direction: 'up' | 'down' | 'flat';
+  delta: number;
+} {
+  if (!Array.isArray(points) || points.length < 2) {
+    return { direction: 'flat', delta: 0 };
+  }
+  const last = points[points.length - 1].value;
+  const prev = points[points.length - 2].value;
+  const delta = percentageChange(prev, last);
+  if (delta > 0.5) return { direction: 'up', delta };
+  if (delta < -0.5) return { direction: 'down', delta };
+  return { direction: 'flat', delta };
+}
+
+/**
+ * Bucket a reliability score (0–1) into the human readable tiers surfaced
+ * in the dashboard's "Health" column.
+ */
+export function reliabilityTier(score: number): 'excellent' | 'good' | 'fair' | 'poor' {
+  if (score >= 0.95) return 'excellent';
+  if (score >= 0.85) return 'good';
+  if (score >= 0.7) return 'fair';
+  return 'poor';
+}
+
+/**
+ * Aggregate volumes across many metric objects (used for the page-level
+ * "Total volume" call-out).
+ */
+export function sumVolume<T extends { totalVolumeUsd: number }>(items: T[]): number {
+  return items.reduce((acc, item) => acc + (item.totalVolumeUsd || 0), 0);
+}
+
+/**
+ * Compute a simple "network health" score in [0, 1] from the route/provide
+ * success-rate inputs. Used as the dashboard's headline indicator.
+ */
+export function computeNetworkHealth(input: {
+  averageSuccessRate: number;
+  averageReliability: number;
+  averageLatencySeconds: number;
+}): number {
+  const { averageSuccessRate, averageReliability, averageLatencySeconds } = input;
+  const latencyPenalty = Math.min(averageLatencySeconds / 600, 1);
+  // 50/40/10 weighting keeps success-rate the dominant factor.
+  return round(
+    averageSuccessRate * 0.5 +
+      averageReliability * 0.4 -
+      latencyPenalty * 0.1,
+    3,
+  );
+}

--- a/apps/dashboard/intelligence/stellar/types.ts
+++ b/apps/dashboard/intelligence/stellar/types.ts
@@ -1,0 +1,60 @@
+/**
+ * File: apps/dashboard/intelligence/stellar/types.ts
+ *
+ * Shared type definitions for the Soroban Bridge Intelligence Dashboard.
+ *
+ * The dashboard is intentionally typed so consumers (graphs, exports, CLI
+ * tooling) can pull a single, stable shape out of the data layer. Any new
+ * metric we want to visualize must be added here first.
+ */
+
+export type MetricTrend = 'up' | 'down' | 'flat';
+
+export interface TrendPoint {
+  /** ISO timestamp or epoch ms – the dashboard normalizes for display. */
+  timestamp: number;
+  /** Numeric value for the metric at this point in time. */
+  value: number;
+}
+
+export interface RouteMetric {
+  routeId: string;
+  routeLabel: string;
+  providerId: string;
+  totalVolumeUsd: number;
+  successRate: number;
+  averageLatencySeconds: number;
+  averageFeeUsd: number;
+  trend: TrendPoint[];
+}
+
+export interface ProviderMetric {
+  providerId: string;
+  providerName: string;
+  supportedRoutes: number;
+  totalVolumeUsd: number;
+  reliabilityScore: number;
+  /** Aggregated historical incidents reported against this provider. */
+  incidentCount: number;
+  trend: TrendPoint[];
+}
+
+export interface AssetMetric {
+  asset: string;
+  totalLiquidityUsd: number;
+  bridgesUsed: string[];
+  averageBridgeFeeUsd: number;
+  trend: TrendPoint[];
+}
+
+export interface DrillDownTarget {
+  kind: 'route' | 'provider' | 'asset';
+  id: string;
+}
+
+export type DrillDownResolver = (target: DrillDownTarget) => void;
+
+export interface DashboardDrillDownContext {
+  onDrillDown: DrillDownResolver;
+  selected: DrillDownTarget | null;
+}

--- a/apps/dashboard/intelligence/stellar/useSorobanIntelligence.ts
+++ b/apps/dashboard/intelligence/stellar/useSorobanIntelligence.ts
@@ -1,0 +1,124 @@
+/**
+ * File: apps/dashboard/intelligence/stellar/useSorobanIntelligence.ts
+ *
+ * Data hook for the Soroban Bridge Intelligence Dashboard.
+ *
+ * Consumer pages call `useSorobanIntelligence()` to receive a
+ * deterministic snapshot of the route / provider / asset metrics plus
+ * derived totals. The hook is mock-friendly: callers can pass a fetcher
+ * that will eventually hit the API, while the default falls back to the
+ * deterministic mock data in `./data`.
+ */
+
+import { useMemo } from 'react';
+
+import {
+  DEFAULT_ASSET_METRICS,
+  DEFAULT_PROVIDER_METRICS,
+  DEFAULT_ROUTE_METRICS,
+} from './data';
+import {
+  computeNetworkHealth,
+  reliabilityTier,
+  sumVolume,
+} from './metrics';
+import type {
+  AssetMetric,
+  ProviderMetric,
+  RouteMetric,
+} from './types';
+
+export interface SorobanIntelligenceInput {
+  routes?: RouteMetric[];
+  providers?: ProviderMetric[];
+  assets?: AssetMetric[];
+}
+
+export interface SorobanIntelligenceSnapshot {
+  routes: RouteMetric[];
+  providers: ProviderMetric[];
+  assets: AssetMetric[];
+  derived: {
+    totalVolumeUsd: number;
+    averageSuccessRate: number;
+    averageReliability: number;
+    averageLatencySeconds: number;
+    networkHealth: number;
+    reliabilityTiers: Record<string, 'excellent' | 'good' | 'fair' | 'poor'>;
+  };
+}
+
+const EMPTY_DERIVED: SorobanIntelligenceSnapshot['derived'] = {
+  totalVolumeUsd: 0,
+  averageSuccessRate: 0,
+  averageReliability: 0,
+  averageLatencySeconds: 0,
+  networkHealth: 0,
+  reliabilityTiers: {},
+};
+
+/**
+ * Returns a fully-typed snapshot for the dashboard. Pure / memoised so
+ * re-renders stay cheap when used inside a `React.memo` parent.
+ */
+export function useSorobanIntelligence(
+  input: SorobanIntelligenceInput = {},
+): SorobanIntelligenceSnapshot {
+  return useMemo(() => {
+    const routes = input.routes ?? DEFAULT_ROUTE_METRICS;
+    const providers = input.providers ?? DEFAULT_PROVIDER_METRICS;
+    const assets = input.assets ?? DEFAULT_ASSET_METRICS;
+
+    const totalVolumeUsd =
+      sumVolume(routes) + sumVolume(providers) + sumVolume(assets);
+
+    const averageSuccessRate = average(routes.map((r) => r.successRate));
+    const averageReliability = average(
+      providers.map((p) => p.reliabilityScore),
+    );
+    const averageLatencySeconds = average(
+      routes.map((r) => r.averageLatencySeconds),
+    );
+
+    const networkHealth = computeNetworkHealth({
+      averageSuccessRate,
+      averageReliability,
+      averageLatencySeconds,
+    });
+
+    const reliabilityTiers = providers.reduce<
+      Record<string, 'excellent' | 'good' | 'fair' | 'poor'>
+    >((acc, provider) => {
+      acc[provider.providerId] = reliabilityTier(provider.reliabilityScore);
+      return acc;
+    }, {});
+
+    const derived = {
+      totalVolumeUsd,
+      averageSuccessRate,
+      averageReliability,
+      averageLatencySeconds,
+      networkHealth,
+      reliabilityTiers,
+    };
+
+    return { routes, providers, assets, derived };
+  }, [
+    input.routes,
+    input.providers,
+    input.assets,
+  ]);
+}
+
+export const EMPTY_SNAPSHOT: SorobanIntelligenceSnapshot = {
+  routes: [],
+  providers: [],
+  assets: [],
+  derived: EMPTY_DERIVED,
+};
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  const total = values.reduce((sum, value) => sum + (value || 0), 0);
+  return total / values.length;
+}


### PR DESCRIPTION
Adds a centralized Soroban Bridge Intelligence Dashboard under `apps/dashboard/intelligence/stellar/` that visualizes route / provider / asset metrics and supports drill-down views. Includes a typed React component, a memoised data hook with deterministic mock snapshots, and dedicated pure helpers (rounding, trend, reliability tier, network-health).

Closes #505

closes #506 

Closes #507