### PR TITLE
feat(contracts): implement TTL helper, flash-loan guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 /.pnp
 .pnp.js
 
+# rust
+**/target/
+**/Cargo.lock
+
 # testing
 /coverage
 
@@ -48,6 +52,11 @@ build_output.log
 *.tsbuildinfo
 next-env.d.ts
 libs/bridge-core/node_modules
+
+# hardhat
+artifacts/
+cache/
+types/
 
 # Secret files
 *.key

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "type": "commonjs",
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/contracts/router/BatchBridgeRouter.sol
+++ b/contracts/router/BatchBridgeRouter.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title IBridgeVault
+/// @notice Minimal interface for the core bridge vault used by routers.
+interface IBridgeVault {
+    function lock(
+        uint32 destinationChainId,
+        address token,
+        uint256 amount,
+        bytes32 recipient
+    ) external;
+}
+
+/// @title BatchBridgeRouter
+/// @notice Allows users to bridge multiple distinct token types to one or more
+///         destination chains in a single atomic transaction.
+contract BatchBridgeRouter {
+    using SafeERC20 for IERC20;
+
+    /// @notice Emitted once per batch with an aggregated payload describing all
+    ///         individual bridge operations.
+    event BatchBridgeDispatched(
+        address indexed sender,
+        uint256 count,
+        uint256 totalAmount,
+        bytes payload
+    );
+
+    /// @notice Core bridge vault that receives token deposits.
+    IBridgeVault public immutable vault;
+
+    error LengthMismatch();
+    error EmptyBatch();
+
+    constructor(address _vault) {
+        require(_vault != address(0), "BatchBridgeRouter: zero vault");
+        vault = IBridgeVault(_vault);
+    }
+
+    /// @notice Deposit multiple tokens into the bridge vault in one transaction.
+    /// @param tokens              ERC-20 tokens to bridge.
+    /// @param amounts             Amounts to bridge for each token.
+    /// @param destinationChainIds Destination chain for each token.
+    /// @param recipients          32-byte normalized recipients for each token.
+    /// @dev The entire batch reverts if any individual `safeTransferFrom` or
+    ///      `lock` call fails, preserving atomicity.
+    function batchDeposit(
+        address[] calldata tokens,
+        uint256[] calldata amounts,
+        uint32[] calldata destinationChainIds,
+        bytes32[] calldata recipients
+    ) external {
+        uint256 count = tokens.length;
+        if (count == 0) revert EmptyBatch();
+        if (
+            amounts.length != count ||
+            destinationChainIds.length != count ||
+            recipients.length != count
+        ) revert LengthMismatch();
+
+        uint256 totalAmount = 0;
+
+        for (uint256 i = 0; i < count; i++) {
+            address token = tokens[i];
+            uint256 amount = amounts[i];
+
+            // Pull tokens from the caller and forward directly to the vault.
+            // SafeERC20 reverts automatically on transfer failures.
+            IERC20(token).safeTransferFrom(msg.sender, address(vault), amount);
+            vault.lock(destinationChainIds[i], token, amount, recipients[i]);
+
+            totalAmount += amount;
+        }
+
+        bytes memory payload = abi.encode(tokens, amounts, destinationChainIds, recipients);
+        emit BatchBridgeDispatched(msg.sender, count, totalAmount, payload);
+    }
+}

--- a/contracts/security/FlashLoanGuard.sol
+++ b/contracts/security/FlashLoanGuard.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title FlashLoanGuard
+/// @notice Base contract that prevents same-block borrow-bridge-swap arbitrage
+///         by tracking the ledger height of the most recent deposit for each
+///         account and reverting cross-chain dispatch actions that occur in the
+///         same block as the deposit.
+/// @dev Inherit this contract and call `_recordDeposit()` on every deposit-like
+///      entry point and apply the `noSameBlockFlashLoan` modifier (or call
+///      `_checkFlashLoanGuard()`) on every cross-chain dispatch action.
+abstract contract FlashLoanGuard {
+    /// @notice Last block number in which an account made a deposit.
+    mapping(address => uint256) private _lastDepositBlock;
+
+    /// @notice Accounts that are authorized to bypass the guard. Intended for
+    ///         verified contract router integrations that perform atomic
+    ///         multi-step operations under protocol-controlled conditions.
+    mapping(address => bool) private _bypassAuthorized;
+
+    /// @notice Thrown when an account attempts a dispatch in the same block as
+    ///         its deposit.
+    error SameBlockFlashLoan(address account);
+
+    /// @notice Emitted when an account's deposit block is recorded.
+    event DepositRecorded(address indexed account, uint256 blockNumber);
+
+    /// @notice Emitted when bypass authorization is changed for an account.
+    event BypassUpdated(address indexed account, bool authorized);
+
+    /// @notice Restricts execution when the caller deposited in the same block.
+    modifier noSameBlockFlashLoan() {
+        _checkFlashLoanGuard();
+        _;
+    }
+
+    /// @notice Record `msg.sender`'s current block as its most recent deposit.
+    /// @dev Call this at the end of deposit/lock entry points.
+    function _recordDeposit() internal {
+        _lastDepositBlock[msg.sender] = block.number;
+        emit DepositRecorded(msg.sender, block.number);
+    }
+
+    /// @notice Revert if `msg.sender` is not bypass-authorized and deposited in
+    ///         the current block.
+    function _checkFlashLoanGuard() internal view {
+        if (!_bypassAuthorized[msg.sender] && _lastDepositBlock[msg.sender] == block.number) {
+            revert SameBlockFlashLoan(msg.sender);
+        }
+    }
+
+    /// @notice Authorize or revoke bypass for `account`. Intended to be called
+    ///         by an admin function in the inheriting contract.
+    function _setBypass(address account, bool authorized) internal {
+        _bypassAuthorized[account] = authorized;
+        emit BypassUpdated(account, authorized);
+    }
+
+    /// @notice Return whether `account` is authorized to bypass the guard.
+    function isBypassAuthorized(address account) external view returns (bool) {
+        return _bypassAuthorized[account];
+    }
+}

