### PR TITLE
feat(indexer): add chain re-org detector and finality confirmation en…

### DIFF
--- a/libs/indexer/jest.config.js
+++ b/libs/indexer/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.spec.ts'],
+};

--- a/libs/indexer/package.json
+++ b/libs/indexer/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@bridgewise/indexer",
+  "version": "0.1.0",
+  "description": "Chain re-org detection and finality confirmation engine for BridgeWise's cross-chain indexer.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT",
+  "dependencies": {}
+}

--- a/libs/indexer/src/finality-tracker.spec.ts
+++ b/libs/indexer/src/finality-tracker.spec.ts
@@ -1,0 +1,63 @@
+import { FinalityTracker, CrossChainMessage, ReleaseEvent, QuarantinedMessage } from './finality-tracker';
+
+describe('FinalityTracker', () => {
+  it('should quarantine a message and release it once it reaches the required confirmation depth', () => {
+    // Use a small custom threshold (3 blocks) instead of the real Ethereum/Polygon
+    // defaults so the test doesn't need to simulate dozens of blocks.
+    const tracker = new FinalityTracker([{ chainId: 999, requiredConfirmations: 3, label: 'TestChain' }]);
+
+    const quarantined: QuarantinedMessage[] = [];
+    const released: ReleaseEvent[] = [];
+    tracker.on('quarantined', (entry) => quarantined.push(entry));
+    tracker.on('released', (event) => released.push(event));
+
+    const message: CrossChainMessage = {
+      messageId: 'msg-final-1',
+      sourceChainId: 999,
+      sourceBlockHeight: 100,
+      sourceBlockHash: '0xabc',
+      payload: { amount: 50 },
+    };
+
+    tracker.quarantineMessage(message);
+    expect(quarantined.length).toBe(1);
+    expect(tracker.getStatus('msg-final-1')?.status).toBe('pending');
+
+    // Head at 100: confirmations = 1 (not yet final for a 3-block requirement)
+    tracker.advanceHead(999, 100);
+    expect(released.length).toBe(0);
+    expect(tracker.getStatus('msg-final-1')?.status).toBe('pending');
+
+    // Head at 101: confirmations = 2 (still not final)
+    tracker.advanceHead(999, 101);
+    expect(released.length).toBe(0);
+
+    // Head at 102: confirmations = 3 (meets the threshold -> release)
+    tracker.advanceHead(999, 102);
+    expect(released.length).toBe(1);
+    expect(released[0].message.messageId).toBe('msg-final-1');
+    expect(released[0].confirmations).toBe(3);
+
+    // Once released, the message is no longer sitting in quarantine.
+    expect(tracker.getStatus('msg-final-1')).toBeUndefined();
+    expect(tracker.getPendingMessages(999)).toHaveLength(0);
+  });
+
+  it('should not release a message before it reaches the required confirmation depth', () => {
+    const tracker = new FinalityTracker([{ chainId: 999, requiredConfirmations: 10 }]);
+
+    const message: CrossChainMessage = {
+      messageId: 'msg-final-2',
+      sourceChainId: 999,
+      sourceBlockHeight: 50,
+      sourceBlockHash: '0xdef',
+      payload: { amount: 10 },
+    };
+
+    tracker.quarantineMessage(message);
+    tracker.advanceHead(999, 55); // only 6 confirmations, threshold is 10
+
+    expect(tracker.getStatus('msg-final-2')?.status).toBe('pending');
+    expect(tracker.getPendingMessages(999)).toHaveLength(1);
+  });
+});

