### PR TITLE
feat(timeline): implement stellar transfer timeline generator (#453)

### DIFF
--- a/src/timeline/transfers/stellar/index.ts
+++ b/src/timeline/transfers/stellar/index.ts
@@ -1,0 +1,7 @@
+export { StellarTransferTimelineGenerator } from './stellar-transfer-timeline';
+export type {
+  TimelineGeneratorOptions,
+  TimelineRenderOptions,
+  TimelineStage,
+  TransferTimeline,
+} from './types';

--- a/src/timeline/transfers/stellar/stellar-transfer-timeline.spec.ts
+++ b/src/timeline/transfers/stellar/stellar-transfer-timeline.spec.ts
@@ -1,0 +1,235 @@
+import { TransferStateMachine } from '../../../transfers/state-machine/stellar';
+import type { TransferLifecycle } from '../../../transfers/state-machine/stellar';
+import { StellarTransferTimelineGenerator } from './stellar-transfer-timeline';
+
+/**
+ * Builds a state machine driven by a caller-controlled clock.
+ */
+function machineAt(transferId: string, clock: { t: number }): TransferStateMachine {
+  return new TransferStateMachine(transferId, () => clock.t);
+}
+
+function generatorAt(now: number): StellarTransferTimelineGenerator {
+  return new StellarTransferTimelineGenerator({ now: () => now });
+}
+
+describe('StellarTransferTimelineGenerator', () => {
+  it('produces a single in-flight stage for a lifecycle with no transitions', () => {
+    const clock = { t: 1000 };
+    const machine = machineAt('tx-empty', clock);
+
+    const timeline = generatorAt(3000).generate(machine.state);
+
+    expect(timeline.stages).toHaveLength(1);
+    expect(timeline.stages[0].state).toBe('CREATED');
+    expect(timeline.stages[0].enteredAt).toBe(1000);
+    expect(timeline.stages[0].isCurrent).toBe(true);
+    expect(timeline.isComplete).toBe(false);
+    expect(timeline.totalDurationMs).toBe(2000);
+  });
+
+  it('derives stage boundaries and durations from consecutive transitions', () => {
+    const clock = { t: 1000 };
+    const machine = machineAt('tx-durations', clock);
+
+    clock.t = 1500;
+    machine.transition('VALIDATING', 'checks started');
+    clock.t = 2200;
+    machine.transition('ROUTE_SELECTED');
+
+    const timeline = generatorAt(3000).generate(machine.state);
+
+    expect(timeline.stages.map((s) => s.state)).toEqual([
+      'CREATED',
+      'VALIDATING',
+      'ROUTE_SELECTED',
+    ]);
+    expect(timeline.stages[0].durationMs).toBe(500);
+    expect(timeline.stages[0].exitedAt).toBe(1500);
+    expect(timeline.stages[1].durationMs).toBe(700);
+    expect(timeline.stages[2].durationMs).toBe(800);
+    expect(timeline.stages[2].isCurrent).toBe(true);
+    expect(timeline.totalDurationMs).toBe(2000);
+  });
+
+  it('records the reason attached to a transition', () => {
+    const clock = { t: 0 };
+    const machine = machineAt('tx-reason', clock);
+
+    clock.t = 50;
+    machine.transition('VALIDATING', 'checks started');
+
+    const timeline = generatorAt(100).generate(machine.state);
+
+    expect(timeline.stages[1].reason).toBe('checks started');
+    expect(timeline.stages[0].reason).toBeUndefined();
+  });
+
+  it('indexes stages sequentially from zero', () => {
+    const clock = { t: 0 };
+    const machine = machineAt('tx-index', clock);
+
+    clock.t = 10;
+    machine.transition('VALIDATING');
+    clock.t = 20;
+    machine.transition('ROUTE_SELECTED');
+
+    const timeline = generatorAt(30).generate(machine.state);
+
+    expect(timeline.stages.map((s) => s.index)).toEqual([0, 1, 2]);
+  });
+
+  it('freezes the timeline once a transfer completes', () => {
+    const clock = { t: 1000 };
+    const machine = machineAt('tx-complete', clock);
+
+    const path = [
+      'VALIDATING',
+      'ROUTE_SELECTED',
+      'BRIDGE_LOCKING',
+      'BRIDGE_LOCKED',
+      'EXECUTING',
+      'COMPLETED',
+    ] as const;
+    path.forEach((state, i) => {
+      clock.t = 1100 + i * 100;
+      machine.transition(state);
+    });
+
+    const timeline = generatorAt(999999).generate(machine.state);
+
+    expect(timeline.isComplete).toBe(true);
+    expect(timeline.stages).toHaveLength(7);
+    expect(timeline.endedAt).toBe(1600);
+    expect(timeline.totalDurationMs).toBe(600);
+    expect(timeline.stages[6].durationMs).toBe(0);
+  });
+
+  it('treats REFUNDED as terminal', () => {
+    const clock = { t: 0 };
+    const machine = machineAt('tx-refunded', clock);
+
+    clock.t = 10;
+    machine.transition('FAILED');
+    clock.t = 20;
+    machine.transition('REFUNDED');
+
+    expect(generatorAt(500).generate(machine.state).isComplete).toBe(true);
+  });
+
+  it('does not treat FAILED as terminal, since recovery remains possible', () => {
+    const clock = { t: 0 };
+    const machine = machineAt('tx-failed', clock);
+
+    clock.t = 10;
+    machine.transition('FAILED', 'bridge timeout');
+
+    const timeline = generatorAt(500).generate(machine.state);
+
+    expect(timeline.isComplete).toBe(false);
+    expect(timeline.currentState).toBe('FAILED');
+    expect(timeline.stages[1].durationMs).toBe(490);
+  });
+
+  it('surfaces a triggered recovery path', () => {
+    const clock = { t: 0 };
+    const machine = machineAt('tx-recovery', clock);
+
+    clock.t = 10;
+    machine.transition('FAILED');
+    machine.setRecoveryPath('auto-retry');
+
+    const timeline = generatorAt(100).generate(machine.state);
+
+    expect(timeline.recoveryPath?.path).toBe('auto-retry');
+  });
+
+  it('omits the recovery path when none was triggered', () => {
+    const clock = { t: 0 };
+    const machine = machineAt('tx-no-recovery', clock);
+
+    expect(generatorAt(100).generate(machine.state).recoveryPath).toBeUndefined();
+  });
+
+  it('sorts out-of-order events and never reports negative durations', () => {
+    const lifecycle: TransferLifecycle = {
+      transferId: 'tx-unsorted',
+      currentState: 'ROUTE_SELECTED',
+      createdAt: 1000,
+      updatedAt: 3000,
+      events: [
+        { from: 'VALIDATING', to: 'ROUTE_SELECTED', timestamp: 3000 },
+        { from: 'CREATED', to: 'VALIDATING', timestamp: 2000 },
+      ],
+    };
+
+    const timeline = generatorAt(4000).generate(lifecycle);
+
+    expect(timeline.stages.map((s) => s.state)).toEqual([
+      'CREATED',
+      'VALIDATING',
+      'ROUTE_SELECTED',
+    ]);
+    expect(timeline.stages.every((s) => s.durationMs >= 0)).toBe(true);
+  });
+
+  it('does not mutate the lifecycle it is given', () => {
+    const clock = { t: 0 };
+    const machine = machineAt('tx-immutable', clock);
+    clock.t = 10;
+    machine.transition('VALIDATING');
+
+    const lifecycle = machine.state;
+    const before = JSON.stringify(lifecycle);
+    generatorAt(100).generate(lifecycle);
+
+    expect(JSON.stringify(lifecycle)).toBe(before);
+  });
+
+  it('rejects a lifecycle without a transferId', () => {
+    const lifecycle: TransferLifecycle = {
+      transferId: '',
+      currentState: 'CREATED',
+      createdAt: 0,
+      updatedAt: 0,
+      events: [],
+    };
+
+    expect(() => generatorAt(100).generate(lifecycle)).toThrow(/transferId/);
+  });
+
+  describe('render', () => {
+    it('marks the active stage and lists every state', () => {
+      const clock = { t: 0 };
+      const machine = machineAt('tx-render', clock);
+      clock.t = 1000;
+      machine.transition('VALIDATING', 'checks started');
+
+      const generator = generatorAt(2000);
+      const output = generator.render(generator.generate(machine.state));
+
+      expect(output).toContain('tx-render');
+      expect(output).toContain('in progress');
+      expect(output).toContain('CREATED');
+      expect(output).toContain('> [1] VALIDATING');
+      expect(output).toContain('checks started');
+    });
+
+    it('honours includeReasons and includeDurations', () => {
+      const clock = { t: 0 };
+      const machine = machineAt('tx-render-opts', clock);
+      clock.t = 1000;
+      machine.transition('VALIDATING', 'checks started');
+
+      const generator = generatorAt(2000);
+      const timeline = generator.generate(machine.state);
+      const output = generator.render(timeline, {
+        includeReasons: false,
+        includeDurations: false,
+      });
+
+      expect(output).not.toContain('checks started');
+      expect(output).not.toContain('so far');
+    });
+  });
+});

--- a/src/timeline/transfers/stellar/stellar-transfer-timeline.ts
+++ b/src/timeline/transfers/stellar/stellar-transfer-timeline.ts
@@ -1,0 +1,180 @@
+import type {
+  TransferLifecycle,
+  TransferState,
+} from '../../../transfers/state-machine/stellar';
+import type {
+  TimelineGeneratorOptions,
+  TimelineRenderOptions,
+  TimelineStage,
+  TransferTimeline,
+} from './types';
+
+/**
+ * States in which a transfer has concluded.
+ *
+ * Mirrored from the transfer state machine (#535), which keeps its own
+ * TERMINAL_STATES module-private. FAILED is deliberately absent: a failed
+ * transfer may still advance to RECOVERING or REFUNDED, so it is not terminal.
+ */
+const TERMINAL_STATES: readonly TransferState[] = ['COMPLETED', 'REFUNDED'];
+
+const SEPARATOR_WIDTH = 56;
+const STATE_COLUMN_WIDTH = 16;
+
+/**
+ * Formats a millisecond duration into a compact human-readable string.
+ */
+function formatDuration(ms: number): string {
+  const safe = Math.max(0, Math.round(ms));
+  if (safe < 1000) {
+    return `${safe}ms`;
+  }
+  const seconds = safe / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`;
+  }
+  const totalMinutes = Math.floor(seconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m ${Math.round(seconds % 60)}s`;
+  }
+  return `${Math.floor(totalMinutes / 60)}h ${totalMinutes % 60}m`;
+}
+
+/**
+ * Stellar Transfer Timeline Generator (#453).
+ *
+ * Derives a stage-by-stage timeline from a TransferLifecycle produced by the
+ * Soroban transfer state machine (#535). Consumers pass the lifecycle snapshot
+ * directly:
+ *
+ *   const generator = new StellarTransferTimelineGenerator();
+ *   const timeline = generator.generate(machine.state);
+ *   console.log(generator.render(timeline));
+ *
+ * The generator is a pure function of its input and holds no transfer state of
+ * its own, so a single instance may be shared across transfers.
+ */
+export class StellarTransferTimelineGenerator {
+  private readonly now: () => number;
+
+  constructor(options: TimelineGeneratorOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /**
+   * Builds a timeline from a transfer lifecycle snapshot.
+   *
+   * Stage boundaries are derived from consecutive transition timestamps, with
+   * `createdAt` anchoring the first stage. Durations are clamped at zero so
+   * out-of-order timestamps cannot produce negative values.
+   */
+  generate(lifecycle: TransferLifecycle): TransferTimeline {
+    if (!lifecycle.transferId) {
+      throw new Error('Cannot generate a timeline without a transferId');
+    }
+
+    const events = [...lifecycle.events].sort((a, b) => a.timestamp - b.timestamp);
+    const isComplete = TERMINAL_STATES.includes(lifecycle.currentState);
+    const observedAt = this.now();
+
+    const stages: TimelineStage[] = [
+      {
+        state: events.length > 0 ? events[0].from : lifecycle.currentState,
+        index: 0,
+        enteredAt: lifecycle.createdAt,
+        durationMs: 0,
+        isCurrent: false,
+      },
+    ];
+
+    for (const event of events) {
+      stages.push({
+        state: event.to,
+        index: stages.length,
+        enteredAt: event.timestamp,
+        durationMs: 0,
+        isCurrent: false,
+        ...(event.reason !== undefined ? { reason: event.reason } : {}),
+      });
+    }
+
+    for (let i = 0; i < stages.length - 1; i += 1) {
+      const stage = stages[i];
+      const exitedAt = stages[i + 1].enteredAt;
+      stage.exitedAt = exitedAt;
+      stage.durationMs = Math.max(0, exitedAt - stage.enteredAt);
+    }
+
+    const finalStage = stages[stages.length - 1];
+    finalStage.isCurrent = true;
+    if (isComplete) {
+      finalStage.exitedAt = finalStage.enteredAt;
+      finalStage.durationMs = 0;
+    } else {
+      finalStage.durationMs = Math.max(0, observedAt - finalStage.enteredAt);
+    }
+
+    const endedAt = isComplete ? finalStage.enteredAt : observedAt;
+
+    return {
+      transferId: lifecycle.transferId,
+      stages,
+      currentState: lifecycle.currentState,
+      startedAt: lifecycle.createdAt,
+      endedAt,
+      totalDurationMs: Math.max(0, endedAt - lifecycle.createdAt),
+      isComplete,
+      ...(lifecycle.recoveryPath !== undefined
+        ? { recoveryPath: lifecycle.recoveryPath }
+        : {}),
+    };
+  }
+
+  /**
+   * Renders a timeline as plain text for logs, CLI output, or support tooling.
+   *
+   * The current stage of an in-flight transfer is marked with `>`; concluded
+   * stages are marked with `*`.
+   */
+  render(timeline: TransferTimeline, options: TimelineRenderOptions = {}): string {
+    const includeReasons = options.includeReasons ?? true;
+    const includeDurations = options.includeDurations ?? true;
+
+    const lines: string[] = [
+      `Transfer ${timeline.transferId} - ${timeline.currentState} (${
+        timeline.isComplete ? 'complete' : 'in progress'
+      })`,
+      `Elapsed ${formatDuration(timeline.totalDurationMs)} across ${
+        timeline.stages.length
+      } stage(s)`,
+      '-'.repeat(SEPARATOR_WIDTH),
+    ];
+
+    for (const stage of timeline.stages) {
+      const isActive = stage.isCurrent && !timeline.isComplete;
+      const offset = formatDuration(stage.enteredAt - timeline.startedAt);
+      let line = `${isActive ? '>' : '*'} [${stage.index}] ${stage.state.padEnd(
+        STATE_COLUMN_WIDTH,
+      )} +${offset}`;
+
+      if (includeDurations) {
+        line += isActive
+          ? `  (${formatDuration(stage.durationMs)} so far)`
+          : `  (${formatDuration(stage.durationMs)})`;
+      }
+      if (includeReasons && stage.reason !== undefined) {
+        line += `  ${stage.reason}`;
+      }
+      lines.push(line);
+    }
+
+    if (timeline.recoveryPath !== undefined) {
+      lines.push('-'.repeat(SEPARATOR_WIDTH));
+      lines.push(
+        `Recovery: ${timeline.recoveryPath.path} - ${timeline.recoveryPath.description}`,
+      );
+    }
+
+    return lines.join('\n');
+  }
+}

--- a/src/timeline/transfers/stellar/types.ts
+++ b/src/timeline/transfers/stellar/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Types for the Stellar Transfer Timeline Generator (#453).
+ *
+ * Builds a stage-by-stage timeline from a transfer lifecycle produced by the
+ * Soroban transfer state machine (#535), recording entry and exit timestamps
+ * plus per-stage durations so transfer progress can be surfaced to users.
+ */
+import type {
+  RecoveryPathDefinition,
+  TransferState,
+} from '../../../transfers/state-machine/stellar';
+
+/**
+ * A single stage occupied by a transfer during its lifecycle.
+ */
+export interface TimelineStage {
+  /** Lifecycle state this stage represents. */
+  state: TransferState;
+  /** Zero-based position of this stage in the timeline. */
+  index: number;
+  /** Epoch milliseconds at which the transfer entered this stage. */
+  enteredAt: number;
+  /** Epoch milliseconds at which the transfer left this stage, if it has. */
+  exitedAt?: number;
+  /** Milliseconds spent in this stage; still accruing while `isCurrent`. */
+  durationMs: number;
+  /** Reason recorded on the transition that entered this stage, if any. */
+  reason?: string;
+  /** True when this is the stage the transfer currently occupies. */
+  isCurrent: boolean;
+}
+
+/**
+ * A generated timeline view for a single transfer.
+ */
+export interface TransferTimeline {
+  transferId: string;
+  /** Stages in chronological order, oldest first. */
+  stages: TimelineStage[];
+  currentState: TransferState;
+  /** Epoch milliseconds at which the transfer was created. */
+  startedAt: number;
+  /** Final transition time, or the observation time while still in flight. */
+  endedAt: number;
+  /** Total elapsed milliseconds between `startedAt` and `endedAt`. */
+  totalDurationMs: number;
+  /** True once the transfer reaches a terminal state. */
+  isComplete: boolean;
+  /** Recovery path recorded on the lifecycle, if one was triggered. */
+  recoveryPath?: RecoveryPathDefinition;
+}
+
+/**
+ * Construction options for {@link StellarTransferTimelineGenerator}.
+ */
+export interface TimelineGeneratorOptions {
+  /** Clock override; defaults to `Date.now`. Injectable for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * Formatting options for the textual timeline view.
+ */
+export interface TimelineRenderOptions {
+  /** Include the reason recorded for each transition. Defaults to `true`. */
+  includeReasons?: boolean;
+  /** Include per-stage durations. Defaults to `true`. */
+  includeDurations?: boolean;
+}


### PR DESCRIPTION
Closes #453

## Summary

Adds a Stellar transfer timeline generator under `src/timeline/transfers/stellar/`, giving users visibility into transfer progress by deriving a stage-by-stage timeline from a transfer's lifecycle.

## Approach

The transfer state machine (#535) at `src/transfers/state-machine/stellar/` already defines the canonical transfer stages (`TransferState`) and records a timestamped `TransferEvent` on every transition. Rather than duplicating that, this generator consumes its `TransferLifecycle` output directly:

```ts
import { TransferStateMachine } from '../../../transfers/state-machine/stellar';
import { StellarTransferTimelineGenerator } from './timeline/transfers/stellar';

const generator = new StellarTransferTimelineGenerator();
const timeline = generator.generate(machine.state);
console.log(generator.render(timeline));
```

Types are imported with `import type`, so there is no runtime coupling, and no existing files are modified.

## Requirements

- **Track transfer stages** — each occupied `TransferState` becomes an indexed `TimelineStage`, in chronological order.
- **Record timestamps** — every stage carries `enteredAt` / `exitedAt` with a computed `durationMs`, derived from consecutive transition timestamps and anchored by `createdAt`.
- **Generate timeline views** — `generate()` returns a structured `TransferTimeline`; `render()` produces a plain-text view for logs, CLI, and support tooling, with configurable reasons and durations.

## Notes

- `FAILED` is deliberately **not** treated as terminal, matching the state machine's own `TERMINAL_STATES` (`COMPLETED`, `REFUNDED`) — a failed transfer can still advance to `RECOVERING` or `REFUNDED`. There is an explicit test for this.
- Completed transfers produce a frozen timeline, so regenerating one later returns identical durations rather than growing with wall-clock time.
- `TERMINAL_STATES` is mirrored locally because the state machine keeps its copy module-private. Exporting it there would be a reasonable follow-up; I left that module untouched to keep this PR in scope.

## Verification

- 14 unit tests pass (`jest src/timeline/transfers/stellar`), driven through a real `TransferStateMachine` with injected clocks.
- Type-checks clean via `tsc --noEmit` scoped to the new module.

Note: a full `tsc --noEmit` on the repo reports pre-existing errors in 9 unrelated files, ~9,700 of them `TS1127: Invalid character` in `src/search/intelligence/stellar/` (those two files appear to be committed in a non-UTF-8 encoding). None are in the files added here, and none were introduced by this PR.