--- a/contracts/soroban/common/Cargo.toml
+++ b/contracts/soroban/common/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "common"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/soroban/common/src/lib.rs
+++ b/contracts/soroban/common/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+//! Shared helpers used across BridgeWise Soroban contracts.
+
+pub mod ttl_helper;
+
+#[cfg(test)]
+mod test;

--- a/contracts/soroban/common/src/test.rs
+++ b/contracts/soroban/common/src/test.rs
@@ -1,0 +1,57 @@
+#![cfg(test)]
+
+use soroban_sdk::{contract, contractimpl, symbol_short, Env};
+
+use crate::ttl_helper::{extend_instance_ttl_if_needed, extend_persistent_ttl_if_needed};
+
+#[contract]
+pub struct TtlTestContract;
+
+#[contractimpl]
+impl TtlTestContract {
+    pub fn seed(env: Env, key: soroban_sdk::Symbol, value: u32) {
+        env.storage().persistent().set(&key, &value);
+    }
+
+    pub fn bump_instance(env: Env, threshold: u32, extend_by: u32) {
+        extend_instance_ttl_if_needed(&env, threshold, extend_by);
+    }
+
+    pub fn bump_persistent(env: Env, key: soroban_sdk::Symbol, threshold: u32, extend_by: u32) {
+        extend_persistent_ttl_if_needed(&env, &key, threshold, extend_by);
+    }
+}
+
+#[test]
+fn instance_ttl_extends_when_below_threshold() {
+    let env = Env::default();
+    let contract_id = env.register(TtlTestContract, ());
+    let client = TtlTestContractClient::new(&env, &contract_id);
+
+    let initial_ttl = env.storage().instance().get_ttl();
+
+    // Advance ledger so remaining TTL is low and then request an extension.
+    env.ledger().set(env.ledger().sequence() + initial_ttl - 5);
+    client.bump_instance(&5, &1_000);
+
+    let new_ttl = env.storage().instance().get_ttl();
+    assert!(new_ttl > initial_ttl - 5);
+}
+
+#[test]
+fn persistent_ttl_extends_when_below_threshold() {
+    let env = Env::default();
+    let contract_id = env.register(TtlTestContract, ());
+    let client = TtlTestContractClient::new(&env, &contract_id);
+
+    let key = symbol_short!("counter");
+    client.seed(&key, &1u32);
+
+    let initial_ttl = env.storage().persistent().get_ttl(&key);
+    env.ledger().set(env.ledger().sequence() + initial_ttl - 5);
+
+    client.bump_persistent(&key, &5, &1_000);
+
+    let new_ttl = env.storage().persistent().get_ttl(&key);
+    assert!(new_ttl > initial_ttl - 5);
+}

--- a/contracts/soroban/common/src/ttl_helper.rs
+++ b/contracts/soroban/common/src/ttl_helper.rs
@@ -1,0 +1,32 @@
+//! TTL extension helpers for Soroban bridge contracts.
+//!
+//! These helpers automatically extend Instance and Persistent storage entry
+//! Time-To-Live (TTL) ledgers on user interactions, preventing critical bridge
+//! state from becoming archived.
+
+use soroban_sdk::{Env, IntoVal};
+
+/// Extend the contract instance TTL when the remaining ledgers drop below
+/// `threshold`.
+///
+/// `extend_by` is the target TTL (in ledgers) that the entry should have after
+/// extension, matching the semantics of `Instance::extend_ttl`. The Soroban host
+/// only performs the extension when the current remaining TTL is below
+/// `threshold`; otherwise the call is a no-op.
+pub fn extend_instance_ttl_if_needed(env: &Env, threshold: u32, extend_by: u32) {
+    env.storage().instance().extend_ttl(threshold, extend_by);
+}
+
+/// Extend a persistent storage entry's TTL when the remaining ledgers drop
+/// below `threshold`.
+///
+/// The key type `K` must be convertible into a Soroban storage key. As with
+/// [`extend_instance_ttl_if_needed`], `extend_by` is the target TTL in ledgers
+/// and the extension only happens when the host determines the remaining TTL
+/// is below `threshold`.
+pub fn extend_persistent_ttl_if_needed<K>(env: &Env, key: &K, threshold: u32, extend_by: u32)
+where
+    K: IntoVal<Env, soroban_sdk::Val> + Clone,
+{
+    env.storage().persistent().extend_ttl(key, threshold, extend_by);
+}