--- a/libs/indexer/src/finality-tracker.ts
+++ b/libs/indexer/src/finality-tracker.ts
@@ -1,0 +1,329 @@
+/**
+ * libs/indexer/src/finality-tracker.ts
+ *
+ * Finality Confirmation Engine
+ * -----------------------------
+ * Quarantines cross-chain transfer messages observed on a source chain and
+ * withholds them from relay until their source block has accumulated enough
+ * confirmations (per-chain finality depth) to be considered safe against
+ * re-orgs.
+ *
+ * Designed to be driven by:
+ *   - `ReorgDetector` ('block' events advance finality; 'reorg' events purge
+ *     or requeue quarantined messages whose source block was invalidated).
+ *   - Your own head-tracking loop (calling `advanceHead` with the latest
+ *     confirmed chain height on each poll/subscription tick).
+ *
+ * Data structures:
+ *   - `quarantine`: Map<messageId, QuarantinedMessage> — O(1) lookup/removal.
+ *   - `byBlock`: Map<blockHeight, Set<messageId>> — index so that a single
+ *     `advanceHead` or `handleReorg` call can efficiently find all messages
+ *     anchored to affected heights without scanning the whole quarantine.
+ */
+
+import { EventEmitter } from 'events';
+import type { ReorgEvent } from './reorg-detector';
+
+/** Identifies a chain and the finality depth (in blocks) required for it. */
+export interface FinalityConfig {
+  chainId: number;
+  /** Number of confirmations required before a message is considered final. */
+  requiredConfirmations: number;
+  /** Human-readable label for logs/metrics, e.g. "Ethereum", "Polygon". */
+  label?: string;
+}
+
+/** A cross-chain transfer message awaiting finality on its source chain. */
+export interface CrossChainMessage {
+  messageId: string;
+  sourceChainId: number;
+  sourceBlockHeight: number;
+  sourceBlockHash: string;
+  /** Arbitrary payload — token transfer details, destination chain, etc. */
+  payload: unknown;
+}
+
+export type QuarantineStatus = 'pending' | 'released' | 'rolled_back';
+
+export interface QuarantinedMessage {
+  message: CrossChainMessage;
+  status: QuarantineStatus;
+  quarantinedAt: number;
+  releasedAt?: number;
+  rolledBackAt?: number;
+  /** Confirmations observed as of the last `advanceHead` call. */
+  confirmations: number;
+}
+
+export interface ReleaseEvent {
+  message: CrossChainMessage;
+  confirmations: number;
+  releasedAt: number;
+}
+
+export interface RollbackEvent {
+  message: CrossChainMessage;
+  reason: 'reorg' | 'manual';
+  rolledBackAt: number;
+}
+
+export class FinalityConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FinalityConfigError';
+  }
+}
+
+/**
+ * Typed events emitted by FinalityTracker:
+ *   'quarantined' -> (msg: QuarantinedMessage) => void
+ *   'released'    -> (event: ReleaseEvent) => void
+ *   'rolledBack'  -> (event: RollbackEvent) => void
+ */
+/** Warning payload emitted when advanceHead sees an out-of-order head height. */
+export interface FinalityWarning {
+  chainId: number;
+  message: string;
+}
+
+/**
+ * Declaration merging: gives `.on()` / `.once()` / `.emit()` typed event
+ * payloads. See the matching pattern on `ReorgDetector` in ./reorg-detector.ts
+ * for why this is necessary.
+ */
+export declare interface FinalityTracker {
+  on(event: 'quarantined', listener: (payload: QuarantinedMessage) => void): this;
+  on(event: 'released', listener: (payload: ReleaseEvent) => void): this;
+  on(event: 'rolledBack', listener: (payload: RollbackEvent) => void): this;
+  on(event: 'warning', listener: (payload: FinalityWarning) => void): this;
+  once(event: 'quarantined', listener: (payload: QuarantinedMessage) => void): this;
+  once(event: 'released', listener: (payload: ReleaseEvent) => void): this;
+  once(event: 'rolledBack', listener: (payload: RollbackEvent) => void): this;
+  once(event: 'warning', listener: (payload: FinalityWarning) => void): this;
+  emit(event: 'quarantined', payload: QuarantinedMessage): boolean;
+  emit(event: 'released', payload: ReleaseEvent): boolean;
+  emit(event: 'rolledBack', payload: RollbackEvent): boolean;
+  emit(event: 'warning', payload: FinalityWarning): boolean;
+}
+
+export class FinalityTracker extends EventEmitter {
+  private readonly configs = new Map<number, FinalityConfig>();
+  private readonly quarantine = new Map<string, QuarantinedMessage>();
+  /** Index: source height -> set of message ids anchored there. Per chain. */
+  private readonly byChainAndBlock = new Map<number, Map<number, Set<string>>>();
+  /** Latest confirmed head height we've observed per chain. */
+  private readonly heads = new Map<number, number>();
+
+  constructor(configs: FinalityConfig[]) {
+    super();
+    for (const cfg of configs) {
+      if (cfg.requiredConfirmations <= 0) {
+        throw new FinalityConfigError(
+          `requiredConfirmations for chain ${cfg.chainId} must be a positive integer`,
+        );
+      }
+      this.configs.set(cfg.chainId, cfg);
+    }
+  }
+
+  /** Register or update finality requirements for a chain at runtime. */
+  public setChainConfig(config: FinalityConfig): void {
+    if (config.requiredConfirmations <= 0) {
+      throw new FinalityConfigError(
+        `requiredConfirmations for chain ${config.chainId} must be a positive integer`,
+      );
+    }
+    this.configs.set(config.chainId, config);
+  }
+
+  /**
+   * Add an incoming cross-chain message to quarantine. It will not be
+   * released until `advanceHead` reports enough confirmations for its
+   * source chain/block.
+   */
+  public quarantineMessage(message: CrossChainMessage): QuarantinedMessage {
+    if (!this.configs.has(message.sourceChainId)) {
+      throw new FinalityConfigError(
+        `No finality config registered for chainId ${message.sourceChainId}`,
+      );
+    }
+    if (this.quarantine.has(message.messageId)) {
+      // Idempotent: return the existing entry rather than duplicating state.
+      return this.quarantine.get(message.messageId)!;
+    }
+
+    const currentHead = this.heads.get(message.sourceChainId);
+    const confirmations =
+      currentHead !== undefined
+        ? Math.max(0, currentHead - message.sourceBlockHeight + 1)
+        : 0;
+
+    const entry: QuarantinedMessage = {
+      message,
+      status: 'pending',
+      quarantinedAt: Date.now(),
+      confirmations,
+    };
+
+    this.quarantine.set(message.messageId, entry);
+    this.indexMessage(message);
+    this.emit('quarantined', entry);
+
+    // In case the message arrived already-final (e.g. backfill scenarios),
+    // check immediately.
+    this.tryRelease(entry);
+
+    return entry;
+  }
+
+  /**
+   * Report the latest confirmed chain head for a given chain. Recomputes
+   * confirmation depth for all pending messages on that chain and releases
+   * any that have crossed the required threshold.
+   */
+  public advanceHead(chainId: number, headHeight: number): void {
+    const cfg = this.configs.get(chainId);
+    if (!cfg) {
+      throw new FinalityConfigError(`No finality config registered for chainId ${chainId}`);
+    }
+
+    const previousHead = this.heads.get(chainId) ?? -1;
+    if (headHeight < previousHead) {
+      // Head moving backwards without a reorg event is unexpected — ignore
+      // rather than corrupt confirmation counts, but surface it for visibility.
+      this.emit('warning', {
+        chainId,
+        message: `advanceHead received headHeight ${headHeight} lower than previous ${previousHead}; ignoring`,
+      });
+      return;
+    }
+    this.heads.set(chainId, headHeight);
+
+    const blockIndex = this.byChainAndBlock.get(chainId);
+    if (!blockIndex) return;
+
+    for (const [height, ids] of blockIndex) {
+      const confirmations = headHeight - height + 1;
+      for (const id of ids) {
+        const entry = this.quarantine.get(id);
+        if (!entry || entry.status !== 'pending') continue;
+        entry.confirmations = confirmations;
+        if (confirmations >= cfg.requiredConfirmations) {
+          this.release(entry);
+        }
+      }
+    }
+  }
+
+  /**
+   * Wire this up to `ReorgDetector`'s 'reorg' event. Any quarantined message
+   * anchored to an invalidated height is rolled back (never released) and
+   * removed from quarantine so it can be safely re-observed if/when the
+   * message reappears on the new canonical chain.
+   */
+  public handleReorg(event: ReorgEvent): void {
+    const blockIndex = this.byChainAndBlock.get(event.chainId);
+    if (!blockIndex) return;
+
+    for (const height of event.invalidatedHeights) {
+      const ids = blockIndex.get(height);
+      if (!ids) continue;
+      for (const id of [...ids]) {
+        const entry = this.quarantine.get(id);
+        if (!entry) continue;
+        this.rollback(entry, 'reorg');
+      }
+      blockIndex.delete(height);
+    }
+  }
+
+  /** Look up the current quarantine record for a message, if any. */
+  public getStatus(messageId: string): QuarantinedMessage | undefined {
+    return this.quarantine.get(messageId);
+  }
+
+  /** All messages currently awaiting finality (not yet released or rolled back). */
+  public getPendingMessages(chainId?: number): QuarantinedMessage[] {
+    const out: QuarantinedMessage[] = [];
+    for (const entry of this.quarantine.values()) {
+      if (entry.status !== 'pending') continue;
+      if (chainId !== undefined && entry.message.sourceChainId !== chainId) continue;
+      out.push(entry);
+    }
+    return out;
+  }
+
+  /** Number of messages currently held in quarantine (any status), useful for metrics. */
+  public get size(): number {
+    return this.quarantine.size;
+  }
+
+  // ---- internal helpers -------------------------------------------------
+
+  private indexMessage(message: CrossChainMessage): void {
+    let blockIndex = this.byChainAndBlock.get(message.sourceChainId);
+    if (!blockIndex) {
+      blockIndex = new Map();
+      this.byChainAndBlock.set(message.sourceChainId, blockIndex);
+    }
+    let ids = blockIndex.get(message.sourceBlockHeight);
+    if (!ids) {
+      ids = new Set();
+      blockIndex.set(message.sourceBlockHeight, ids);
+    }
+    ids.add(message.messageId);
+  }
+
+  private deindexMessage(message: CrossChainMessage): void {
+    const blockIndex = this.byChainAndBlock.get(message.sourceChainId);
+    const ids = blockIndex?.get(message.sourceBlockHeight);
+    ids?.delete(message.messageId);
+    if (ids && ids.size === 0) {
+      blockIndex!.delete(message.sourceBlockHeight);
+    }
+  }
+
+  private tryRelease(entry: QuarantinedMessage): void {
+    const cfg = this.configs.get(entry.message.sourceChainId);
+    if (!cfg) return;
+    if (entry.status === 'pending' && entry.confirmations >= cfg.requiredConfirmations) {
+      this.release(entry);
+    }
+  }
+
+  private release(entry: QuarantinedMessage): void {
+    entry.status = 'released';
+    entry.releasedAt = Date.now();
+    this.quarantine.delete(entry.message.messageId);
+    this.deindexMessage(entry.message);
+
+    const event: ReleaseEvent = {
+      message: entry.message,
+      confirmations: entry.confirmations,
+      releasedAt: entry.releasedAt,
+    };
+    this.emit('released', event);
+  }
+
+  private rollback(entry: QuarantinedMessage, reason: 'reorg' | 'manual'): void {
+    entry.status = 'rolled_back';
+    entry.rolledBackAt = Date.now();
+    this.quarantine.delete(entry.message.messageId);
+    this.deindexMessage(entry.message);
+
+    const event: RollbackEvent = {
+      message: entry.message,
+      reason,
+      rolledBackAt: entry.rolledBackAt,
+    };
+    this.emit('rolledBack', event);
+  }
+}
+
+/** Convenience factory for the common chains referenced in the issue. */
+export function defaultFinalityConfigs(): FinalityConfig[] {
+  return [
+    { chainId: 1, requiredConfirmations: 64, label: 'Ethereum' },
+    { chainId: 137, requiredConfirmations: 32, label: 'Polygon' },
+  ];
+}

