### PR TITLE
Feat/bridge contracts

### DIFF
--- a/contracts/core/BridgeSender.sol
+++ b/contracts/core/BridgeSender.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title BridgeSender
+/// @notice Source-chain contract that dispatches cross-chain messages with
+///         auto-incrementing nonces per destination chain.
+contract BridgeSender {
+    /// @notice Emitted when a cross-chain message is dispatched.
+    event MessageDispatched(
+        uint32 indexed destinationChainId,
+        uint64 indexed nonce,
+        bytes32 messageHash,
+        bytes payload
+    );
+
+    /// @notice Maps destination chain ID to the next outbound nonce.
+    mapping(uint32 => uint64) public outboundNonces;
+
+    /// @notice Dispatch a cross-chain message to the specified destination chain.
+    /// @param destinationChainId The target chain identifier.
+    /// @param payload            The arbitrary message payload.
+    /// @return nonce             The nonce assigned to this message.
+    function dispatchMessage(
+        uint32 destinationChainId,
+        bytes calldata payload
+    ) external virtual returns (uint64 nonce) {
+        nonce = outboundNonces[destinationChainId];
+        outboundNonces[destinationChainId] = nonce + 1;
+
+        bytes32 messageHash = keccak256(abi.encodePacked(destinationChainId, nonce, payload));
+
+        emit MessageDispatched(destinationChainId, nonce, messageHash, payload);
+    }
+}

--- a/contracts/crypto/MerkleProofYul.sol
+++ b/contracts/crypto/MerkleProofYul.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title MerkleProofYul
+/// @notice Gas-optimized sparse Merkle proof verification using inline
+///         assembly. Targets at least 25% gas savings vs. the standard
+///         OpenZeppelin MerkleProof library by hashing directly in
+///         scratch space (0x00–0x40) and avoiding memory allocations.
+library MerkleProofYul {
+    /// @notice Verify a Merkle inclusion proof entirely in Yul/Assembly.
+    /// @param proof Array of sibling hashes from leaf to root.
+    /// @param root   Expected Merkle root.
+    /// @param leaf   The leaf hash to verify.
+    /// @return True if the proof is valid.
+    function verifyProof(
+        bytes32[] memory proof,
+        bytes32 root,
+        bytes32 leaf
+    ) internal pure returns (bool) {
+        // Assembly-optimized verification
+        assembly {
+            let computedHash := leaf
+            let proofLength := mload(proof)
+            let proofStart := add(proof, 0x20)
+
+            for { let i := 0 } lt(i, proofLength) { i := add(i, 1) } {
+                let sibling := mload(add(proofStart, mul(i, 0x20)))
+
+                // Sort: put smaller hash first for canonical ordering
+                // Use scratch space at 0x00 and 0x20 for the pair
+                switch lt(computedHash, sibling)
+                case 1 {
+                    // computedHash < sibling → write computedHash first
+                    mstore(0x00, computedHash)
+                    mstore(0x20, sibling)
+                }
+                default {
+                    // sibling <= computedHash → write sibling first
+                    mstore(0x00, sibling)
+                    mstore(0x20, computedHash)
+                }
+
+                // Hash the pair in scratch space
+                computedHash := keccak256(0x00, 0x40)
+            }
+
+            // Compare computed hash against root
+            switch eq(computedHash, root)
+            case 1 { storeTrue() }
+            default { storeFalse() }
+
+            function storeTrue() {
+                mstore(0x00, 1)
+                return(0x00, 0x20)
+            }
+
+            function storeFalse() {
+                mstore(0x00, 0)
+                return(0x00, 0x20)
+            }
+        }
+    }
+}
+
+/// @dev Wrapper contract to expose the library for testing.
+contract MerkleProofYulWrapper {
+    function verify(
+        bytes32[] calldata proof,
+        bytes32 root,
+        bytes32 leaf
+    ) external pure returns (bool) {
+        return MerkleProofYul.verifyProof(proof, root, leaf);
+    }
+}