--- a/contracts/vault/VaultHealthEvaluator.sol
+++ b/contracts/vault/VaultHealthEvaluator.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title IReserveVault
+/// @notice Minimal interface for vaults that report per-token locked reserves.
+interface IReserveVault {
+    /// @notice Total reserves locked for `token`.
+    function lockedReserves(address token) external view returns (uint256);
+}
+
+/// @title VaultHealthEvaluator
+/// @notice On-chain solvency calculator that compares locked reserves against
+///         outstanding wrapped token supply.
+contract VaultHealthEvaluator {
+    /// @notice Health status tiers expressed in basis points.
+    /// @dev Ratio = (TotalLockedReserves * 10_000) / TotalMintedWrapped.
+    enum HealthStatus {
+        SOLVENT,
+        UNDERCOLLATERALIZED,
+        CRITICAL
+    }
+
+    /// @notice Basis-point denominator used for the ratio.
+    uint256 public constant BPS = 10_000;
+
+    /// @notice Ratio below which the vault is considered undercollateralized.
+    uint256 public constant UNDERCOLLATERALIZED_THRESHOLD = 10_000; // 100%
+
+    /// @notice Ratio below which the vault is considered critical.
+    uint256 public constant CRITICAL_THRESHOLD = 8_000; // 80%
+
+    /// @notice Compute the solvency ratio and health status for `wrappedToken`
+    ///         using reserves tracked by `reserveVault`.
+    /// @param reserveVault Vault that reports locked reserves for the token.
+    /// @param wrappedToken ERC-20 wrapped asset whose total supply represents
+    ///        outstanding obligations.
+    /// @return ratioBps Collateralization ratio in basis points.
+    /// @return status Current health status flag.
+    function evaluate(
+        address reserveVault,
+        address wrappedToken
+    ) external view returns (uint256 ratioBps, HealthStatus status) {
+        uint256 totalLocked = IReserveVault(reserveVault).lockedReserves(wrappedToken);
+        uint256 totalMinted = IERC20(wrappedToken).totalSupply();
+
+        if (totalMinted == 0) {
+            return (0, HealthStatus.SOLVENT);
+        }
+
+        ratioBps = (totalLocked * BPS) / totalMinted;
+
+        if (ratioBps < CRITICAL_THRESHOLD) {
+            status = HealthStatus.CRITICAL;
+        } else if (ratioBps < UNDERCOLLATERALIZED_THRESHOLD) {
+            status = HealthStatus.UNDERCOLLATERALIZED;
+        } else {
+            status = HealthStatus.SOLVENT;
+        }
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "hardhat/config";
+import hardhatToolboxMochaEthers from "@nomicfoundation/hardhat-toolbox-mocha-ethers";
+
+export default defineConfig({
+  plugins: [hardhatToolboxMochaEthers],
+  solidity: "0.8.20",
+  paths: {
+    sources: "./contracts",
+    tests: "./test",
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
         "@nomicfoundation/hardhat-network-helpers": "^3.0.11",
-        "@nomicfoundation/hardhat-toolbox": "^7.0.0",
+        "@nomicfoundation/hardhat-toolbox-mocha-ethers": "^3.0.7",
         "@openzeppelin/contracts": "^5.6.1",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
@@ -80,6 +80,14 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@angular-devkit/core": {
       "version": "19.2.19",
@@ -1379,6 +1387,434 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
+      "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.6.1",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3315,6 +3751,20 @@
         "typeorm": "^0.3.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
+      "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
@@ -3453,6 +3903,136 @@
         "@nomicfoundation/hardhat-utils": "^4.1.5"
       }
     },
+    "node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-4.0.15.tgz",
+      "integrity": "sha512-qLBvq2RcKuffObX08LVZr9LixDSnsJwwxeRKYCfr5p1VTkMT0XP5JU2Y8AOIady39O5v7ZuzIEY+xH+DdqrBKA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/hardhat-errors": "^3.0.17",
+        "@nomicfoundation/hardhat-utils": "^4.1.5",
+        "@nomicfoundation/hardhat-zod-utils": "^3.0.5",
+        "ethereum-cryptography": "^2.2.1",
+        "ethers": "^6.14.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "hardhat": "^3.8.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ethers-chai-matchers": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers-chai-matchers/-/hardhat-ethers-chai-matchers-3.0.11.tgz",
+      "integrity": "sha512-pAOTjBQRNKqCh8cLJD6dsOeGWrU8fe9Wrz4UqO03qhJbwmj0md2bq2LEPaMZAgDtxVS0ZteiVGx64DgBfyb7XA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/hardhat-utils": "^4.1.4",
+        "@types/chai-as-promised": "^8.0.1",
+        "chai-as-promised": "^8.0.0",
+        "deep-eql": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^4.0.7",
+        "chai": ">=5.1.2 <7",
+        "ethers": "^6.14.0",
+        "hardhat": "^3.8.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition/-/hardhat-ignition-3.1.8.tgz",
+      "integrity": "sha512-zVsR1SA1gqjd3SF3C+BljttSEMOaIbSIEvHgFhXF/A1IgeecJYD/MqGcvGAW4s51r5ZGQnUSl9t/5VQKvuExlw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/hardhat-errors": "^3.0.16",
+        "@nomicfoundation/hardhat-utils": "^4.1.4",
+        "@nomicfoundation/ignition-core": "^3.1.8",
+        "@nomicfoundation/ignition-ui": "^3.1.2",
+        "json5": "^2.2.3",
+        "prompts": "^2.4.2"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-verify": "^3.0.0",
+        "hardhat": "^3.8.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ignition-ethers": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ignition-ethers/-/hardhat-ignition-ethers-3.1.6.tgz",
+      "integrity": "sha512-RtdrlOm69wgj6NzSih3FvdNw9TqfdzMhEc0n6D6CsSLo7Czyi2xBZUoN9NiUSL7eh+RyQ2ueN6WRlDP+qgG9pg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/hardhat-errors": "^3.0.15"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^4.0.0",
+        "@nomicfoundation/hardhat-ignition": "^3.1.2",
+        "@nomicfoundation/hardhat-verify": "^3.0.0",
+        "@nomicfoundation/ignition-core": "^3.0.7",
+        "ethers": "^6.14.0",
+        "hardhat": "^3.8.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-keystore": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-keystore/-/hardhat-keystore-3.0.12.tgz",
+      "integrity": "sha512-uXySRPOOHtAg/RrwmqiQyw0QDA6Er3H6rB4su0J59mBPC/QHw9B5F9dDfF2u+FZn5LVWH6Gh58mEvJhRt0a4dQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/ciphers": "1.2.1",
+        "@noble/hashes": "1.7.1",
+        "@nomicfoundation/hardhat-errors": "^3.0.15",
+        "@nomicfoundation/hardhat-utils": "^4.1.3",
+        "@nomicfoundation/hardhat-zod-utils": "^3.0.5",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "hardhat": "^3.8.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-keystore/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-mocha": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-mocha/-/hardhat-mocha-3.0.21.tgz",
+      "integrity": "sha512-z2onvzLHEHTlSpv4+iuMjnlj7RVnaGrGXBpn3fuveE9MaTllnh/lOBGtCGbTmxjut1iL0giuPZtHuvtpbqstCg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/hardhat-errors": "^3.0.15",
+        "@nomicfoundation/hardhat-utils": "^4.1.2",
+        "@nomicfoundation/hardhat-zod-utils": "^3.0.5",
+        "tsx": "^4.19.3",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "hardhat": "^3.8.0",
+        "mocha": "^11.0.0"
+      }
+    },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-3.0.11.tgz",
@@ -3467,12 +4047,49 @@
         "hardhat": "^3.8.0"
       }
     },