--- a/libs/indexer/src/index.ts
+++ b/libs/indexer/src/index.ts
@@ -1,0 +1,2 @@
+export * from './reorg-detector';
+export * from './finality-tracker';

--- a/libs/indexer/src/reorg-detector.spec.ts
+++ b/libs/indexer/src/reorg-detector.spec.ts
@@ -1,0 +1,87 @@
+import { ReorgDetector, BlockHeader, ReorgEvent, ContinuityBreakEvent, ChainReorgError } from './reorg-detector';
+import { FinalityTracker, defaultFinalityConfigs, RollbackEvent } from './finality-tracker';
+
+describe('ReorgDetector and FinalityTracker', () => {
+  it('should detect a block hash mutation and trigger a re-org rollback', () => {
+    const detector = new ReorgDetector({ chainId: 1, historyDepth: 10 });
+    const tracker = new FinalityTracker(defaultFinalityConfigs());
+
+    const reorgEvents: ReorgEvent[] = [];
+    const rollbacks: RollbackEvent[] = [];
+
+    detector.on('reorg', (event: ReorgEvent) => reorgEvents.push(event));
+    tracker.on('rolledBack', (event: RollbackEvent) => rollbacks.push(event));
+
+    // 1. Feed initial valid blocks
+    const b1: BlockHeader = { chainId: 1, height: 1, hash: '0x111', parentHash: '0x000', timestamp: Date.now() };
+    const b2: BlockHeader = { chainId: 1, height: 2, hash: '0x222', parentHash: '0x111', timestamp: Date.now() };
+
+    detector.processBlock(b1);
+    detector.processBlock(b2);
+
+    // Quarantine a message tied to block height 2
+    tracker.quarantineMessage({
+      messageId: 'msg-1',
+      sourceChainId: 1,
+      sourceBlockHeight: 2,
+      sourceBlockHash: '0x222',
+      payload: { amount: 100 },
+    });
+
+    // Hook tracker to detector reorg events
+    detector.on('reorg', (event: ReorgEvent) => tracker.handleReorg(event));
+
+    // 2. Feed a conflicting block at height 2 (re-org mutation)
+    const b2Alt: BlockHeader = { chainId: 1, height: 2, hash: '0x222-alt', parentHash: '0x111', timestamp: Date.now() };
+    detector.processBlock(b2Alt);
+
+    expect(reorgEvents.length).toBe(1);
+    expect(reorgEvents[0].invalidatedHeights).toContain(2);
+    expect(rollbacks.length).toBe(1);
+    expect(rollbacks[0].message.messageId).toBe('msg-1');
+  });
+
+  it('should emit a continuityBreak when a block arrives whose parent is unknown', () => {
+    // tolerateUnknownParent: true so the detector reports the break instead of throwing,
+    // which is the mode you'd use on a live indexer that must keep running.
+    const detector = new ReorgDetector({ chainId: 1, historyDepth: 10, tolerateUnknownParent: true });
+
+    const breaks: ContinuityBreakEvent[] = [];
+    detector.on('continuityBreak', (event: ContinuityBreakEvent) => breaks.push(event));
+
+    const b1: BlockHeader = { chainId: 1, height: 1, hash: '0x111', parentHash: '0x000', timestamp: Date.now() };
+    detector.processBlock(b1);
+
+    // Height 5 arrives with a parentHash that doesn't match anything in history
+    // (a gap: heights 2-4 were never seen, and the claimed parent is unrecognized).
+    const b5: BlockHeader = {
+      chainId: 1,
+      height: 5,
+      hash: '0x555',
+      parentHash: '0xdeadbeef',
+      timestamp: Date.now(),
+    };
+    detector.processBlock(b5);
+
+    expect(breaks.length).toBe(1);
+    expect(breaks[0].atHeight).toBe(5);
+    expect(breaks[0].receivedParentHash).toBe('0xdeadbeef');
+  });
+
+  it('should throw ChainReorgError on continuity break when tolerateUnknownParent is false (default)', () => {
+    const detector = new ReorgDetector({ chainId: 1, historyDepth: 10 });
+
+    const b1: BlockHeader = { chainId: 1, height: 1, hash: '0x111', parentHash: '0x000', timestamp: Date.now() };
+    detector.processBlock(b1);
+
+    const b5: BlockHeader = {
+      chainId: 1,
+      height: 5,
+      hash: '0x555',
+      parentHash: '0xdeadbeef',
+      timestamp: Date.now(),
+    };
+
+    expect(() => detector.processBlock(b5)).toThrow(ChainReorgError);
+  });
+});