--- a/contracts/libraries/AddressUtils.sol
+++ b/contracts/libraries/AddressUtils.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title AddressUtils
+/// @notice Utility library for converting between 20-byte EVM addresses and
+///         32-byte normalized cross-chain recipient identifiers.
+library AddressUtils {
+    /// @notice Convert a 32-byte identifier to a 20-byte EVM address.
+    /// @dev Reverts if the upper 12 bytes are non-zero (dirty high-order bits).
+    /// @param input The 32-byte cross-chain recipient identifier.
+    /// @return The corresponding 20-byte EVM address.
+    function bytes32ToAddress(bytes32 input) internal pure returns (address) {
+        // Check that upper 12 bytes are zeroed
+        require(
+            uint96(uint256(input)) == 0,
+            "InvalidAddressMapping"
+        );
+        return address(uint160(uint256(input)));
+    }
+
+    /// @notice Convert a 20-byte EVM address to a 32-byte identifier by left-padding with zeroes.
+    /// @param input The 20-byte EVM address.
+    /// @return The corresponding 32-byte cross-chain identifier.
+    function addressToBytes32(address input) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(input)));
+    }
+}

--- a/contracts/router/NativeBridgeRouter.sol
+++ b/contracts/router/NativeBridgeRouter.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title IWETH Minimal interface for wrapped native token.
+interface IWETH {
+    function deposit() external payable;
+    function approve(address spender, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+/// @title IBridgeVault Minimal interface for the core bridge vault.
+interface IBridgeVault {
+    function lock(
+        uint32 destinationChainId,
+        address token,
+        uint256 amount,
+        bytes32 recipient
+    ) external;
+}
+
+/// @title NativeBridgeRouter
+/// @notice Accepts native gas tokens ($ETH, $XLM), auto-wraps them to
+///         ERC-20/WETH, and dispatches cross-chain lock events in a single
+///         transaction — removing the need for users to manually deposit
+///         into wrapped token contracts before bridging.
+contract NativeBridgeRouter {
+    event NativeBridged(
+        uint32 indexed destinationChainId,
+        address indexed sender,
+        uint256 amount,
+        bytes32 recipient
+    );
+
+    IWETH public immutable weth;
+    IBridgeVault public immutable vault;
+
+    error InsufficientBalance();
+    error RefundFailed();
+
+    constructor(address _weth, address _vault) {
+        weth = IWETH(_weth);
+        vault = IBridgeVault(_vault);
+    }
+
+    /// @notice Receive native ETH (e.g. from a plain transfer).
+    receive() external payable {}
+
+    /// @notice Wrap native ETH and bridge it in a single call.
+    /// @param destinationChainId Target chain for the cross-chain transfer.
+    /// @param recipient          32-byte normalized recipient on destination.
+    function depositNative(
+        uint32 destinationChainId,
+        bytes32 recipient
+    ) external payable {
+        uint256 value = msg.value;
+        require(value > 0, "NativeBridgeRouter: zero value");
+
+        // Wrap native → WETH
+        weth.deposit{value: value}();
+
+        // Approve the vault to pull WETH
+        weth.approve(address(vault), value);
+
+        // Lock in the bridge vault
+        vault.lock(destinationChainId, address(weth), value, recipient);
+
+        emit NativeBridged(destinationChainId, msg.sender, value, recipient);
+    }
+}

--- a/test/core/BridgeSender.test.ts
+++ b/test/core/BridgeSender.test.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("BridgeSender", () => {
+  async function deploy() {
+    const [owner, user] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory("BridgeSender");
+    const sender = await Factory.deploy();
+    await sender.waitForDeployment();
+    return { sender, owner, user };
+  }
+
+  const DEST_CHAIN = 1;
+  const PAYLOAD = ethers.toUtf8Bytes("hello-cross-chain");
+
+  it("starts with nonce 0 for any destination chain", async () => {
+    const { sender } = await deploy();
+    expect(await sender.outboundNonces(DEST_CHAIN)).to.equal(0);
+  });
+
+  it("increments nonce per dispatched message", async () => {
+    const { sender } = await deploy();
+
+    const tx0 = await sender.dispatchMessage(DEST_CHAIN, PAYLOAD);
+    await tx0.wait();
+    expect(await sender.outboundNonces(DEST_CHAIN)).to.equal(1);
+
+    const tx1 = await sender.dispatchMessage(DEST_CHAIN, PAYLOAD);
+    await tx1.wait();
+    expect(await sender.outboundNonces(DEST_CHAIN)).to.equal(2);
+  });
+
+  it("maintains independent nonces per destination chain", async () => {
+    const { sender } = await deploy();
+    const CHAIN_A = 1;
+    const CHAIN_B = 137;
+
+    await (await sender.dispatchMessage(CHAIN_A, PAYLOAD)).wait();
+    await (await sender.dispatchMessage(CHAIN_A, PAYLOAD)).wait();
+    await (await sender.dispatchMessage(CHAIN_B, PAYLOAD)).wait();
+
+    expect(await sender.outboundNonces(CHAIN_A)).to.equal(2);
+    expect(await sender.outboundNonces(CHAIN_B)).to.equal(1);
+  });
+
+  it("emits MessageDispatched with correct nonce", async () => {
+    const { sender } = await deploy();
+
+    await expect(sender.dispatchMessage(DEST_CHAIN, PAYLOAD))
+      .to.emit(sender, "MessageDispatched")
+      .withArgs(DEST_CHAIN, 0, ethers.anyValue, ethers.hexlify(PAYLOAD));
+  });
+
+  it("emits sequential nonces in events", async () => {
+    const { sender } = await deploy();
+
+    const tx0 = sender.dispatchMessage(DEST_CHAIN, PAYLOAD);
+    await expect(tx0)
+      .to.emit(sender, "MessageDispatched")
+      .withArgs(DEST_CHAIN, 0, ethers.anyValue, ethers.hexlify(PAYLOAD));
+
+    const tx1 = sender.dispatchMessage(DEST_CHAIN, PAYLOAD);
+    await expect(tx1)
+      .to.emit(sender, "MessageDispatched")
+      .withArgs(DEST_CHAIN, 1, ethers.anyValue, ethers.hexlify(PAYLOAD));
+  });
+});

--- a/test/crypto/MerkleProofYul.test.ts
+++ b/test/crypto/MerkleProofYul.test.ts
@@ -1,0 +1,109 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("MerkleProofYul", () => {
+  async function deploy() {
+    const [owner] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory("MerkleProofYulWrapper");
+    const verifier = await Factory.deploy();
+    await verifier.waitForDeployment();
+    return { verifier };
+  }
+
+  // Helper: build a simple 4-leaf Merkle tree
+  function buildTree(leaves: string[]): { root: string; tree: string[] } {
+    const hashed = leaves.map((l) => ethers.keccak256(ethers.toUtf8Bytes(l)));
+    const tree = [...hashed];
+
+    let level = [...hashed];
+    while (level.length > 1) {
+      const next: string[] = [];
+      for (let i = 0; i < level.length; i += 2) {
+        const left = level[i];
+        const right = i + 1 < level.length ? level[i + 1] : level[i];
+        const sorted = left < right ? [left, right] : [right, left];
+        next.push(ethers.keccak256(ethers.concat(sorted)));
+      }
+      level = next;
+    }
+
+    return { root: level[0], tree };
+  }
+
+  function getProof(tree: string[], index: number): string[] {
+    const proof: string[] = [];
+    let level = [...tree];
+    let idx = index;
+
+    while (level.length > 1) {
+      const next: string[] = [];
+      for (let i = 0; i < level.length; i += 2) {
+        const left = level[i];
+        const right = i + 1 < level.length ? level[i + 1] : level[i];
+        if (i === idx || i + 1 === idx) {
+          proof.push(i === idx ? right : left);
+        }
+        const sorted = left < right ? [left, right] : [right, left];
+        next.push(ethers.keccak256(ethers.concat(sorted)));
+      }
+      level = next;
+      idx = Math.floor(idx / 2);
+    }
+
+    return proof;
+  }
+
+  it("verifies a valid 4-leaf Merkle proof", async () => {
+    const { verifier } = await deploy();
+    const leaves = ["apple", "banana", "cherry", "date"];
+    const { root, tree } = buildTree(leaves);
+
+    const proof = getProof(tree, 0);
+    expect(await verifier.verify(proof, root, tree[0])).to.equal(true);
+  });
+
+  it("verifies each leaf in a 4-leaf tree", async () => {
+    const { verifier } = await deploy();
+    const leaves = ["alpha", "beta", "gamma", "delta"];
+    const { root, tree } = buildTree(leaves);
+
+    for (let i = 0; i < leaves.length; i++) {
+      const proof = getProof(tree, i);
+      expect(await verifier.verify(proof, root, tree[i])).to.equal(true);
+    }
+  });
+
+  it("rejects a tampered leaf", async () => {
+    const { verifier } = await deploy();
+    const leaves = ["one", "two", "three", "four"];
+    const { root, tree } = buildTree(leaves);
+
+    const fakeLeaf = ethers.keccak256(ethers.toUtf8Bytes("tampered"));
+    const proof = getProof(tree, 0);
+    expect(await verifier.verify(proof, root, fakeLeaf)).to.equal(false);
+  });
+
+  it("rejects a wrong root", async () => {
+    const { verifier } = await deploy();
+    const leaves = ["x", "y", "z"];
+    const { tree } = buildTree(leaves);
+
+    const fakeRoot = ethers.keccak256(ethers.toUtf8Bytes("wrong-root"));
+    const proof = getProof(tree, 0);
+    expect(await verifier.verify(proof, fakeRoot, tree[0])).to.equal(false);
+  });
+
+  it("rejects an empty proof with non-matching root", async () => {
+    const { verifier } = await deploy();
+    const leaf = ethers.keccak256(ethers.toUtf8Bytes("solo"));
+    const fakeRoot = ethers.keccak256(ethers.toUtf8Bytes("nope"));
+    expect(await verifier.verify([], fakeRoot, leaf)).to.equal(false);
+  });
+
+  it("verifies a single-leaf tree (empty proof)", async () => {
+    const { verifier } = await deploy();
+    const leaf = ethers.keccak256(ethers.toUtf8Bytes("only"));
+    // Root of a single-leaf tree is the leaf itself
+    expect(await verifier.verify([], leaf, leaf)).to.equal(true);
+  });
+});

--- a/test/libraries/AddressUtils.test.ts
+++ b/test/libraries/AddressUtils.test.ts
@@ -1,0 +1,64 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("AddressUtils", () => {
+  let addressUtils: any;
+
+  before(async () => {
+    const factory = await ethers.getContractFactory("AddressUtils");
+    // Libraries need to be linked; for testing we deploy via a helper contract
+    // that exposes the library functions. Alternatively, use inline assembly tests.
+    addressUtils = await factory.deploy();
+    await addressUtils.waitForDeployment();
+  });
+
+  describe("bytes32ToAddress", () => {
+    it("converts a clean 32-byte value to a 20-byte address", async () => {
+      const addr = ethers.getAddress("0x1234567890AbcdEF1234567890aBcdef12345678");
+      const padded = ethers.zeroPadValue(addr, 32);
+      const result = await addressUtils.bytes32ToAddress(padded);
+      expect(result).to.equal(addr);
+    });
+
+    it("converts a zero bytes32 to the zero address", async () => {
+      const result = await addressUtils.bytes32ToAddress(ethers.ZeroHash);
+      expect(result).to.equal(ethers.ZeroAddress);
+    });
+
+    it("reverts when upper 12 bytes are non-zero", async () => {
+      const dirty = "0x0000000000000000000000011234567890AbcdEF1234567890aBcdef12345678";
+      await expect(
+        addressUtils.bytes32ToAddress(dirty)
+      ).to.be.revertedWith("InvalidAddressMapping");
+    });
+
+    it("reverts when a high byte is set", async () => {
+      const dirty = "0xff00000000000000000000001234567890AbcdEF1234567890aBcdef12345678";
+      await expect(
+        addressUtils.bytes32ToAddress(dirty)
+      ).to.be.revertedWith("InvalidAddressMapping");
+    });
+  });
+
+  describe("addressToBytes32", () => {
+    it("left-pads a 20-byte address with zeroes", async () => {
+      const addr = ethers.getAddress("0x1234567890AbcdEF1234567890aBcdef12345678");
+      const result = await addressUtils.addressToBytes32(addr);
+      expect(result).to.equal(ethers.zeroPadValue(addr, 32));
+    });
+
+    it("converts the zero address to zero bytes32", async () => {
+      const result = await addressUtils.addressToBytes32(ethers.ZeroAddress);
+      expect(result).to.equal(ethers.ZeroHash);
+    });
+  });
+
+  describe("round-trip", () => {
+    it("bytes32ToAddress(addressToBytes32(addr)) == addr", async () => {
+      const addr = ethers.getAddress("0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B");
+      const padded = await addressUtils.addressToBytes32(addr);
+      const roundTripped = await addressUtils.bytes32ToAddress(padded);
+      expect(roundTripped).to.equal(addr);
+    });
+  });
+});

--- a/test/router/NativeBridgeRouter.test.ts
+++ b/test/router/NativeBridgeRouter.test.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("NativeBridgeRouter", () => {
+  const DEST_CHAIN = 1;
+  const RECIPIENT = ethers.zeroPadValue("0xabcdef", 32);
+
+  async function deploy() {
+    const [owner, user] = await ethers.getSigners();
+
+    // Deploy mock WETH
+    const WETHFactory = await ethers.getContractFactory("BridgeWrappedToken");
+    const weth = await WETHFactory.deploy("Wrapped ETH", "WETH", owner.address);
+    await weth.waitForDeployment();
+
+    // Deploy mock vault (we'll use a simple receiver that accepts lock calls)
+    const VaultFactory = await ethers.getContractFactory("BridgeReceiverBase");
+    const vault = await VaultFactory.deploy(owner.address, owner.address);
+    await vault.waitForDeployment();
+
+    // Deploy router
+    const RouterFactory = await ethers.getContractFactory("NativeBridgeRouter");
+    const router = await RouterFactory.deploy(
+      await weth.getAddress(),
+      await vault.getAddress()
+    );
+    await router.waitForDeployment();
+
+    return { router, weth, vault, owner, user };
+  }
+
+  it("wraps native ETH and forwards to vault on depositNative", async () => {
+    const { router, weth, vault, user } = await deploy();
+    const amount = ethers.parseEther("1.0");
+
+    await router.connect(user).depositNative(DEST_CHAIN, RECIPIENT, { value: amount });
+
+    // Router should have no WETH left (it forwarded to vault)
+    expect(await weth.balanceOf(await router.getAddress())).to.equal(0);
+  });
+
+  it("emits NativeBridged event", async () => {
+    const { router, user } = await deploy();
+    const amount = ethers.parseEther("0.5");
+
+    await expect(
+      router.connect(user).depositNative(DEST_CHAIN, RECIPIENT, { value: amount })
+    )
+      .to.emit(router, "NativeBridged")
+      .withArgs(DEST_CHAIN, user.address, amount, RECIPIENT);
+  });
+
+  it("reverts on zero value", async () => {
+    const { router, user } = await deploy();
+
+    await expect(
+      router.connect(user).depositNative(DEST_CHAIN, RECIPIENT, { value: 0 })
+    ).to.be.revertedWith("NativeBridgeRouter: zero value");
+  });
+
+  it("accepts native ETH via receive()", async () => {
+    const { router, owner } = await deploy();
+    const amount = ethers.parseEther("1.0");
+
+    await owner.sendTransaction({ to: await router.getAddress(), value: amount });
+    const balance = await ethers.provider.getBalance(await router.getAddress());
+    expect(balance).to.equal(amount);
+  });
+});


### PR DESCRIPTION
Closes #762
Closes #763
Closes #776
Closes #777

- AddressUtils.sol — bytes32 ↔ address conversion with dirty-bit revert
- BridgeSender.sol — auto-incrementing nonces per destination chain
- NativeBridgeRouter.sol — native ETH auto-wrap and bridge in one tx
- MerkleProofYul.sol — gas-optimized assembly Merkle verifier
- All 4 contracts have corresponding test files