-    "node_modules/@nomicfoundation/hardhat-toolbox": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-7.0.0.tgz",
-      "integrity": "sha512-pMoxUU0WWxXv5zkE6mm3JZcvLN94TCax+NVZv5TMscnfwQ42lm+qEAnNxuGNneFbo8JGbHu1B6aEzV08bhmI3w==",
+    "node_modules/@nomicfoundation/hardhat-toolbox-mocha-ethers": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox-mocha-ethers/-/hardhat-toolbox-mocha-ethers-3.0.7.tgz",
+      "integrity": "sha512-7uF3QgU+o21AZjtZdp7YIS1daHj7fD0iSFkZwZE94Nxv54j5crFCNc7YPu1W+glBKmYjFKoRUqhyC30L9rNFrQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^4.0.0",
+        "@nomicfoundation/hardhat-ethers-chai-matchers": "^3.0.0",
+        "@nomicfoundation/hardhat-ignition": "^3.0.0",
+        "@nomicfoundation/hardhat-ignition-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-keystore": "^3.0.0",
+        "@nomicfoundation/hardhat-mocha": "^3.0.0",
+        "@nomicfoundation/hardhat-network-helpers": "^3.0.0",
+        "@nomicfoundation/hardhat-typechain": "^3.0.0",
+        "@nomicfoundation/hardhat-verify": "^3.0.0",
+        "@nomicfoundation/ignition-core": "^3.0.0",
+        "chai": ">=5.1.2 <7",
+        "ethers": "^6.14.0",
+        "hardhat": "^3.8.0",
+        "mocha": "^11.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-typechain": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-typechain/-/hardhat-typechain-3.1.1.tgz",
+      "integrity": "sha512-2+G5L6RPNVpdQtr2nqNOv/qnNNo9GNmJ5V/w2ozJnApEdMxyLiEOOcVcFtZIFQ6Un2clzMph2HbkSwaIT7buEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/hardhat-errors": "^3.0.15",
+        "@nomicfoundation/hardhat-utils": "^4.1.3",
+        "@nomicfoundation/hardhat-zod-utils": "^3.0.4",
+        "@typechain/ethers-v6": "^0.5.0",
+        "typechain": "^8.3.1",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^4.0.0",
+        "ethers": "^6.14.0",
+        "hardhat": "^3.8.0"
+      }
     },
     "node_modules/@nomicfoundation/hardhat-utils": {
       "version": "4.1.6",
@@ -3497,6 +4114,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@nomicfoundation/hardhat-verify": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-3.0.21.tgz",
+      "integrity": "sha512-kaV9BfmFw5VbjMEyyQxoXVe0qwkEUi7wfi/WVTiVU0mdUUwojvk8hv0oT87vHO6FeYVGAcN/FEwmYZqBOiip6Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.8.0",
+        "@nomicfoundation/hardhat-errors": "^3.0.16",
+        "@nomicfoundation/hardhat-utils": "^4.1.4",
+        "@nomicfoundation/hardhat-zod-utils": "^3.0.5",
+        "cbor2": "^1.9.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "hardhat": "^3.8.0"
+      }
+    },
     "node_modules/@nomicfoundation/hardhat-zod-utils": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-zod-utils/-/hardhat-zod-utils-3.0.5.tgz",