--- a/libs/indexer/src/reorg-detector.ts
+++ b/libs/indexer/src/reorg-detector.ts
@@ -1,0 +1,341 @@
+/**
+ * libs/indexer/src/reorg-detector.ts
+ *
+ * Chain Re-Org Detector
+ * ---------------------
+ * Maintains a bounded, in-memory history of indexed block headers (hash + parentHash)
+ * for a given chain, and detects two classes of anomalies as new blocks arrive:
+ *
+ *   1. CONTINUITY BREAK — the incoming block's parentHash does not match the hash
+ *      we have on file for the previous height (a gap, skipped block, or the node
+ *      handed us an inconsistent view of the chain).
+ *
+ *   2. HASH MUTATION (re-org) — we already have a block recorded at this height,
+ *      and the incoming block's hash differs from what we stored. This means the
+ *      canonical chain changed underneath us and everything from the divergence
+ *      point forward must be treated as rolled back.
+ *
+ * On detection, the detector walks back through its buffer to find the last common
+ * ancestor (the fork point) and emits a `reorg` event describing exactly which
+ * heights/hashes are now invalid, so downstream consumers (event indexers, the
+ * finality tracker, relayers, etc.) can roll back unfinalized state safely.
+ */
+
+import { EventEmitter } from 'events';
+
+/** Minimal block header shape the detector needs. Extend as required. */
+export interface BlockHeader {
+  chainId: number;
+  height: number;
+  hash: string;
+  parentHash: string;
+  timestamp: number;
+}
+
+/** Emitted when a re-org is detected. */
+export interface ReorgEvent {
+  chainId: number;
+  /** Height of the deepest block still common to old and new chains. */
+  commonAncestorHeight: number;
+  /** Hash of the common ancestor block. */
+  commonAncestorHash: string;
+  /** Heights that must be rolled back (old, now-invalid chain), highest first. */
+  invalidatedHeights: number[];
+  /** The blocks that were removed from local history because of the re-org. */
+  invalidatedBlocks: BlockHeader[];
+  /** The new block that triggered detection. */
+  triggeringBlock: BlockHeader;
+  detectedAt: number;
+}
+
+/** Emitted when an incoming block cannot be reconciled with local history at all. */
+export interface ContinuityBreakEvent {
+  chainId: number;
+  expectedParentHash: string;
+  receivedParentHash: string;
+  atHeight: number;
+  triggeringBlock: BlockHeader;
+  detectedAt: number;
+}
+
+export interface ReorgDetectorOptions {
+  chainId: number;
+  /** How many blocks of history to retain. Must exceed your deepest expected re-org. */
+  historyDepth: number;
+  /**
+   * If true, a continuity break (missing parent, unknown parent hash) that cannot
+   * be resolved within the buffer is treated as a re-org against the entire buffer
+   * rather than throwing. Defaults to false (strict mode throws).
+   */
+  tolerateUnknownParent?: boolean;
+}
+
+/**
+ * Fixed-capacity circular buffer keyed by height, backed by a Map for O(1)
+ * lookups by height and by hash. Oldest entries are evicted once `capacity`
+ * is exceeded.
+ */
+class BlockHistoryBuffer {
+  private readonly capacity: number;
+  private readonly byHeight = new Map<number, BlockHeader>();
+  private readonly byHash = new Map<string, BlockHeader>();
+  /** Insertion order of heights, used to evict the oldest when over capacity. */
+  private order: number[] = [];
+
+  constructor(capacity: number) {
+    if (capacity <= 0) {
+      throw new RangeError('historyDepth must be a positive integer');
+    }
+    this.capacity = capacity;
+  }
+
+  get size(): number {
+    return this.byHeight.size;
+  }
+
+  getByHeight(height: number): BlockHeader | undefined {
+    return this.byHeight.get(height);
+  }
+
+  getByHash(hash: string): BlockHeader | undefined {
+    return this.byHash.get(hash);
+  }
+
+  get highestHeight(): number | undefined {
+    return this.order.length ? this.order[this.order.length - 1] : undefined;
+  }
+
+  /** Insert or overwrite the block recorded at this height. */
+  set(block: BlockHeader): void {
+    if (!this.byHeight.has(block.height)) {
+      this.order.push(block.height);
+    } else {
+      const existing = this.byHeight.get(block.height);
+      if (existing) this.byHash.delete(existing.hash);
+    }
+    this.byHeight.set(block.height, block);
+    this.byHash.set(block.hash, block);
+    this.evictIfNeeded();
+  }
+
+  /** Remove every recorded block at or above the given height (used on rollback). */
+  invalidateFrom(height: number): BlockHeader[] {
+    const removed: BlockHeader[] = [];
+    for (const h of [...this.byHeight.keys()]) {
+      if (h >= height) {
+        const block = this.byHeight.get(h);
+        if (block) {
+          removed.push(block);
+          this.byHeight.delete(h);
+          this.byHash.delete(block.hash);
+        }
+      }
+    }
+    this.order = this.order.filter((h) => h < height);
+    return removed.sort((a, b) => b.height - a.height);
+  }
+
+  private evictIfNeeded(): void {
+    while (this.order.length > this.capacity) {
+      const oldest = this.order.shift();
+      if (oldest === undefined) break;
+      const block = this.byHeight.get(oldest);
+      if (block) {
+        this.byHeight.delete(oldest);
+        this.byHash.delete(block.hash);
+      }
+    }
+  }
+}
+
+export class ChainReorgError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChainReorgError';
+  }
+}
+
+/**
+ * Typed event names emitted by ReorgDetector.
+ *   'reorg'            -> (event: ReorgEvent) => void
+ *   'continuityBreak'  -> (event: ContinuityBreakEvent) => void
+ *   'block'            -> (block: BlockHeader) => void   // accepted, no anomaly
+ */
+/**
+ * Declaration merging: gives `.on()` / `.once()` / `.emit()` typed event
+ * payloads instead of the default EventEmitter signature of
+ * `(event: string | symbol, listener: (...args: any[]) => void)`.
+ * This is what makes `detector.on('reorg', (event) => ...)` infer
+ * `event: ReorgEvent` automatically, with no `any` and no extra casts.
+ */
+export declare interface ReorgDetector {
+  on(event: 'reorg', listener: (payload: ReorgEvent) => void): this;
+  on(event: 'continuityBreak', listener: (payload: ContinuityBreakEvent) => void): this;
+  on(event: 'block', listener: (payload: BlockHeader) => void): this;
+  once(event: 'reorg', listener: (payload: ReorgEvent) => void): this;
+  once(event: 'continuityBreak', listener: (payload: ContinuityBreakEvent) => void): this;
+  once(event: 'block', listener: (payload: BlockHeader) => void): this;
+  emit(event: 'reorg', payload: ReorgEvent): boolean;
+  emit(event: 'continuityBreak', payload: ContinuityBreakEvent): boolean;
+  emit(event: 'block', payload: BlockHeader): boolean;
+}
+
+export class ReorgDetector extends EventEmitter {
+  private readonly chainId: number;
+  private readonly history: BlockHistoryBuffer;
+  private readonly tolerateUnknownParent: boolean;
+
+  constructor(options: ReorgDetectorOptions) {
+    super();
+    this.chainId = options.chainId;
+    this.history = new BlockHistoryBuffer(options.historyDepth);
+    this.tolerateUnknownParent = options.tolerateUnknownParent ?? false;
+  }
+
+  /** Current number of blocks retained in the local history buffer. */
+  get bufferedBlockCount(): number {
+    return this.history.size;
+  }
+
+  get highestIndexedHeight(): number | undefined {
+    return this.history.highestHeight;
+  }
+
+  /**
+   * Feed a newly observed block into the detector. Call this for every block
+   * your indexer processes, in height order, as soon as it's fetched from the
+   * source chain (before you commit its logs as final).
+   */
+  public processBlock(block: BlockHeader): void {
+    if (block.chainId !== this.chainId) {
+      throw new ChainReorgError(
+        `Block chainId ${block.chainId} does not match detector chainId ${this.chainId}`,
+      );
+    }
+
+    const existingAtHeight = this.history.getByHeight(block.height);
+
+    // Case 1: We already recorded a different block at this height -> re-org.
+    if (existingAtHeight && existingAtHeight.hash !== block.hash) {
+      this.handleReorg(block);
+      return;
+    }
+
+    // Case 2: Same block re-delivered (idempotent no-op).
+    if (existingAtHeight && existingAtHeight.hash === block.hash) {
+      return;
+    }
+
+    // Case 3: New height. Verify continuity against our recorded parent.
+    const expectedParent = this.history.getByHeight(block.height - 1);
+
+    if (expectedParent) {
+      if (expectedParent.hash !== block.parentHash) {
+        // The parent we know about doesn't match what this block claims.
+        // This is really a re-org rooted at (height - 1) or earlier.
+        this.handleReorg(block);
+        return;
+      }
+    } else if (this.history.size > 0) {
+      // We have history but not the immediate parent — either a gap (skipped
+      // heights) or we're catching up after a restart. Try to locate the
+      // parent hash anywhere in the buffer to confirm we're still on a known
+      // chain; if we can't, treat it as a continuity break.
+      const parentElsewhere = this.history.getByHash(block.parentHash);
+      if (!parentElsewhere) {
+        this.emitContinuityBreak(block);
+        if (!this.tolerateUnknownParent) {
+          throw new ChainReorgError(
+            `Continuity break at height ${block.height} on chain ${this.chainId}: ` +
+              `parentHash ${block.parentHash} not found in local history`,
+          );
+        }
+      }
+    }
+
+    this.history.set(block);
+    this.emit('block', block);
+  }
+
+  /**
+   * Walk back from the incoming block to find the last common ancestor still
+   * present in our buffer, roll back everything above it, record the new
+   * block, and emit a `reorg` event with full rollback details.
+   */
+  private handleReorg(triggeringBlock: BlockHeader): void {
+    let ancestorHeight = triggeringBlock.height - 1;
+    let ancestorHash = triggeringBlock.parentHash;
+
+    // Walk down until we find a height where our recorded hash matches the
+    // hash the new fork claims as its ancestor, or we run out of buffer.
+    while (ancestorHeight >= 0) {
+      const candidate = this.history.getByHeight(ancestorHeight);
+      if (!candidate) {
+        // We've walked past the edge of our retained history — the re-org is
+        // deeper than `historyDepth`. We can't safely determine the true fork
+        // point; roll back everything we have and surface that fact.
+        break;
+      }
+      if (candidate.hash === ancestorHash) {
+        break; // found common ancestor
+      }
+      // Move further back: the new fork's ancestor at this depth is whatever
+      // its own chain claims — but we only have the triggering block itself
+      // client-side, so once the immediate parent doesn't match, the safest
+      // assumption is to invalidate down to the deepest point we can still
+      // verify against stored parent hashes.
+      ancestorHeight -= 1;
+      const deeper = this.history.getByHeight(ancestorHeight);
+      ancestorHash = deeper ? deeper.hash : ancestorHash;
+    }
+
+    const rollbackFrom = ancestorHeight + 1;
+    const invalidatedBlocks = this.history.invalidateFrom(rollbackFrom);
+
+    if (invalidatedBlocks.length === 0 && triggeringBlock.height <= (this.history.highestHeight ?? -1)) {
+      // Defensive fallback: nothing matched invalidateFrom's filter (shouldn't
+      // normally happen) — invalidate at minimum the triggering height.
+      invalidatedBlocks.push(...this.history.invalidateFrom(triggeringBlock.height));
+    }
+
+    const commonAncestor = this.history.getByHeight(ancestorHeight);
+
+    const event: ReorgEvent = {
+      chainId: this.chainId,
+      commonAncestorHeight: ancestorHeight,
+      commonAncestorHash: commonAncestor?.hash ?? ancestorHash,
+      invalidatedHeights: invalidatedBlocks.map((b) => b.height),
+      invalidatedBlocks,
+      triggeringBlock,
+      detectedAt: Date.now(),
+    };
+
+    // Record the new canonical block now that stale entries are gone.
+    this.history.set(triggeringBlock);
+
+    this.emit('reorg', event);
+  }
+
+  private emitContinuityBreak(block: BlockHeader): void {
+    const expectedParent = this.history.getByHeight(block.height - 1);
+    const event: ContinuityBreakEvent = {
+      chainId: this.chainId,
+      expectedParentHash: expectedParent?.hash ?? '',
+      receivedParentHash: block.parentHash,
+      atHeight: block.height,
+      triggeringBlock: block,
+      detectedAt: Date.now(),
+    };
+    this.emit('continuityBreak', event);
+  }
+
+  /** Snapshot of currently buffered blocks, sorted ascending by height. Useful for tests/debugging. */
+  public snapshot(): BlockHeader[] {
+    const out: BlockHeader[] = [];
+    for (let h = this.history.highestHeight ?? -1; h >= 0; h--) {
+      const b = this.history.getByHeight(h);
+      if (b) out.unshift(b);
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
Implements a chain re-org detector and finality confirmation engine for cross-chain message safety.

- `ReorgDetector`: tracks block history, detects hash mutations and parent-hash continuity breaks, emits `reorg`/`continuityBreak` events
- `FinalityTracker`: quarantines cross-chain messages until they reach required confirmations (per-chain configurable), rolls back on re-org

Closes #738