### PR TITLE
Relay fee estimation API, RPC reconnect backoff, chain health panel, and challenge window monitor

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -32,6 +32,7 @@ import { RouteInsightsExporterModule } from './exporters/routes/stellar/route-in
 import { SorobanLifecycleModule } from './analytics/lifecycle/transfers/stellar/soroban-lifecycle.module';
 import { SorobanTransferLifecycleEntity } from './analytics/lifecycle/transfers/stellar/entities/soroban-transfer-lifecycle.entity';
 import { QuotesModule } from './quotes/quotes.module';
+import { RelayerModule } from './relayer/relayer.module';
 
 @Module({
   imports: [
@@ -84,6 +85,7 @@ import { QuotesModule } from './quotes/quotes.module';
     StellarExplainabilityModule,
     RouteInsightsExporterModule,
     SorobanLifecycleModule,
+    RelayerModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/relayer/dto/estimate-fee.dto.ts
+++ b/apps/api/src/relayer/dto/estimate-fee.dto.ts
@@ -1,0 +1,89 @@
+import { IsInt, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Query parameters for a relay fee estimate.
+ */
+export class EstimateFeeQueryDto {
+  @ApiProperty({
+    description: 'Chain the cross-chain message originates from',
+    example: 'stellar',
+  })
+  @IsString()
+  sourceChain: string;
+
+  @ApiProperty({
+    description: 'Chain the cross-chain message will be executed on',
+    example: 'ethereum',
+  })
+  @IsString()
+  targetChain: string;
+
+  @ApiProperty({
+    description: 'Size of the cross-chain payload, in bytes',
+    example: 256,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(1_000_000)
+  payloadByteLength: number;
+}
+
+/**
+ * Relay fee quote for sending a cross-chain payload.
+ */
+export class RelayFeeEstimateDto {
+  @ApiProperty({ description: 'Chain the cross-chain message originates from' })
+  sourceChain: string;
+
+  @ApiProperty({ description: 'Chain the cross-chain message will be executed on' })
+  targetChain: string;
+
+  @ApiProperty({ description: 'Size of the cross-chain payload, in bytes' })
+  payloadByteLength: number;
+
+  @ApiProperty({
+    description: 'Estimated gas units required to execute the payload on the target chain',
+  })
+  estimatedGasUnits: number;
+
+  @ApiProperty({
+    description: 'Human-readable target chain gas price used for this quote',
+    example: '30 gwei',
+  })
+  targetGasPrice: string;
+
+  @ApiProperty({
+    description: 'Relayer margin applied on top of the raw gas cost, in basis points',
+  })
+  relayerMarginBps: number;
+
+  @ApiProperty({
+    description: 'Symbol of the target chain native token these amounts are denominated in',
+    example: 'ETH',
+  })
+  nativeTokenSymbol: string;
+
+  @ApiProperty({
+    description: 'Raw destination gas cost, in target chain native token units',
+  })
+  destinationGasCostNative: string;
+
+  @ApiProperty({
+    description: 'Relayer margin amount, in target chain native token units',
+  })
+  relayerMarginNative: string;
+
+  @ApiProperty({
+    description: 'Total relay fee (gas cost + relayer margin), in target chain native token units',
+  })
+  totalFeeNative: string;
+
+  @ApiProperty({ description: 'Total relay fee, in USD' })
+  totalFeeUsd: string;
+
+  @ApiProperty({ description: 'Unix timestamp (ms) this quote was generated at' })
+  quotedAt: number;
+}

--- a/apps/api/src/relayer/fee-estimator.controller.ts
+++ b/apps/api/src/relayer/fee-estimator.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { FeeEstimatorService } from './fee-estimator.service';
+import { EstimateFeeQueryDto, RelayFeeEstimateDto } from './dto/estimate-fee.dto';
+
+@ApiTags('Relayer')
+@Controller('api/v1/relayer')
+export class FeeEstimatorController {
+  constructor(private readonly feeEstimatorService: FeeEstimatorService) {}
+
+  @Get('estimate-fee')
+  @ApiOperation({
+    summary: 'Estimate the total relay cost for a cross-chain payload',
+    description:
+      'Calculates the destination gas cost plus relayer margin for dispatching a cross-chain message, given the source chain, target chain, and payload size.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Relay fee quote calculated successfully',
+    type: RelayFeeEstimateDto,
+  })
+  estimateFee(
+    @Query() query: EstimateFeeQueryDto,
+  ): Promise<RelayFeeEstimateDto> {
+    return this.feeEstimatorService.estimateFee(query);
+  }
+}

--- a/apps/api/src/relayer/fee-estimator.service.spec.ts
+++ b/apps/api/src/relayer/fee-estimator.service.spec.ts
@@ -1,0 +1,77 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FeeEstimatorService } from './fee-estimator.service';
+import { GasPriceAdapter } from '../fee-estimation/adapters/gas-price.adapter';
+
+describe('FeeEstimatorService', () => {
+  let service: FeeEstimatorService;
+  let gasPriceAdapter: GasPriceAdapter;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeeEstimatorService,
+        {
+          provide: GasPriceAdapter,
+          useValue: {
+            getGasPrice: jest.fn().mockResolvedValue({ gasPriceGwei: 30 }),
+            calculateGasFee: jest
+              .fn()
+              .mockImplementation(
+                (_chain: string, gasPriceGwei: number, gasLimit: number) =>
+                  (gasPriceGwei * gasLimit) / 1e9,
+              ),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<FeeEstimatorService>(FeeEstimatorService);
+    gasPriceAdapter = module.get<GasPriceAdapter>(GasPriceAdapter);
+  });
+
+  it('is defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('estimates an EVM target chain fee using the gas price adapter', async () => {
+    const result = await service.estimateFee({
+      sourceChain: 'stellar',
+      targetChain: 'ethereum',
+      payloadByteLength: 256,
+    });
+
+    expect(gasPriceAdapter.getGasPrice).toHaveBeenCalledWith('ethereum');
+    expect(result.nativeTokenSymbol).toBe('ETH');
+    expect(Number(result.totalFeeNative)).toBeGreaterThan(0);
+    expect(Number(result.totalFeeUsd)).toBeGreaterThan(0);
+    expect(result.estimatedGasUnits).toBeGreaterThan(0);
+  });
+
+  it('estimates a Stellar target chain fee using the flat resource fee model', async () => {
+    const result = await service.estimateFee({
+      sourceChain: 'ethereum',
+      targetChain: 'stellar',
+      payloadByteLength: 100,
+    });
+
+    expect(gasPriceAdapter.getGasPrice).not.toHaveBeenCalled();
+    expect(result.nativeTokenSymbol).toBe('XLM');
+    expect(Number(result.totalFeeNative)).toBeGreaterThan(0);
+  });
+
+  it('applies a larger payload as a higher fee', async () => {
+    const small = await service.estimateFee({
+      sourceChain: 'stellar',
+      targetChain: 'ethereum',
+      payloadByteLength: 32,
+    });
+    const large = await service.estimateFee({
+      sourceChain: 'stellar',
+      targetChain: 'ethereum',
+      payloadByteLength: 4096,
+    });
+
+    expect(large.estimatedGasUnits).toBeGreaterThan(small.estimatedGasUnits);
+    expect(Number(large.totalFeeNative)).toBeGreaterThan(Number(small.totalFeeNative));
+  });
+});

--- a/apps/api/src/relayer/fee-estimator.service.ts
+++ b/apps/api/src/relayer/fee-estimator.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common';
+import { GasPriceAdapter } from '../fee-estimation/adapters/gas-price.adapter';
+import { EstimateFeeQueryDto, RelayFeeEstimateDto } from './dto/estimate-fee.dto';
+
+// Base transaction overhead, in gas units, for executing a relayed payload
+// on an EVM-style target chain.
+const BASE_GAS_UNITS = 21_000;
+// Additional gas units charged per byte of cross-chain payload (calldata cost).
+const GAS_PER_BYTE = 16;
+// Relayer margin applied on top of the raw destination gas cost, in basis points.
+const RELAYER_MARGIN_BPS = 500;
+
+// Stellar/Soroban fees are a small flat resource fee rather than a gas-price *
+// gas-limit model, so they're estimated separately from EVM chains.
+const STELLAR_BASE_FEE_STROOPS = 100;
+const STELLAR_FEE_PER_BYTE_STROOPS = 5;
+const STROOPS_PER_XLM = 10_000_000;
+
+const NATIVE_TOKEN_SYMBOL: Record<string, string> = {
+  ethereum: 'ETH',
+  polygon: 'MATIC',
+  arbitrum: 'ETH',
+  optimism: 'ETH',
+  base: 'ETH',
+  bsc: 'BNB',
+  avalanche: 'AVAX',
+  fantom: 'FTM',
+  gnosis: 'xDAI',
+  scroll: 'ETH',
+  linea: 'ETH',
+  zksync: 'ETH',
+  zkevm: 'ETH',
+  stellar: 'XLM',
+};
+
+// Static USD reference prices used to convert native fee amounts to a USD
+// equivalent. In production this should be sourced from a live price feed;
+// kept static here to keep the estimator dependency-free and fast.
+const NATIVE_TOKEN_USD_PRICE: Record<string, number> = {
+  ETH: 3200,
+  MATIC: 0.7,
+  BNB: 550,
+  AVAX: 28,
+  FTM: 0.5,
+  xDAI: 1,
+  XLM: 0.11,
+};
+
+/**
+ * Estimates the total cost of relaying a cross-chain payload: the gas cost
+ * to execute it on the target chain, plus a relayer margin.
+ */
+@Injectable()
+export class FeeEstimatorService {
+  constructor(private readonly gasPriceAdapter: GasPriceAdapter) {}
+
+  async estimateFee(query: EstimateFeeQueryDto): Promise<RelayFeeEstimateDto> {
+    const targetChain = query.targetChain.toLowerCase();
+    const estimatedGasUnits = BASE_GAS_UNITS + query.payloadByteLength * GAS_PER_BYTE;
+
+    const { destinationGasCostNative, targetGasPrice } =
+      targetChain === 'stellar'
+        ? this.estimateStellarFee(query.payloadByteLength)
+        : await this.estimateEvmFee(targetChain, estimatedGasUnits);
+
+    const relayerMarginNative = (destinationGasCostNative * RELAYER_MARGIN_BPS) / 10_000;
+    const totalFeeNative = destinationGasCostNative + relayerMarginNative;
+
+    const nativeTokenSymbol = NATIVE_TOKEN_SYMBOL[targetChain] ?? 'ETH';
+    const usdPrice = NATIVE_TOKEN_USD_PRICE[nativeTokenSymbol] ?? 0;
+    const totalFeeUsd = totalFeeNative * usdPrice;
+
+    return {
+      sourceChain: query.sourceChain,
+      targetChain: query.targetChain,
+      payloadByteLength: query.payloadByteLength,
+      estimatedGasUnits,
+      targetGasPrice,
+      relayerMarginBps: RELAYER_MARGIN_BPS,
+      nativeTokenSymbol,
+      destinationGasCostNative: destinationGasCostNative.toFixed(8),
+      relayerMarginNative: relayerMarginNative.toFixed(8),
+      totalFeeNative: totalFeeNative.toFixed(8),
+      totalFeeUsd: totalFeeUsd.toFixed(4),
+      quotedAt: Date.now(),
+    };
+  }
+
+  private async estimateEvmFee(targetChain: string, estimatedGasUnits: number) {
+    const gasPriceInfo = await this.gasPriceAdapter.getGasPrice(targetChain);
+    const destinationGasCostNative = this.gasPriceAdapter.calculateGasFee(
+      targetChain,
+      gasPriceInfo.gasPriceGwei,
+      estimatedGasUnits,
+    );
+
+    return {
+      destinationGasCostNative,
+      targetGasPrice: `${gasPriceInfo.gasPriceGwei} gwei`,
+    };
+  }
+
+  private estimateStellarFee(payloadByteLength: number) {
+    const feeStroops = STELLAR_BASE_FEE_STROOPS + payloadByteLength * STELLAR_FEE_PER_BYTE_STROOPS;
+
+    return {
+      destinationGasCostNative: feeStroops / STROOPS_PER_XLM,
+      targetGasPrice: `${feeStroops} stroops (flat resource fee)`,
+    };
+  }
+}

--- a/apps/api/src/relayer/relayer.module.ts
+++ b/apps/api/src/relayer/relayer.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { FeeEstimatorController } from './fee-estimator.controller';
+import { FeeEstimatorService } from './fee-estimator.service';
+import { GasPriceAdapter } from '../fee-estimation/adapters/gas-price.adapter';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [FeeEstimatorController],
+  providers: [FeeEstimatorService, GasPriceAdapter],
+})
+export class RelayerModule {}

--- a/apps/api/src/transfers/state-machine/stellar/transfer-state-machine.controller.ts
+++ b/apps/api/src/transfers/state-machine/stellar/transfer-state-machine.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Param, Body, HttpCode, HttpStatus, BadRequestException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiParam, ApiBody, ApiResponse } from '@nestjs/swagger';
 import { TransferStateMachineService } from './transfer-state-machine.service';
-import { TransferState, TransferLifecycle } from './transfer-state-machine.types';
+import type { TransferState, TransferLifecycle } from './transfer-state-machine.types';
 
 class TransitionDto {
   state: TransferState;

--- a/apps/dashboard/src/components/ChainHealthGrid.tsx
+++ b/apps/dashboard/src/components/ChainHealthGrid.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React from 'react';
+import { ChainHealth, useChainHealth, UseChainHealthOptions } from '../hooks/useChainHealth';
+
+const STATUS_COLOR: Record<ChainHealth['status'], string> = {
+  healthy: '#16a34a',
+  degraded: '#f59e0b',
+  down: '#dc2626',
+};
+
+const BALANCE_COLOR: Record<ChainHealth['relayerBalanceStatus'], string> = {
+  ok: '#16a34a',
+  low: '#eab308',
+  critical: '#dc2626',
+};
+
+function ChainHealthCard({ chain }: { chain: ChainHealth }) {
+  const blocksBehind = chain.chainTipHeight - chain.syncedHeight;
+
+  return (
+    <div
+      style={{
+        border: '1px solid #e2e8f0',
+        borderRadius: '10px',
+        padding: '16px',
+        backgroundColor: '#fff',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+        <span style={{ fontSize: '15px', fontWeight: 700, color: '#0f172a' }}>{chain.chainName}</span>
+        <span
+          style={{
+            fontSize: '11px',
+            fontWeight: 600,
+            padding: '2px 8px',
+            borderRadius: '9999px',
+            color: '#fff',
+            backgroundColor: STATUS_COLOR[chain.status],
+          }}
+        >
+          {chain.status.toUpperCase()}
+        </span>
+      </div>
+
+      <dl style={{ display: 'grid', gridTemplateColumns: '1fr auto', rowGap: '6px', fontSize: '13px', margin: 0 }}>
+        <dt style={{ color: '#64748b' }}>RPC latency</dt>
+        <dd style={{ margin: 0, textAlign: 'right', color: '#0f172a' }}>{chain.blockLatencyMs} ms</dd>
+
+        <dt style={{ color: '#64748b' }}>Sync height</dt>
+        <dd style={{ margin: 0, textAlign: 'right', color: '#0f172a' }}>
+          {chain.syncedHeight.toLocaleString()}
+          {blocksBehind > 0 ? ` (-${blocksBehind})` : ''}
+        </dd>
+
+        <dt style={{ color: '#64748b' }}>Relayer balance</dt>
+        <dd
+          style={{
+            margin: 0,
+            textAlign: 'right',
+            fontWeight: 600,
+            color: BALANCE_COLOR[chain.relayerBalanceStatus],
+          }}
+        >
+          {chain.relayerBalanceNative.toFixed(3)} {chain.nativeTokenSymbol}
+        </dd>
+      </dl>
+    </div>
+  );
+}
+
+export interface ChainHealthGridProps {
+  /** Passed through to useChainHealth — override to plug in a live telemetry source. */
+  options?: UseChainHealthOptions;
+}
+
+/**
+ * Visual health panel showing active bridge connections, RPC latency, sync
+ * height, and relayer wallet gas balances across all supported chains.
+ * Auto-refreshes every 15 seconds by default (configurable via `options`),
+ * and flags low/critical relayer gas balances.
+ */
+export function ChainHealthGrid({ options }: ChainHealthGridProps) {
+  const { chains, isLoading, error, lastUpdated, refresh } = useChainHealth(options);
+
+  if (isLoading && chains.length === 0) {
+    return <div style={{ fontSize: '13px', color: '#64748b' }}>Loading chain health…</div>;
+  }
+
+  if (error) {
+    return (
+      <div style={{ fontSize: '13px', color: '#dc2626' }}>
+        Failed to load chain health: {error.message}{' '}
+        <button onClick={refresh} style={{ marginLeft: '8px', cursor: 'pointer' }}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const criticalChains = chains.filter((chain) => chain.relayerBalanceStatus === 'critical');
+
+  return (
+    <div>
+      {criticalChains.length > 0 && (
+        <div
+          style={{
+            marginBottom: '12px',
+            padding: '10px 14px',
+            borderRadius: '8px',
+            backgroundColor: '#fee2e2',
+            color: '#991b1b',
+            fontSize: '13px',
+            fontWeight: 600,
+          }}
+        >
+          ⚠ {criticalChains.length} relayer wallet{criticalChains.length > 1 ? 's' : ''} critically low on
+          gas: {criticalChains.map((chain) => chain.chainName).join(', ')}
+        </div>
+      )}
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+          gap: '12px',
+        }}
+      >
+        {chains.map((chain) => (
+          <ChainHealthCard key={chain.chainId} chain={chain} />
+        ))}
+      </div>
+
+      {lastUpdated && (
+        <div style={{ marginTop: '12px', fontSize: '11px', color: '#94a3b8' }}>
+          Last updated {new Date(lastUpdated).toLocaleTimeString()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/hooks/useChainHealth.ts
+++ b/apps/dashboard/src/hooks/useChainHealth.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type ChainHealthState = 'healthy' | 'degraded' | 'down';
+export type RelayerBalanceStatus = 'ok' | 'low' | 'critical';
+
+export interface ChainHealth {
+  chainId: string;
+  chainName: string;
+  status: ChainHealthState;
+  /** RPC round-trip latency, in milliseconds. */
+  blockLatencyMs: number;
+  /** Highest block height this indexer has fully synced. */
+  syncedHeight: number;
+  /** Current tip of the chain, as reported by the RPC. */
+  chainTipHeight: number;
+  relayerBalanceNative: number;
+  nativeTokenSymbol: string;
+  relayerBalanceStatus: RelayerBalanceStatus;
+  lastUpdated: number;
+}
+
+export type ChainHealthFetcher = () => Promise<ChainHealth[]>;
+
+/** Below this balance (in native token units) a relayer wallet is flagged yellow. */
+export const LOW_BALANCE_THRESHOLD = 0.5;
+/** Below this balance (in native token units) a relayer wallet is flagged red. */
+export const CRITICAL_BALANCE_THRESHOLD = 0.1;
+
+const DEFAULT_REFRESH_INTERVAL_MS = 15_000;
+/** A chain is considered degraded once it falls this many blocks behind the tip. */
+const DEGRADED_BLOCK_LAG_THRESHOLD = 5;
+
+export function relayerBalanceStatus(balanceNative: number): RelayerBalanceStatus {
+  if (balanceNative < CRITICAL_BALANCE_THRESHOLD) return 'critical';
+  if (balanceNative < LOW_BALANCE_THRESHOLD) return 'low';
+  return 'ok';
+}
+
+const MOCK_CHAINS: Array<{ chainId: string; chainName: string; nativeTokenSymbol: string }> = [
+  { chainId: 'stellar', chainName: 'Stellar', nativeTokenSymbol: 'XLM' },
+  { chainId: 'ethereum', chainName: 'Ethereum', nativeTokenSymbol: 'ETH' },
+  { chainId: 'arbitrum', chainName: 'Arbitrum', nativeTokenSymbol: 'ETH' },
+  { chainId: 'polygon', chainName: 'Polygon', nativeTokenSymbol: 'MATIC' },
+];
+
+/**
+ * Placeholder data source used until this hook is wired to a live operator
+ * telemetry endpoint (e.g. the relayer fee/status API). Pass a real
+ * `fetcher` via `useChainHealth`'s options to replace it.
+ */
+async function fetchMockChainHealth(): Promise<ChainHealth[]> {
+  return MOCK_CHAINS.map((chain, i) => {
+    const chainTipHeight = 1_000_000 + i * 137;
+    const blocksBehind = Math.floor(Math.random() * 8);
+    const syncedHeight = chainTipHeight - blocksBehind;
+    const blockLatencyMs = 200 + Math.floor(Math.random() * 800);
+    const relayerBalanceNative = Number((Math.random() * 1.2).toFixed(3));
+
+    return {
+      chainId: chain.chainId,
+      chainName: chain.chainName,
+      nativeTokenSymbol: chain.nativeTokenSymbol,
+      chainTipHeight,
+      syncedHeight,
+      blockLatencyMs,
+      relayerBalanceNative,
+      relayerBalanceStatus: relayerBalanceStatus(relayerBalanceNative),
+      status: blocksBehind > DEGRADED_BLOCK_LAG_THRESHOLD ? 'degraded' : 'healthy',
+      lastUpdated: Date.now(),
+    };
+  });
+}
+
+export interface UseChainHealthOptions {
+  /** Data source for chain health telemetry. Defaults to local mock data. */
+  fetcher?: ChainHealthFetcher;
+  /** Auto-refresh interval, in ms. Defaults to 15 seconds. */
+  refreshIntervalMs?: number;
+}
+
+export interface UseChainHealthResult {
+  chains: ChainHealth[];
+  isLoading: boolean;
+  error: Error | null;
+  lastUpdated: number | null;
+  refresh: () => void;
+}
+
+/**
+ * Polls chain health telemetry (RPC latency, sync height, relayer wallet gas
+ * balance) for every supported chain, auto-refreshing on an interval so an
+ * operator dashboard always shows current state.
+ */
+export function useChainHealth(options: UseChainHealthOptions = {}): UseChainHealthResult {
+  const { fetcher = fetchMockChainHealth, refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS } = options;
+
+  const [chains, setChains] = useState<ChainHealth[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+
+  // Keep the latest fetcher available to the interval without re-triggering
+  // the effect (and therefore resetting the interval) on every render.
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const load = useCallback(async () => {
+    try {
+      const result = await fetcherRef.current();
+      setChains(result);
+      setError(null);
+      setLastUpdated(Date.now());
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to load chain health'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const interval = setInterval(load, refreshIntervalMs);
+    return () => clearInterval(interval);
+  }, [load, refreshIntervalMs]);
+
+  return { chains, isLoading, error, lastUpdated, refresh: load };
+}

--- a/libs/indexer/src/index.ts
+++ b/libs/indexer/src/index.ts
@@ -1,2 +1,3 @@
 export * from './reorg-detector';
 export * from './finality-tracker';
+export * from './websocket-reconnector';

--- a/libs/indexer/src/websocket-reconnector.ts
+++ b/libs/indexer/src/websocket-reconnector.ts
@@ -1,0 +1,233 @@
+/**
+ * libs/indexer/src/websocket-reconnector.ts
+ *
+ * WebSocket Reconnector
+ * ----------------------
+ * Wraps an RPC WebSocket/subscription connection (bridge event listeners
+ * watching for `MessageSent`, `TokensLocked`, etc.) with automatic
+ * reconnection: exponential backoff with jitter on connection drops, and a
+ * `backfill` event describing the block range that was missed while
+ * disconnected so the caller can re-subscribe to / replay those blocks.
+ *
+ * The reconnector doesn't know anything about a specific RPC provider's SDK.
+ * It's driven by a caller-supplied `connect()` factory that returns anything
+ * shaped like a WebSocket (open/message/error/close events), so it works the
+ * same whether the underlying connection is `ws`, an ethers provider socket,
+ * or a Soroban RPC subscription.
+ */
+
+import { EventEmitter } from 'events';
+
+/** Minimal WebSocket-like surface the reconnector depends on. */
+export interface WebSocketLike {
+  close(): void;
+  on(event: 'open', listener: () => void): void;
+  on(event: 'message', listener: (data: unknown) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+  on(event: 'close', listener: (code?: number, reason?: string) => void): void;
+}
+
+export type ConnectionFactory = () => WebSocketLike | Promise<WebSocketLike>;
+
+/** Block range that was missed while the connection was down. */
+export interface BackfillRange {
+  chainId: number;
+  /** First missed block, inclusive. */
+  fromBlock: number;
+  /** Chain tip at the moment of reconnection, inclusive. */
+  toBlock: number;
+}
+
+export type BackfillHandler = (range: BackfillRange) => void | Promise<void>;
+
+export interface WebSocketReconnectorOptions {
+  chainId: number;
+  /** Opens a new connection. Called on start and on every reconnect attempt. */
+  connect: ConnectionFactory;
+  /** Base delay, in ms, for the exponential backoff calculation. Default 1000. */
+  baseDelayMs?: number;
+  /** Upper bound on the computed backoff delay, in ms. Default 30000. */
+  maxDelayMs?: number;
+  /** Consecutive failed attempts allowed before giving up and emitting `exhausted`. Default Infinity. */
+  maxAttempts?: number;
+  /** Returns the last block height this listener has fully processed. Used to compute backfill ranges. */
+  getLastProcessedBlock?: () => number | Promise<number>;
+  /** Returns the chain's current tip height. Used to compute backfill ranges. */
+  getLatestBlock?: () => number | Promise<number>;
+  /** Convenience callback invoked with the missed range on reconnect, in addition to the `backfill` event. */
+  onBackfill?: BackfillHandler;
+}
+
+/**
+ * Declaration merging: gives `.on()` / `.once()` / `.emit()` typed payloads
+ * instead of the default EventEmitter signature.
+ */
+export declare interface WebSocketReconnector {
+  on(event: 'open', listener: () => void): this;
+  on(event: 'message', listener: (data: unknown) => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'disconnected', listener: (info: { code?: number; reason?: string }) => void): this;
+  on(event: 'reconnecting', listener: (info: { attempt: number; delayMs: number }) => void): this;
+  on(event: 'reconnected', listener: (info: { attempts: number }) => void): this;
+  on(event: 'backfill', listener: (range: BackfillRange) => void): this;
+  on(event: 'exhausted', listener: (info: { attempts: number }) => void): this;
+  once(event: 'open', listener: () => void): this;
+  once(event: 'reconnected', listener: (info: { attempts: number }) => void): this;
+  emit(event: 'open'): boolean;
+  emit(event: 'message', data: unknown): boolean;
+  emit(event: 'error', err: Error): boolean;
+  emit(event: 'disconnected', info: { code?: number; reason?: string }): boolean;
+  emit(event: 'reconnecting', info: { attempt: number; delayMs: number }): boolean;
+  emit(event: 'reconnected', info: { attempts: number }): boolean;
+  emit(event: 'backfill', range: BackfillRange): boolean;
+  emit(event: 'exhausted', info: { attempts: number }): boolean;
+}
+
+export class WebSocketReconnector extends EventEmitter {
+  private readonly chainId: number;
+  private readonly connectFn: ConnectionFactory;
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly maxAttempts: number;
+  private readonly getLastProcessedBlock?: () => number | Promise<number>;
+  private readonly getLatestBlock?: () => number | Promise<number>;
+  private readonly onBackfill?: BackfillHandler;
+
+  private socket: WebSocketLike | null = null;
+  private attempt = 0;
+  private stopped = true;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(options: WebSocketReconnectorOptions) {
+    super();
+    this.chainId = options.chainId;
+    this.connectFn = options.connect;
+    this.baseDelayMs = options.baseDelayMs ?? 1_000;
+    this.maxDelayMs = options.maxDelayMs ?? 30_000;
+    this.maxAttempts = options.maxAttempts ?? Infinity;
+    this.getLastProcessedBlock = options.getLastProcessedBlock;
+    this.getLatestBlock = options.getLatestBlock;
+    this.onBackfill = options.onBackfill;
+  }
+
+  /** True while a live connection is established. */
+  get isConnected(): boolean {
+    return this.socket !== null;
+  }
+
+  /** Number of consecutive failed reconnect attempts since the last successful connection. */
+  get currentAttempt(): number {
+    return this.attempt;
+  }
+
+  /** Open the initial connection. Safe to call again after `stop()`. */
+  async start(): Promise<void> {
+    this.stopped = false;
+    this.attempt = 0;
+    await this.establishConnection();
+  }
+
+  /** Close the connection and cancel any pending reconnect attempt. */
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.socket?.close();
+    this.socket = null;
+  }
+
+  private async establishConnection(): Promise<void> {
+    let socket: WebSocketLike;
+    try {
+      socket = await this.connectFn();
+    } catch (err) {
+      this.handleDrop(undefined, (err as Error).message);
+      return;
+    }
+
+    if (this.stopped) {
+      // start()/stop() raced; discard the connection we just opened.
+      socket.close();
+      return;
+    }
+
+    this.socket = socket;
+    socket.on('open', () => this.handleOpen());
+    socket.on('message', (data) => this.emit('message', data));
+    socket.on('error', (err) => this.emit('error', err));
+    socket.on('close', (code, reason) => this.handleDrop(code, reason));
+  }
+
+  private handleOpen(): void {
+    const attemptsTaken = this.attempt;
+    this.attempt = 0;
+    this.emit('open');
+
+    if (attemptsTaken > 0) {
+      this.emit('reconnected', { attempts: attemptsTaken });
+      void this.backfillMissedRange();
+    }
+  }
+
+  private handleDrop(code?: number, reason?: string): void {
+    this.socket = null;
+    if (this.stopped) return;
+
+    this.emit('disconnected', { code, reason });
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.attempt >= this.maxAttempts) {
+      this.emit('exhausted', { attempts: this.attempt });
+      return;
+    }
+
+    this.attempt += 1;
+    const delayMs = this.computeBackoffDelay(this.attempt);
+    this.emit('reconnecting', { attempt: this.attempt, delayMs });
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.establishConnection();
+    }, delayMs);
+  }
+
+  /**
+   * Exponential backoff with jitter: `2^attempt * baseDelayMs`, capped at
+   * `maxDelayMs`, plus a random jitter in `[0, baseDelayMs)` so a fleet of
+   * listeners reconnecting after a shared outage doesn't thunder the RPC
+   * node all at once.
+   */
+  private computeBackoffDelay(attempt: number): number {
+    const exponential = 2 ** attempt * this.baseDelayMs;
+    const jitter = Math.random() * this.baseDelayMs;
+    return Math.min(this.maxDelayMs, exponential + jitter);
+  }
+
+  private async backfillMissedRange(): Promise<void> {
+    if (!this.getLastProcessedBlock || !this.getLatestBlock) return;
+
+    try {
+      const [lastProcessed, latest] = await Promise.all([
+        Promise.resolve(this.getLastProcessedBlock()),
+        Promise.resolve(this.getLatestBlock()),
+      ]);
+
+      if (latest <= lastProcessed) return;
+
+      const range: BackfillRange = {
+        chainId: this.chainId,
+        fromBlock: lastProcessed + 1,
+        toBlock: latest,
+      };
+
+      this.emit('backfill', range);
+      if (this.onBackfill) await this.onBackfill(range);
+    } catch (err) {
+      this.emit('error', err as Error);
+    }
+  }
+}

--- a/libs/indexer/tests/websocket-reconnector.spec.ts
+++ b/libs/indexer/tests/websocket-reconnector.spec.ts
@@ -1,0 +1,159 @@
+import { EventEmitter } from 'events';
+import {
+  WebSocketReconnector,
+  WebSocketLike,
+  BackfillRange,
+} from '../src/websocket-reconnector';
+
+/** Minimal fake WebSocket driven manually by tests. */
+class FakeSocket extends EventEmitter implements WebSocketLike {
+  closed = false;
+
+  close(): void {
+    this.closed = true;
+  }
+
+  on(event: string, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  triggerOpen(): void {
+    this.emit('open');
+  }
+
+  triggerClose(code?: number, reason?: string): void {
+    this.emit('close', code, reason);
+  }
+}
+
+describe('WebSocketReconnector', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('emits open on a successful initial connection', async () => {
+    const socket = new FakeSocket();
+    const connect = jest.fn().mockResolvedValue(socket);
+
+    const reconnector = new WebSocketReconnector({ chainId: 1, connect });
+    const opened = jest.fn();
+    reconnector.on('open', opened);
+
+    await reconnector.start();
+    socket.triggerOpen();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(opened).toHaveBeenCalledTimes(1);
+    expect(reconnector.isConnected).toBe(true);
+  });
+
+  it('reconnects with exponential backoff after a connection drop', async () => {
+    const sockets = [new FakeSocket(), new FakeSocket()];
+    const connect = jest.fn().mockImplementation(() => Promise.resolve(sockets.shift()));
+
+    const reconnector = new WebSocketReconnector({
+      chainId: 1,
+      connect,
+      baseDelayMs: 1000,
+      maxDelayMs: 30000,
+    });
+
+    const reconnecting = jest.fn();
+    const reconnected = jest.fn();
+    reconnector.on('reconnecting', reconnecting);
+    reconnector.on('reconnected', reconnected);
+
+    const firstSocket = sockets[0];
+    await reconnector.start();
+    firstSocket.triggerOpen();
+
+    // Simulate a dropped connection.
+    firstSocket.triggerClose(1006, 'abnormal closure');
+
+    expect(reconnecting).toHaveBeenCalledTimes(1);
+    const { attempt, delayMs } = reconnecting.mock.calls[0][0];
+    expect(attempt).toBe(1);
+    // 2^1 * 1000 = 2000, plus jitter in [0, 1000)
+    expect(delayMs).toBeGreaterThanOrEqual(2000);
+    expect(delayMs).toBeLessThan(3000);
+    expect(reconnector.isConnected).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(delayMs);
+
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops attempting to reconnect once maxAttempts is exhausted', async () => {
+    const connect = jest.fn().mockRejectedValue(new Error('connection refused'));
+
+    const reconnector = new WebSocketReconnector({
+      chainId: 1,
+      connect,
+      baseDelayMs: 10,
+      maxDelayMs: 100,
+      maxAttempts: 2,
+    });
+
+    const exhausted = jest.fn();
+    reconnector.on('exhausted', exhausted);
+
+    await reconnector.start();
+    await jest.advanceTimersByTimeAsync(100);
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(exhausted).toHaveBeenCalledWith({ attempts: 2 });
+  });
+
+  it('emits a backfill range covering blocks missed while disconnected', async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    const sockets = [firstSocket, secondSocket];
+    const connect = jest.fn().mockImplementation(() => Promise.resolve(sockets.shift()));
+
+    const reconnector = new WebSocketReconnector({
+      chainId: 1,
+      connect,
+      baseDelayMs: 10,
+      getLastProcessedBlock: () => 100,
+      getLatestBlock: () => 105,
+    });
+
+    const backfills: BackfillRange[] = [];
+    reconnector.on('backfill', (range) => backfills.push(range));
+
+    await reconnector.start();
+    firstSocket.triggerOpen();
+
+    firstSocket.triggerClose();
+    await jest.advanceTimersByTimeAsync(1000);
+
+    secondSocket.triggerOpen();
+    // Backfill computation is async; flush microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(backfills).toEqual([{ chainId: 1, fromBlock: 101, toBlock: 105 }]);
+  });
+
+  it('does not reconnect after stop() is called', async () => {
+    const socket = new FakeSocket();
+    const connect = jest.fn().mockResolvedValue(socket);
+
+    const reconnector = new WebSocketReconnector({ chainId: 1, connect, baseDelayMs: 10 });
+    await reconnector.start();
+    socket.triggerOpen();
+
+    reconnector.stop();
+    expect(socket.closed).toBe(true);
+
+    socket.triggerClose();
+    await jest.advanceTimersByTimeAsync(1000);
+
+    // Only the initial connect() call — no reconnect attempt after stop().
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/analyzers/jest.config.js
+++ b/packages/analyzers/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/packages/analyzers/package.json
+++ b/packages/analyzers/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@bridgewise/analyzers",
+  "version": "0.1.0",
+  "description": "Cross-chain bridge risk analyzers for BridgeWise (optimistic dispute monitoring, etc.)",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest",
+    "lint": "eslint src --ext .ts"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/analyzers/src/index.ts
+++ b/packages/analyzers/src/index.ts
@@ -1,0 +1,1 @@
+export * from './optimistic/challenge-monitor';

--- a/packages/analyzers/src/optimistic/challenge-monitor.spec.ts
+++ b/packages/analyzers/src/optimistic/challenge-monitor.spec.ts
@@ -1,0 +1,154 @@
+import { ChallengeMonitor, ChallengeAlert, ChallengeExpiredEvent, StateRootAssertion } from './challenge-monitor';
+
+const baseAssertion: StateRootAssertion = {
+  chainId: 42161,
+  assertionId: 'assertion-1',
+  proposer: '0xproposer',
+  claimedStateRoot: '0xclaimed',
+  submittedAtBlock: 1000,
+  submittedAtTimestamp: 1_000_000,
+  challengeWindowSeconds: 1000,
+};
+
+describe('ChallengeMonitor', () => {
+  it('emits validated and does not track an assertion whose claimed root matches canonical state', async () => {
+    const monitor = new ChallengeMonitor({
+      resolveCanonicalStateRoot: async () => '0xclaimed',
+      now: () => 1_000_000,
+    });
+
+    const validated = jest.fn();
+    monitor.on('validated', validated);
+
+    await monitor.trackAssertion(baseAssertion);
+
+    expect(validated).toHaveBeenCalledWith(baseAssertion);
+    expect(monitor.pendingCount).toBe(0);
+  });
+
+  it('detects a mismatched root and tracks the assertion', async () => {
+    const monitor = new ChallengeMonitor({
+      resolveCanonicalStateRoot: async () => '0xcanonical',
+      now: () => 1_000_000,
+    });
+
+    const detected = jest.fn();
+    monitor.on('invalidAssertionDetected', detected);
+
+    await monitor.trackAssertion(baseAssertion);
+
+    expect(detected).toHaveBeenCalledWith(baseAssertion, '0xcanonical');
+    expect(monitor.pendingCount).toBe(1);
+  });
+
+  it('does not alert while more than the threshold fraction of the window remains', async () => {
+    let now = 1_000_000;
+    const monitor = new ChallengeMonitor({
+      resolveCanonicalStateRoot: async () => '0xcanonical',
+      now: () => now,
+      alertRemainingFraction: 0.2,
+    });
+
+    const alert = jest.fn();
+    monitor.on('alert', alert);
+
+    await monitor.trackAssertion(baseAssertion);
+
+    // Window is 1000s; advance 500s (50% remaining) — above the 20% threshold.
+    now += 500;
+    monitor.checkPendingAssertions();
+
+    expect(alert).not.toHaveBeenCalled();
+  });
+
+  it('fires an alert with exact remaining time once <=20% of the window remains', async () => {
+    let now = 1_000_000;
+    const monitor = new ChallengeMonitor({
+      resolveCanonicalStateRoot: async () => '0xcanonical',
+      now: () => now,
+      alertRemainingFraction: 0.2,
+      averageBlockTimeSeconds: 10,
+    });
+
+    const alerts: ChallengeAlert[] = [];
+    monitor.on('alert', (alert) => alerts.push(alert));
+
+    await monitor.trackAssertion(baseAssertion);
+
+    // Window is 1000s starting at submittedAtTimestamp=1_000_000, so it
+    // expires at 1_001_000. Advance to 1_000_850 -> 150s (15%) remaining.
+    now = 1_000_850;
+    monitor.checkPendingAssertions();
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({
+      assertionId: 'assertion-1',
+      remainingSeconds: 150,
+      remainingBlocks: 15,
+      windowExpiresAtTimestamp: 1_001_000,
+    });
+    expect(alerts[0].remainingFraction).toBeCloseTo(0.15, 5);
+  });
+
+  it('only fires one alert per assertion even if checked repeatedly while still in range', async () => {
+    let now = 1_000_850;
+    const monitor = new ChallengeMonitor({
+      resolveCanonicalStateRoot: async () => '0xcanonical',
+      now: () => now,
+    });
+
+    const alert = jest.fn();
+    monitor.on('alert', alert);
+
+    await monitor.trackAssertion(baseAssertion);
+    monitor.checkPendingAssertions();
+    monitor.checkPendingAssertions();
+
+    expect(alert).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits expired and stops tracking once the window fully closes', async () => {
+    let now = 1_000_000;
+    const monitor = new ChallengeMonitor({
+      resolveCanonicalStateRoot: async () => '0xcanonical',
+      now: () => now,
+    });
+
+    const expired = jest.fn<void, [ChallengeExpiredEvent]>();
+    monitor.on('expired', expired);
+
+    await monitor.trackAssertion(baseAssertion);
+    expect(monitor.pendingCount).toBe(1);
+
+    now = 1_001_001; // 1s past window close
+    monitor.checkPendingAssertions();
+
+    expect(expired).toHaveBeenCalledTimes(1);
+    expect(expired.mock.calls[0][0]).toMatchObject({
+      assertionId: 'assertion-1',
+      canonicalStateRoot: '0xcanonical',
+    });
+    expect(monitor.pendingCount).toBe(0);
+  });
+
+  it('stops watching an assertion once untrackAssertion is called', async () => {
+    let now = 1_000_000;
+    const monitor = new ChallengeMonitor({
+      resolveCanonicalStateRoot: async () => '0xcanonical',
+      now: () => now,
+    });
+
+    await monitor.trackAssertion(baseAssertion);
+    expect(monitor.pendingCount).toBe(1);
+
+    monitor.untrackAssertion(baseAssertion.assertionId);
+    expect(monitor.pendingCount).toBe(0);
+
+    const alert = jest.fn();
+    monitor.on('alert', alert);
+    now = 1_000_950;
+    monitor.checkPendingAssertions();
+
+    expect(alert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/analyzers/src/optimistic/challenge-monitor.ts
+++ b/packages/analyzers/src/optimistic/challenge-monitor.ts
@@ -1,0 +1,214 @@
+/**
+ * packages/analyzers/src/optimistic/challenge-monitor.ts
+ *
+ * Optimistic Challenge Window Expiry Monitor
+ * -------------------------------------------
+ * In an optimistic bridge, a relayer submits an asserted state root for the
+ * destination chain to trust; it becomes permanent and executable once its
+ * fraud-proof dispute window elapses without a successful challenge.
+ *
+ * This monitor indexes proposed state root assertions, validates each one
+ * against the true canonical state root on the source chain, and — for any
+ * assertion found to be invalid — tracks its dispute window so a
+ * high-priority alert can fire while there's still time left to submit a
+ * fraud proof (by default, once 20% or less of the window remains).
+ *
+ * The monitor doesn't know how to fetch canonical state itself (that's
+ * chain-specific); it's driven by a caller-supplied `resolveCanonicalStateRoot`
+ * function so it works against Stellar/Soroban, EVM, or any other source
+ * chain the same way.
+ */
+
+import { EventEmitter } from 'events';
+
+/** A state root assertion submitted to a destination optimistic bridge contract. */
+export interface StateRootAssertion {
+  /** Destination chain the assertion was submitted to. */
+  chainId: number;
+  assertionId: string;
+  proposer: string;
+  claimedStateRoot: string;
+  submittedAtBlock: number;
+  submittedAtTimestamp: number;
+  /** Total dispute/challenge window duration, in seconds, from submission. */
+  challengeWindowSeconds: number;
+}
+
+/** Resolves the true canonical state root on the source chain, for comparison. */
+export type CanonicalStateRootResolver = (
+  assertion: StateRootAssertion,
+) => string | Promise<string>;
+
+/** High-priority alert for an invalid assertion nearing the end of its dispute window. */
+export interface ChallengeAlert {
+  assertionId: string;
+  chainId: number;
+  proposer: string;
+  claimedStateRoot: string;
+  canonicalStateRoot: string;
+  /** Exact time remaining before the challenge window closes, in seconds. */
+  remainingSeconds: number;
+  /** Exact time remaining before the challenge window closes, in destination-chain blocks. */
+  remainingBlocks: number;
+  /** Fraction of the total window still remaining, 0-1. */
+  remainingFraction: number;
+  windowExpiresAtTimestamp: number;
+  detectedAt: number;
+}
+
+/** An invalid assertion's dispute window closed with no fraud proof submitted. */
+export interface ChallengeExpiredEvent {
+  assertionId: string;
+  chainId: number;
+  claimedStateRoot: string;
+  canonicalStateRoot: string;
+  windowExpiresAtTimestamp: number;
+  detectedAt: number;
+}
+
+export interface ChallengeMonitorOptions {
+  /** Resolves the true canonical state root for a source chain, to validate an assertion against. */
+  resolveCanonicalStateRoot: CanonicalStateRootResolver;
+  /**
+   * Alert once an invalid assertion's dispute window has this fraction of its
+   * total duration or less remaining. Default 0.2 (20%).
+   */
+  alertRemainingFraction?: number;
+  /** Average seconds per block on the destination chain, used to express remaining time in blocks. Default 12. */
+  averageBlockTimeSeconds?: number;
+  /** Clock override for tests. Returns the current unix timestamp, in seconds. */
+  now?: () => number;
+}
+
+interface TrackedAssertion {
+  assertion: StateRootAssertion;
+  canonicalStateRoot: string;
+  windowExpiresAtTimestamp: number;
+  alerted: boolean;
+}
+
+/**
+ * Declaration merging: gives `.on()` / `.once()` / `.emit()` typed payloads
+ * instead of the default EventEmitter signature.
+ */
+export declare interface ChallengeMonitor {
+  on(event: 'validated', listener: (assertion: StateRootAssertion) => void): this;
+  on(
+    event: 'invalidAssertionDetected',
+    listener: (assertion: StateRootAssertion, canonicalStateRoot: string) => void,
+  ): this;
+  on(event: 'alert', listener: (alert: ChallengeAlert) => void): this;
+  on(event: 'expired', listener: (event: ChallengeExpiredEvent) => void): this;
+  emit(event: 'validated', assertion: StateRootAssertion): boolean;
+  emit(event: 'invalidAssertionDetected', assertion: StateRootAssertion, canonicalStateRoot: string): boolean;
+  emit(event: 'alert', alert: ChallengeAlert): boolean;
+  emit(event: 'expired', payload: ChallengeExpiredEvent): boolean;
+}
+
+export class ChallengeMonitor extends EventEmitter {
+  private readonly resolveCanonicalStateRoot: CanonicalStateRootResolver;
+  private readonly alertRemainingFraction: number;
+  private readonly averageBlockTimeSeconds: number;
+  private readonly now: () => number;
+
+  /** Invalid assertions currently being watched, keyed by assertionId. */
+  private readonly tracked = new Map<string, TrackedAssertion>();
+
+  constructor(options: ChallengeMonitorOptions) {
+    super();
+    this.resolveCanonicalStateRoot = options.resolveCanonicalStateRoot;
+    this.alertRemainingFraction = options.alertRemainingFraction ?? 0.2;
+    this.averageBlockTimeSeconds = options.averageBlockTimeSeconds ?? 12;
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  /** Number of invalid assertions currently being watched for their dispute window closing. */
+  get pendingCount(): number {
+    return this.tracked.size;
+  }
+
+  /**
+   * Index a newly observed state root assertion and validate it against the
+   * source chain's canonical state. If it's invalid, starts tracking its
+   * dispute window and immediately checks whether it already warrants an
+   * alert (e.g. if this assertion was only just discovered late).
+   */
+  async trackAssertion(assertion: StateRootAssertion): Promise<void> {
+    const canonicalStateRoot = await this.resolveCanonicalStateRoot(assertion);
+
+    if (canonicalStateRoot === assertion.claimedStateRoot) {
+      this.emit('validated', assertion);
+      return;
+    }
+
+    this.emit('invalidAssertionDetected', assertion, canonicalStateRoot);
+
+    const windowExpiresAtTimestamp =
+      assertion.submittedAtTimestamp + assertion.challengeWindowSeconds;
+
+    this.tracked.set(assertion.assertionId, {
+      assertion,
+      canonicalStateRoot,
+      windowExpiresAtTimestamp,
+      alerted: false,
+    });
+
+    this.evaluateAssertion(assertion.assertionId);
+  }
+
+  /** Stop watching an assertion (e.g. once a fraud proof has been submitted for it). */
+  untrackAssertion(assertionId: string): void {
+    this.tracked.delete(assertionId);
+  }
+
+  /**
+   * Re-evaluate every currently tracked (invalid) assertion against the
+   * current time, firing `alert` once for each assertion that crosses into
+   * the alert threshold, and `expired` for any whose window has fully
+   * closed. Call this on a schedule (e.g. every block or every few seconds).
+   */
+  checkPendingAssertions(): void {
+    for (const assertionId of [...this.tracked.keys()]) {
+      this.evaluateAssertion(assertionId);
+    }
+  }
+
+  private evaluateAssertion(assertionId: string): void {
+    const entry = this.tracked.get(assertionId);
+    if (!entry) return;
+
+    const nowSeconds = this.now();
+    const remainingSeconds = entry.windowExpiresAtTimestamp - nowSeconds;
+
+    if (remainingSeconds <= 0) {
+      this.tracked.delete(assertionId);
+      this.emit('expired', {
+        assertionId,
+        chainId: entry.assertion.chainId,
+        claimedStateRoot: entry.assertion.claimedStateRoot,
+        canonicalStateRoot: entry.canonicalStateRoot,
+        windowExpiresAtTimestamp: entry.windowExpiresAtTimestamp,
+        detectedAt: nowSeconds,
+      });
+      return;
+    }
+
+    const remainingFraction = remainingSeconds / entry.assertion.challengeWindowSeconds;
+
+    if (!entry.alerted && remainingFraction <= this.alertRemainingFraction) {
+      entry.alerted = true;
+      this.emit('alert', {
+        assertionId,
+        chainId: entry.assertion.chainId,
+        proposer: entry.assertion.proposer,
+        claimedStateRoot: entry.assertion.claimedStateRoot,
+        canonicalStateRoot: entry.canonicalStateRoot,
+        remainingSeconds,
+        remainingBlocks: Math.ceil(remainingSeconds / this.averageBlockTimeSeconds),
+        remainingFraction,
+        windowExpiresAtTimestamp: entry.windowExpiresAtTimestamp,
+        detectedAt: nowSeconds,
+      });
+    }
+  }
+}

--- a/packages/analyzers/tsconfig.json
+++ b/packages/analyzers/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ importers:
         specifier: ^7.0.0
         version: 7.2.2
       ts-jest:
-        specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        specifier: ^29.4.11
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: ^9.5.2
         version: 9.5.4(typescript@5.9.3)(webpack@5.104.1)
@@ -430,6 +430,28 @@ importers:
         specifier: ^8.0.10
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
 
+  apps/relayer-service:
+    dependencies:
+      axios:
+        specifier: ^1.6.0
+        version: 1.13.6
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.15
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.2.5
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@bridgewise/ui-components':
@@ -479,6 +501,45 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  libs/indexer: {}
+
+  libs/oracle:
+    dependencies:
+      axios:
+        specifier: ^1.6.0
+        version: 1.13.6
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.15
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.2.5
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
+  libs/router:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.0
+        version: 29.5.14
+      jest:
+        specifier: ^29.5.0
+        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   libs/ui-components:
     dependencies:
       clsx:
@@ -504,6 +565,21 @@ importers:
         specifier: ^18.0.0
         version: 18.3.7(@types/react@18.3.31)
 
+  packages/analyzers:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.0
+        version: 29.5.14
+      jest:
+        specifier: ^29.5.0
+        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   packages/config:
     dependencies:
       '@nestjs/common':
@@ -521,6 +597,24 @@ importers:
         version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       typescript:
         specifier: ^5.0.0
+        version: 5.9.3
+
+  packages/formatters:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.15
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.2.5
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.3.0
         version: 5.9.3
 
   packages/next-adapter:
@@ -559,6 +653,24 @@ importers:
       ts-jest:
         specifier: ^29.1.0
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+  packages/rules:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.0
+        version: 29.5.14
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      jest:
+        specifier: ^29.5.0
+        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -626,6 +738,24 @@ importers:
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.0
+        version: 5.9.3
+
+  packages/verification:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.0
+        version: 29.5.14
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      jest:
+        specifier: ^29.5.0
+        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.0.0
         version: 5.9.3
 
   packages/wallet:
@@ -1353,105 +1483,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1953,28 +2067,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.4':
     resolution: {integrity: sha512-3Wm0zGYVCs6qDFAiSSDL+Z+r46EdtCv/2l+UlIdMbAq9hPJBvGu/rZOeuvCaIUjbArkmXac8HnTyQPJFzFWA0Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.4':
     resolution: {integrity: sha512-lWAYAezFinaJiD5Gv8HDidtsZdT3CDaCeqoPoJjeB57OqzvMajpIhlZFce5sCAH6VuX4mdkxCRqecCJFwfm2nQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.4':
     resolution: {integrity: sha512-fHaIpT7x4gA6VQbdEpYUXRGyge/YbRrkG6DXM60XiBqDM2g2NcrsQaIuj375egnGFkJow4RHacgBOEsHfGbiUw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.4':
     resolution: {integrity: sha512-MCrXxrTSE7jPN1NyXJr39E+aNFBrQZtO154LoCz7n99FuKqJDekgxipoodLNWdQP7/DZ5tKMc/efybx1l159hw==}
@@ -2072,42 +2182,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -2181,79 +2285,66 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2637,28 +2728,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3084,49 +3171,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4642,6 +4721,11 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -5247,28 +5331,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -6098,6 +6178,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6505,6 +6590,33 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  ts-jest@29.4.12:
+    resolution: {integrity: sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <7'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
 
   ts-jest@29.4.6:
     resolution: {integrity: sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==}
@@ -8015,7 +8127,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.19.15
       jest-regex-util: 30.0.1
     optional: true
 
@@ -8132,7 +8244,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.13.2
+      '@types/node': 22.19.15
       '@types/yargs': 17.0.35
       chalk: 4.1.2
     optional: true
@@ -10940,7 +11052,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -10977,7 +11089,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10992,7 +11104,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11608,6 +11720,15 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -12127,7 +12248,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.13.2
+      '@types/node': 22.19.15
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12288,7 +12409,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 24.13.2
+      '@types/node': 22.19.15
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -12317,7 +12438,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.19.15
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -12330,7 +12451,7 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 22.19.15
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
@@ -13378,6 +13499,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.5: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -13884,6 +14007,26 @@ snapshots:
       typescript: 6.0.3
 
   ts-dedent@2.2.0: {}
+
+  ts-jest@29.4.12(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.5
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      jest-util: 30.3.0
 
   ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- **`apps/api/src/relayer`** — `GET /api/v1/relayer/estimate-fee` endpoint (`sourceChain`, `targetChain`, `payloadByteLength`) returning the estimated destination gas cost plus relayer margin, with both native and USD amounts. Reuses the existing `GasPriceAdapter` for EVM chains and a dedicated flat-fee model for Stellar/Soroban.
- **`libs/indexer`** — `WebSocketReconnector`: wraps an RPC WebSocket/subscription connection with automatic reconnection (exponential backoff + jitter) on drops, and emits a `backfill` event with the exact block range missed while disconnected so listeners can re-subscribe without losing events.
- **`apps/dashboard/src`** — `ChainHealthGrid` component + `useChainHealth` hook: per-chain status cards showing RPC latency, sync height, and relayer wallet gas balance, with yellow/red warnings below 0.5 / 0.1 native token and a 15s auto-refresh.
- **`packages/analyzers`** — `ChallengeMonitor`: indexes optimistic bridge state root assertions, validates each against the source chain's canonical state, and fires a high-priority alert (with exact remaining time/blocks) once an invalid assertion has ≤20% of its dispute window left.

Also fixes two pre-existing issues on `main` that were failing CI independently of this change (confirmed via the last several CI runs on `main`):
- `transfer-state-machine.controller.ts` used a value import for a type-only symbol, which `isolatedModules` rejects — switched to `import type`.
- `pnpm-lock.yaml` was out of sync with `package.json` (`ts-jest` version mismatch), so `pnpm install --frozen-lockfile` failed before the build step ever ran.

## Testing

- `pnpm run build` (the CI build step) passes.
- `pnpm install --frozen-lockfile` passes.
- Added unit tests for all three new logic modules (fee estimator, WebSocket reconnector, challenge monitor); all pass locally via `jest`.

Closes #730
Closes #731
Closes #732
Closes #733