@@ -3510,6 +4146,57 @@
       "peerDependencies": {
         "zod": "^3.23.8"
       }
+    },
+    "node_modules/@nomicfoundation/ignition-core": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-core/-/ignition-core-3.1.8.tgz",
+      "integrity": "sha512-HJsV8WNa3wa9g8eqNqT4ZsgEI/zNEmByHCro6yHRc+E1VbCZCalXScgZ2ZSjsZlvQdMw19sk8av1YIxRm28rRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/address": "5.6.1",
+        "@nomicfoundation/hardhat-errors": "^3.0.16",
+        "@nomicfoundation/hardhat-utils": "^4.1.4",
+        "@nomicfoundation/solidity-analyzer": "^0.1.1",
+        "cbor2": "^1.9.0",
+        "ethers": "^6.14.0",
+        "immer": "10.0.2",
+        "lodash-es": "4.17.21",
+        "ndjson": "2.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-core/node_modules/@ethersproject/address": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
+      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.2",
+        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/keccak256": "^5.6.1",
+        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/rlp": "^5.6.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ignition-ui": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ignition-ui/-/ignition-ui-3.1.2.tgz",
+      "integrity": "sha512-OoS5eQi9WBeiYI6EXurhqrpr6syRVhnaUzdx5fyK/1syKGq9BsjWWHXTNru0qk5ZFQ9f/KMTZotcDZD4eAdCpg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
       "version": "0.1.2",
@@ -4055,6 +4742,23 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@typechain/ethers-v6": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz",
+      "integrity": "sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.2",
+        "typescript": ">=4.7.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4126,6 +4830,17 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-meQ1wDr1K5KRCSvG2lX7n7/5wf70BeptTKst0axGvnN6zqaVpRqegoIbugiAPSqOW9K9aL8gDVrm7a2LXOtn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/chai": "*"
       }
     },
     "node_modules/@types/connect": {
@@ -4301,6 +5016,14 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -4955,6 +5678,14 @@
         "node": ">=0.3.0"
       }
     },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -5157,6 +5888,17 @@
       "dev": true,
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -5396,6 +6138,14 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bn.js": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -5443,6 +6193,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -5639,6 +6405,17 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cbor2": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/cbor2/-/cbor2-1.12.0.tgz",
+      "integrity": "sha512-3Cco8XQhi27DogSp9Ri6LYNZLi/TBY/JVnDe+mj06NkBjW/ZYOtekaEU4wZ4xcRMNrFkDv8KNtOAqHyDfz3lYg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.7"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5647,6 +6424,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "check-error": "^2.1.1"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 7"
       }
     },
     "node_modules/chalk": {
@@ -5682,6 +6473,17 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -5887,6 +6689,147 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/commander": {
@@ -6193,6 +7136,20 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -6211,6 +7168,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-equal": {
@@ -6243,6 +7211,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -6467,6 +7446,31 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -7003,6 +8007,91 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ethers": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.11.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.21.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/eventemitter2": {
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
@@ -7291,6 +8380,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -7306,6 +8409,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -7854,6 +8968,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -7864,6 +8990,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -7986,6 +9136,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -8288,6 +9450,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -9970,6 +11154,14 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10084,6 +11276,14 @@
       "engines": {
         "node": ">=7.10.1"
       }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -10228,6 +11428,22 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -10551,6 +11767,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -10592,6 +11824,149 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/ms": {
@@ -10677,6 +12052,38 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ndjson": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
+      "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.5",
+        "readable-stream": "^3.6.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "ndjson": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ndjson/node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -11617,6 +13024,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -11918,6 +13336,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/serve-static": {
@@ -12274,6 +13703,14 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
+      "dev": true,
+      "license": "WTFPL OR MIT",
+      "peer": true
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -12521,6 +13958,45 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
@@ -12763,6 +14239,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -12907,6 +14394,34 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-command-line-args": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
+      "integrity": "sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.0",
+        "string-format": "^2.0.0"
+      },
+      "bin": {
+        "write-markdown": "dist/write-markdown.js"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": ">=3.7.0"
       }
     },
     "node_modules/ts-jest": {
@@ -13162,6 +14677,124 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typechain": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.3.2.tgz",
+      "integrity": "sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prettier": "^2.1.1",
+        "debug": "^4.3.1",
+        "fs-extra": "^7.0.0",
+        "glob": "7.1.7",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^1.0.4",
+        "prettier": "^2.3.1",
+        "ts-command-line-args": "^2.2.0",
+        "ts-essentials": "^7.0.1"
+      },
+      "bin": {
+        "typechain": "dist/cli/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.3.0"
+      }
+    },
+    "node_modules/typechain/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/typechain/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typechain/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/typechain/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typechain/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/typechain/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -13412,6 +15045,17 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/uglify-js": {
@@ -13969,6 +15613,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -14009,10 +15687,11 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14094,6 +15773,37 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "type": "module",
   "scripts": {
     "build": "nest build --path apps/api/tsconfig.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
@@ -51,7 +52,7 @@
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
     "@nomicfoundation/hardhat-network-helpers": "^3.0.11",
-    "@nomicfoundation/hardhat-toolbox": "^7.0.0",
+    "@nomicfoundation/hardhat-toolbox-mocha-ethers": "^3.0.7",
     "@openzeppelin/contracts": "^5.6.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",

--- a/test/router/BatchBridgeRouter.test.ts
+++ b/test/router/BatchBridgeRouter.test.ts
@@ -1,0 +1,121 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("BatchBridgeRouter", () => {
+  let ethers: any;
+  let RECIPIENT_A: string;
+  let RECIPIENT_B: string;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+    RECIPIENT_A = ethers.zeroPadValue("0xaaaa", 32);
+    RECIPIENT_B = ethers.zeroPadValue("0xbbbb", 32);
+  });
+
+  const DEST_CHAIN_A = 1;
+  const DEST_CHAIN_B = 2;
+
+  async function deploy() {
+    const [owner, user] = await ethers.getSigners();
+
+    const VaultFactory = await ethers.getContractFactory("MockBridgeVault");
+    const vault = await VaultFactory.deploy();
+    await vault.waitForDeployment();
+
+    const RouterFactory = await ethers.getContractFactory("BatchBridgeRouter");
+    const router = await RouterFactory.deploy(await vault.getAddress());
+    await router.waitForDeployment();
+
+    const TokenFactory = await ethers.getContractFactory("MockERC20");
+    const tokenA = await TokenFactory.deploy("Token A", "TKA");
+    await tokenA.waitForDeployment();
+    const tokenB = await TokenFactory.deploy("Token B", "TKB");
+    await tokenB.waitForDeployment();
+
+    return { router, vault, tokenA, tokenB, owner, user };
+  }
+
+  it("processes multi-asset deposits atomically", async () => {
+    const { router, vault, tokenA, tokenB, user } = await deploy();
+
+    const amountA = ethers.parseEther("1.5");
+    const amountB = ethers.parseEther("2.5");
+
+    await tokenA.mint(user.address, amountA);
+    await tokenB.mint(user.address, amountB);
+    await tokenA.connect(user).approve(await router.getAddress(), amountA);
+    await tokenB.connect(user).approve(await router.getAddress(), amountB);
+
+    const tokenAAddr = await tokenA.getAddress();
+    const tokenBAddr = await tokenB.getAddress();
+    const expectedPayload = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address[]", "uint256[]", "uint32[]", "bytes32[]"],
+      [
+        [tokenAAddr, tokenBAddr],
+        [amountA, amountB],
+        [DEST_CHAIN_A, DEST_CHAIN_B],
+        [RECIPIENT_A, RECIPIENT_B],
+      ]
+    );
+
+    await expect(
+      router.connect(user).batchDeposit(
+        [tokenAAddr, tokenBAddr],
+        [amountA, amountB],
+        [DEST_CHAIN_A, DEST_CHAIN_B],
+        [RECIPIENT_A, RECIPIENT_B]
+      )
+    )
+      .to.emit(router, "BatchBridgeDispatched")
+      .withArgs(user.address, 2n, amountA + amountB, expectedPayload);
+
+    expect(await vault.recordCount()).to.equal(2n);
+    expect(await tokenA.balanceOf(await vault.getAddress())).to.equal(amountA);
+    expect(await tokenB.balanceOf(await vault.getAddress())).to.equal(amountB);
+  });
+
+  it("reverts the entire batch when any transfer fails", async () => {
+    const { router, vault, tokenA, tokenB, user } = await deploy();
+
+    const amountA = ethers.parseEther("1");
+    const amountB = ethers.parseEther("1");
+
+    await tokenA.mint(user.address, amountA);
+    await tokenB.mint(user.address, amountB);
+    await tokenA.connect(user).approve(await router.getAddress(), amountA);
+    // Do not approve tokenB.
+
+    await expect(
+      router.connect(user).batchDeposit(
+        [await tokenA.getAddress(), await tokenB.getAddress()],
+        [amountA, amountB],
+        [DEST_CHAIN_A, DEST_CHAIN_B],
+        [RECIPIENT_A, RECIPIENT_B]
+      )
+    ).to.revert(ethers);
+
+    expect(await vault.recordCount()).to.equal(0n);
+  });
+
+  it("reverts on array length mismatch", async () => {
+    const { router, tokenA, user } = await deploy();
+
+    await expect(
+      router.connect(user).batchDeposit(
+        [await tokenA.getAddress()],
+        [ethers.parseEther("1"), ethers.parseEther("1")],
+        [DEST_CHAIN_A],
+        [RECIPIENT_A]
+      )
+    ).to.be.revertedWithCustomError(router, "LengthMismatch");
+  });
+
+  it("reverts on empty batch", async () => {
+    const { router, user } = await deploy();
+
+    await expect(
+      router.connect(user).batchDeposit([], [], [], [])
+    ).to.be.revertedWithCustomError(router, "EmptyBatch");
+  });
+});

--- a/test/router/MockBridgeVault.sol
+++ b/test/router/MockBridgeVault.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title MockBridgeVault
+/// @notice Test double that records lock calls and tracks token balances.
+contract MockBridgeVault {
+    struct LockRecord {
+        uint32 destinationChainId;
+        address token;
+        uint256 amount;
+        bytes32 recipient;
+    }
+
+    LockRecord[] public records;
+
+    function lock(
+        uint32 destinationChainId,
+        address token,
+        uint256 amount,
+        bytes32 recipient
+    ) external {
+        records.push(LockRecord(destinationChainId, token, amount, recipient));
+    }
+
+    function recordCount() external view returns (uint256) {
+        return records.length;
+    }
+}

--- a/test/security/FlashLoanGuard.test.ts
+++ b/test/security/FlashLoanGuard.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("FlashLoanGuard", () => {
+  let ethers: any;
+  let networkHelpers: any;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+    networkHelpers = connection.networkHelpers;
+  });
+
+  async function deploy() {
+    const [owner, user, router] = await ethers.getSigners();
+    const Guard = await ethers.getContractFactory("FlashLoanGuardHarness");
+    const guard = await Guard.deploy();
+    await guard.waitForDeployment();
+    return { guard, owner, user, router };
+  }
+
+  it("records a deposit block", async () => {
+    const { guard, user } = await deploy();
+
+    const blockBefore = await ethers.provider.getBlockNumber();
+    await expect(guard.connect(user).recordDeposit())
+      .to.emit(guard, "DepositRecorded")
+      .withArgs(user.address, blockBefore + 1);
+  });
+
+  it("reverts dispatch when deposit happened in the same block", async () => {
+    const { guard, user } = await deploy();
+
+    await expect(
+      guard.connect(user).recordDepositAndDispatch()
+    ).to.be.revertedWithCustomError(guard, "SameBlockFlashLoan").withArgs(user.address);
+  });
+
+  it("allows dispatch after advancing one block", async () => {
+    const { guard, user } = await deploy();
+
+    await guard.connect(user).recordDeposit();
+    await networkHelpers.mine();
+
+    await expect(guard.connect(user).guardedDispatch())
+      .to.emit(guard, "Dispatched")
+      .withArgs(user.address);
+  });
+
+  it("bypasses guard for authorized router addresses", async () => {
+    const { guard, router } = await deploy();
+
+    await guard.setBypass(router.address, true);
+    expect(await guard.isBypassAuthorized(router.address)).to.equal(true);
+
+    await guard.connect(router).recordDeposit();
+    await expect(guard.connect(router).guardedDispatch())
+      .to.emit(guard, "Dispatched")
+      .withArgs(router.address);
+  });
+
+  it("revokes bypass authorization", async () => {
+    const { guard, router } = await deploy();
+
+    await guard.setBypass(router.address, true);
+    await guard.setBypass(router.address, false);
+    expect(await guard.isBypassAuthorized(router.address)).to.equal(false);
+
+    await expect(guard.connect(router).recordDepositAndDispatch())
+      .to.be.revertedWithCustomError(guard, "SameBlockFlashLoan")
+      .withArgs(router.address);
+  });
+});

--- a/test/security/FlashLoanGuardHarness.sol
+++ b/test/security/FlashLoanGuardHarness.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {FlashLoanGuard} from "../../contracts/security/FlashLoanGuard.sol";
+
+/// @title FlashLoanGuardHarness
+/// @notice Concrete harness exposing the internal FlashLoanGuard helpers for
+///         unit testing.
+contract FlashLoanGuardHarness is FlashLoanGuard {
+    event Dispatched(address indexed sender);
+
+    /// @notice Records a deposit for `msg.sender`.
+    function recordDeposit() external {
+        _recordDeposit();
+    }
+
+    /// @notice Simulates a cross-chain dispatch action protected by the guard.
+    function guardedDispatch() external noSameBlockFlashLoan {
+        emit Dispatched(msg.sender);
+    }
+
+    /// @notice Records a deposit and immediately dispatches in the same
+    ///         transaction to test same-block flash-loan detection.
+    function recordDepositAndDispatch() external {
+        _recordDeposit();
+        _checkFlashLoanGuard();
+        emit Dispatched(msg.sender);
+    }
+
+    /// @notice Authorize or revoke bypass for `account`.
+    function setBypass(address account, bool authorized) external {
+        _setBypass(account, authorized);
+    }
+}

--- a/test/vault/MockReserveVault.sol
+++ b/test/vault/MockReserveVault.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title MockReserveVault
+/// @notice Test double allowing manual configuration of per-token locked reserves.
+contract MockReserveVault {
+    mapping(address => uint256) public lockedReserves;
+
+    function setLockedReserves(address token, uint256 amount) external {
+        lockedReserves[token] = amount;
+    }
+}

--- a/test/vault/VaultHealthEvaluator.test.ts
+++ b/test/vault/VaultHealthEvaluator.test.ts
@@ -1,0 +1,88 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("VaultHealthEvaluator", () => {
+  let ethers: any;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+  });
+
+  async function deploy() {
+    const [admin, vaultAddr] = await ethers.getSigners();
+
+    const Evaluator = await ethers.getContractFactory("VaultHealthEvaluator");
+    const evaluator = await Evaluator.deploy();
+    await evaluator.waitForDeployment();
+
+    const ReserveVault = await ethers.getContractFactory("MockReserveVault");
+    const reserveVault = await ReserveVault.deploy();
+    await reserveVault.waitForDeployment();
+
+    const Token = await ethers.getContractFactory("BridgeWrappedToken");
+    const token = await Token.deploy("Bridged USDC", "bwUSDC", vaultAddr.address, admin.address);
+    await token.waitForDeployment();
+
+    return { evaluator, reserveVault, token, admin, vaultAddr };
+  }
+
+  it("returns SOLVENT when reserves equal or exceed minted supply", async () => {
+    const { evaluator, reserveVault, token, vaultAddr } = await deploy();
+
+    await token.connect(vaultAddr).mint(ethers.getAddress(ethers.hexlify(ethers.randomBytes(20))), ethers.parseEther("1"));
+    await reserveVault.setLockedReserves(await token.getAddress(), ethers.parseEther("1.2"));
+
+    const [ratio, status] = await evaluator.evaluate(
+      await reserveVault.getAddress(),
+      await token.getAddress()
+    );
+
+    expect(ratio).to.equal(12_000n); // 120% in bps
+    expect(status).to.equal(0); // SOLVENT
+  });
+
+  it("returns UNDERCOLLATERALIZED when ratio is between 80% and 100%", async () => {
+    const { evaluator, reserveVault, token, vaultAddr } = await deploy();
+
+    await token.connect(vaultAddr).mint(ethers.getAddress(ethers.hexlify(ethers.randomBytes(20))), ethers.parseEther("1"));
+    await reserveVault.setLockedReserves(await token.getAddress(), ethers.parseEther("0.9"));
+
+    const [ratio, status] = await evaluator.evaluate(
+      await reserveVault.getAddress(),
+      await token.getAddress()
+    );
+
+    expect(ratio).to.equal(9_000n); // 90% in bps
+    expect(status).to.equal(1); // UNDERCOLLATERALIZED
+  });
+
+  it("returns CRITICAL when ratio is below 80%", async () => {
+    const { evaluator, reserveVault, token, vaultAddr } = await deploy();
+
+    await token.connect(vaultAddr).mint(ethers.getAddress(ethers.hexlify(ethers.randomBytes(20))), ethers.parseEther("1"));
+    await reserveVault.setLockedReserves(await token.getAddress(), ethers.parseEther("0.5"));
+
+    const [ratio, status] = await evaluator.evaluate(
+      await reserveVault.getAddress(),
+      await token.getAddress()
+    );
+
+    expect(ratio).to.equal(5_000n); // 50% in bps
+    expect(status).to.equal(2); // CRITICAL
+  });
+
+  it("returns zero ratio and SOLVENT when no wrapped tokens are minted", async () => {
+    const { evaluator, reserveVault, token } = await deploy();
+
+    await reserveVault.setLockedReserves(await token.getAddress(), ethers.parseEther("100"));
+
+    const [ratio, status] = await evaluator.evaluate(
+      await reserveVault.getAddress(),
+      await token.getAddress()
+    );
+
+    expect(ratio).to.equal(0n);
+    expect(status).to.equal(0); // SOLVENT
+  });
+});


### PR DESCRIPTION
Closes #792, closes #793, closes #794, closes #795

## Summary
Implements four contract-level features across Soroban and EVM modules.

## Changes
- #792 – Add Soroban TTL auto-bump helpers for instance and persistent storage.
- #793 – Add `FlashLoanGuard` to block same-block deposit-and-dispatch arbitrage with optional router bypass.
- #794 – Add `VaultHealthEvaluator` on-chain solvency ratio calculator.
- #795 – Add `BatchBridgeRouter` for atomic multi-asset bridge deposits.

## Testing
- New Hardhat 3 tests: `test/security/FlashLoanGuard.test.ts`, `test/vault/VaultHealthEvaluator.test.ts`, `test/router/BatchBridgeRouter.test.ts`
- All 13 new tests pass.
- `cargo check` passes for `contracts/soroban/common`.