### PR TITLE
Feat/b002 validator zero check

### DIFF
--- a/contracts/execution/GasEscrow.sol
+++ b/contracts/execution/GasEscrow.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {SafeNativeTransfer} from "../utils/SafeNativeTransfer.sol";
+
 /// @title GasEscrow
 /// @notice Destination execution gas escrow module holding gas stipends and refunding unused gas.
 contract GasEscrow {
@@ -35,8 +37,7 @@ contract GasEscrow {
         if (msg.value > executionCost) {
             refundAmount = msg.value - executionCost;
             if (refundAmount > 0 && refundAddress != address(0)) {
-                (bool refundSuccess, ) = refundAddress.call{value: refundAmount}("");
-                require(refundSuccess, "Refund transfer failed");
+                SafeNativeTransfer.safeTransferNative(refundAddress, refundAmount);
             }
         } else {
             refundAmount = 0;

--- a/contracts/utils/SafeNativeTransfer.sol
+++ b/contracts/utils/SafeNativeTransfer.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title SafeNativeTransfer
+/// @notice Gas-optimised native-asset transfer helper for bridge unlock / refund paths.
+/// @dev Replaces the naked `to.call{value: amount}("")` pattern.
+///
+///      The high-level form allocates an empty `bytes` argument in memory, and — when the
+///      return data is captured in order to bubble a reason string — copies the entire
+///      callee revert payload into dynamic memory before the transaction unwinds. A
+///      malicious or merely verbose recipient therefore controls how much gas a *failed*
+///      claim burns.
+///
+///      This helper forwards all gas but pins both the argument and return-data windows to
+///      zero length, so nothing is ever copied back, and signals failure with the 4-byte
+///      {NativeTransferFailed} selector.
+library SafeNativeTransfer {
+    /// @notice The native-asset transfer reverted or the recipient rejected it.
+    /// @dev Selector `0xf4b3b1bc` — mirrored as a literal in the assembly block below.
+    error NativeTransferFailed();
+
+    /// @notice Sends `amount` wei to `to`, forwarding all remaining gas.
+    /// @dev Reverts with {NativeTransferFailed} if the call does not succeed. The recipient
+    ///      is still free to consume the forwarded gas, so callers that need re-entrancy
+    ///      protection must apply it themselves — this helper only bounds the *return* path.
+    /// @param to Recipient of the native asset.
+    /// @param amount Amount in wei. A zero amount is a no-op call, not a revert.
+    function safeTransferNative(address to, uint256 amount) internal {
+        assembly ("memory-safe") {
+            // call(gas, addr, value, argsOffset, argsSize, retOffset, retSize)
+            //
+            // `codesize()` is used for both memory offsets: it is guaranteed non-zero and,
+            // paired with a zero length, it neither triggers memory expansion nor copies
+            // any return data. No memory is touched on either the success or failure path.
+            if iszero(call(gas(), to, amount, codesize(), 0x00, codesize(), 0x00)) {
+                // `NativeTransferFailed()`
+                mstore(0x00, 0xf4b3b1bc)
+                // Revert with the 4 low-order bytes of the scratch word.
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+}

--- a/rules/b002_validator_zero_check.rs
+++ b/rules/b002_validator_zero_check.rs
@@ -1,0 +1,710 @@
+//! Rule **B002** — Unchecked validator address assignment.
+//!
+//! # What it detects
+//!
+//! Functions that mutate a validator set / multi-sig signer set (either by name
+//! — `addValidator`, `rotateSigner`, `setGuardians`, … — or by writing to a
+//! validator-shaped state slot) while accepting an `address` (or `address[]`)
+//! parameter that is never asserted to be non-zero.
+//!
+//! # Why it matters
+//!
+//! `ecrecover` returns `address(0)` for malformed signatures (`v = 0`, or an
+//! `s` value outside the lower half-order). If `address(0)` is registered as an
+//! active validator, an attacker can satisfy one slot of the signature
+//! threshold with an all-zero signature, effectively lowering the quorum by one
+//! for every zero entry present in the set.
+//!
+//! # Remediation
+//!
+//! ```solidity
+//! require(validator != address(0), "B002: zero validator");
+//! // or
+//! if (validator == address(0)) revert ZeroValidator();
+//! ```
+//!
+//! # Accepted proof-of-check forms
+//!
+//! * `require(v != address(0), ...)` / `assert(v != address(0))`
+//! * `if (v == address(0)) revert ...;`
+//! * a guarding modifier whose name mentions zero/valid-address, e.g.
+//!   `nonZeroAddress(v)`
+//! * an internal helper call such as `_requireNonZeroAddress(v)`
+//! * per-element checks for array inputs, including through a local alias
+//!   (`address candidate = validators[i]; require(candidate != address(0));`)
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Stable identifier for this rule.
+pub const RULE_ID: &str = "B002";
+/// Human readable slug used by the report renderer.
+pub const RULE_NAME: &str = "unchecked-validator-zero-address";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+/// A single B002 violation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    pub rule_id: &'static str,
+    pub rule_name: &'static str,
+    pub file: String,
+    /// 1-based line of the `function` keyword.
+    pub line: usize,
+    pub function: String,
+    /// Address parameters that reach the validator write without a zero check.
+    pub unchecked_params: Vec<String>,
+    pub severity: Severity,
+    pub message: String,
+}
+
+/// Run rule B002 over a single Solidity source unit.
+pub fn analyze(source: &str, file_path: &str) -> Vec<Finding> {
+    let clean: Vec<char> = strip_noise(source).chars().collect();
+    let mut findings = Vec::new();
+
+    for func in parse_functions(&clean) {
+        let body = compact(&func.body);
+        let header = compact(&func.header);
+
+        if !mutates_validator_set(&func.name, &body) {
+            continue;
+        }
+
+        let unchecked: Vec<String> = func
+            .params
+            .iter()
+            .filter(|p| !has_zero_check(p, &header, &body))
+            .map(|p| p.name.clone())
+            .collect();
+
+        if unchecked.is_empty() {
+            continue;
+        }
+
+        findings.push(Finding {
+            rule_id: RULE_ID,
+            rule_name: RULE_NAME,
+            file: file_path.to_string(),
+            line: func.line,
+            function: func.name.clone(),
+            message: format!(
+                "`{}` updates the validator/signer set using address input(s) `{}` \
+                 without an explicit `address(0)` assertion. A zero entry silently \
+                 lowers the signature threshold because `ecrecover` yields \
+                 `address(0)` for invalid signatures.",
+                func.name,
+                unchecked.join("`, `")
+            ),
+            unchecked_params: unchecked,
+            severity: Severity::High,
+        });
+    }
+
+    findings
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight Solidity function extraction
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Param {
+    name: String,
+    /// `address[]` inputs are checked element-wise.
+    is_array: bool,
+}
+
+#[derive(Debug, Clone)]
+struct FunctionNode {
+    name: String,
+    /// Only `address` / `address[]` parameters are retained.
+    params: Vec<Param>,
+    /// Text between the parameter list and the body (visibility, modifiers…).
+    header: String,
+    body: String,
+    line: usize,
+}
+
+fn is_ident_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+/// Blanks out comments and string/char literals so their contents can never be
+/// mistaken for code, while preserving line breaks for accurate line numbers.
+fn strip_noise(src: &str) -> String {
+    let chars: Vec<char> = src.chars().collect();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+        let next = chars.get(i + 1).copied().unwrap_or('\0');
+
+        if c == '/' && next == '/' {
+            while i < chars.len() && chars[i] != '\n' {
+                out.push(' ');
+                i += 1;
+            }
+        } else if c == '/' && next == '*' {
+            out.push_str("  ");
+            i += 2;
+            while i < chars.len() && !(chars[i] == '*' && chars.get(i + 1) == Some(&'/')) {
+                out.push(if chars[i] == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+            if i < chars.len() {
+                out.push_str("  ");
+                i += 2;
+            }
+        } else if c == '"' || c == '\'' {
+            let quote = c;
+            out.push(' ');
+            i += 1;
+            while i < chars.len() && chars[i] != quote {
+                if chars[i] == '\\' {
+                    out.push(' ');
+                    i += 1;
+                    if i < chars.len() {
+                        out.push(' ');
+                        i += 1;
+                    }
+                    continue;
+                }
+                out.push(if chars[i] == '\n' { '\n' } else { ' ' });
+                i += 1;
+            }
+            if i < chars.len() {
+                out.push(' ');
+                i += 1;
+            }
+        } else {
+            out.push(c);
+            i += 1;
+        }
+    }
+
+    out
+}
+
+/// Index of the delimiter closing the one at `open_idx`.
+fn matching(chars: &[char], open_idx: usize, open: char, close: char) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut i = open_idx;
+    while i < chars.len() {
+        if chars[i] == open {
+            depth += 1;
+        } else if chars[i] == close {
+            if depth == 0 {
+                return None;
+            }
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn skip_ws(chars: &[char], mut i: usize) -> usize {
+    while i < chars.len() && chars[i].is_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+fn word_at(chars: &[char], i: usize, word: &str) -> bool {
+    let w: Vec<char> = word.chars().collect();
+    if i + w.len() > chars.len() || chars[i..i + w.len()] != w[..] {
+        return false;
+    }
+    let before_ok = i == 0 || !is_ident_char(chars[i - 1]);
+    let after_ok = i + w.len() >= chars.len() || !is_ident_char(chars[i + w.len()]);
+    before_ok && after_ok
+}
+
+fn parse_functions(clean: &[char]) -> Vec<FunctionNode> {
+    let mut out = Vec::new();
+    let mut i = 0;
+
+    while i < clean.len() {
+        if !word_at(clean, i, "function") {
+            i += 1;
+            continue;
+        }
+        let kw_start = i;
+
+        let mut j = skip_ws(clean, i + "function".len());
+        let name_start = j;
+        while j < clean.len() && is_ident_char(clean[j]) {
+            j += 1;
+        }
+        let name: String = clean[name_start..j].iter().collect();
+        j = skip_ws(clean, j);
+
+        if name.is_empty() || j >= clean.len() || clean[j] != '(' {
+            i = kw_start + 1;
+            continue;
+        }
+
+        let params_close = match matching(clean, j, '(', ')') {
+            Some(k) => k,
+            None => break,
+        };
+        let params_txt: String = clean[j + 1..params_close].iter().collect();
+
+        // Walk the header (visibility / mutability / modifiers / returns) until
+        // the body opens, bailing out on `;` for interface & abstract stubs.
+        let header_start = params_close + 1;
+        let mut k = header_start;
+        let mut depth = 0i32;
+        let mut body_open = None;
+        while k < clean.len() {
+            match clean[k] {
+                '(' => depth += 1,
+                ')' => depth -= 1,
+                '{' if depth == 0 => {
+                    body_open = Some(k);
+                    break;
+                }
+                ';' if depth == 0 => break,
+                _ => {}
+            }
+            k += 1;
+        }
+
+        let body_open = match body_open {
+            Some(b) => b,
+            None => {
+                i = params_close + 1;
+                continue;
+            }
+        };
+        let body_close = match matching(clean, body_open, '{', '}') {
+            Some(c) => c,
+            None => break,
+        };
+
+        let params = parse_address_params(&params_txt);
+        if !params.is_empty() {
+            out.push(FunctionNode {
+                name,
+                params,
+                header: clean[header_start..body_open].iter().collect(),
+                body: clean[body_open + 1..body_close].iter().collect(),
+                line: clean[..kw_start].iter().filter(|c| **c == '\n').count() + 1,
+            });
+        }
+
+        i = body_close + 1;
+    }
+
+    out
+}
+
+/// Splits a parameter list on top-level commas and keeps only address inputs.
+fn parse_address_params(text: &str) -> Vec<Param> {
+    let mut params = Vec::new();
+    let mut depth = 0i32;
+    let mut current = String::new();
+
+    let push_current = |raw: &str, params: &mut Vec<Param>| {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return;
+        }
+        let tokens: Vec<&str> = raw.split_whitespace().collect();
+        let ty = tokens[0];
+        if !ty.starts_with("address") {
+            return;
+        }
+        let name = match tokens.last() {
+            // `function f(address)` — unnamed, nothing to reason about.
+            Some(n) if tokens.len() > 1 => n.trim_matches(|c: char| !is_ident_char(c)),
+            _ => return,
+        };
+        if name.is_empty() {
+            return;
+        }
+        params.push(Param {
+            name: name.to_string(),
+            is_array: raw.contains('['),
+        });
+    };
+
+    for c in text.chars() {
+        match c {
+            '(' | '[' => {
+                depth += 1;
+                current.push(c);
+            }
+            ')' | ']' => {
+                depth -= 1;
+                current.push(c);
+            }
+            ',' if depth == 0 => {
+                push_current(&current, &mut params);
+                current.clear();
+            }
+            _ => current.push(c),
+        }
+    }
+    push_current(&current, &mut params);
+
+    params
+}
+
+// ---------------------------------------------------------------------------
+// Heuristics
+// ---------------------------------------------------------------------------
+
+/// Identifier fragments that mark a validator / multi-sig membership slot.
+const VALIDATOR_HINTS: &[&str] = &[
+    "validator",
+    "signer",
+    "guardian",
+    "attestor",
+    "attester",
+    "multisig",
+    "quorum",
+    "committee",
+    "relayer",
+];
+
+/// True when the function is a validator-set / signer-set mutation routine,
+/// either by naming convention or by writing to a validator-shaped slot.
+fn mutates_validator_set(name: &str, compact_body: &str) -> bool {
+    let lower_name = name.to_ascii_lowercase();
+    if VALIDATOR_HINTS.iter().any(|h| lower_name.contains(h)) {
+        return true;
+    }
+
+    let chars: Vec<char> = compact_body.to_ascii_lowercase().chars().collect();
+
+    for hint in VALIDATOR_HINTS {
+        let mut from = 0;
+        while let Some(start) = find_from(&chars, hint, from) {
+            // Expand to the full identifier containing the hint.
+            let mut end = start + hint.len();
+            while end < chars.len() && is_ident_char(chars[end]) {
+                end += 1;
+            }
+            from = start + hint.len();
+
+            // `validators[x] = ...`
+            let after = if end < chars.len() && chars[end] == '[' {
+                match matching(&chars, end, '[', ']') {
+                    Some(close) => close + 1,
+                    None => continue,
+                }
+            } else {
+                end
+            };
+
+            if after >= chars.len() {
+                continue;
+            }
+            let tail: String = chars[after..].iter().collect();
+            let is_write = (tail.starts_with('=') && !tail.starts_with("=="))
+                || tail.starts_with(".push(")
+                || tail.starts_with(".pop(")
+                || tail.starts_with(".add(")
+                || tail.starts_with(".remove(")
+                || tail.starts_with(".set(");
+            if is_write {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn compact(s: &str) -> String {
+    s.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+/// Char-index substring search (byte offsets are unsafe for slicing here).
+fn find_from(chars: &[char], needle: &str, from: usize) -> Option<usize> {
+    let n: Vec<char> = needle.chars().collect();
+    if n.is_empty() || n.len() > chars.len() {
+        return None;
+    }
+    (from..=chars.len() - n.len()).find(|&i| chars[i..i + n.len()] == n[..])
+}
+
+fn mentions_zero_address(s: &str) -> bool {
+    let l = s.to_ascii_lowercase();
+    l.contains("address(0)")
+        || l.contains("address(0x0)")
+        || l.contains("address(uint160(0))")
+        || l.contains("0x0000000000000000000000000000000000000000")
+}
+
+/// Whole-identifier occurrence test over whitespace-stripped source.
+fn references(haystack: &str, name: &str) -> bool {
+    let h: Vec<char> = haystack.chars().collect();
+    let n: Vec<char> = name.chars().collect();
+    if n.is_empty() || n.len() > h.len() {
+        return false;
+    }
+    (0..=h.len() - n.len()).any(|i| word_at(&h, i, name))
+}
+
+struct Guard {
+    /// Condition text, whitespace-stripped.
+    cond: String,
+    /// Whether the guard aborts on failure (`require`/`assert`, or an `if`
+    /// whose branch reverts).
+    aborts: bool,
+}
+
+/// Extracts `require(...)`, `assert(...)` and `if (...)` guards from a body.
+fn guards(compact_body: &str) -> Vec<Guard> {
+    let chars: Vec<char> = compact_body.chars().collect();
+    let mut out = Vec::new();
+
+    for (kw, is_if) in [("require", false), ("assert", false), ("if", true)] {
+        let mut i = 0;
+        while i < chars.len() {
+            if !word_at(&chars, i, kw) {
+                i += 1;
+                continue;
+            }
+            let open = i + kw.len();
+            if open >= chars.len() || chars[open] != '(' {
+                i += 1;
+                continue;
+            }
+            let close = match matching(&chars, open, '(', ')') {
+                Some(c) => c,
+                None => break,
+            };
+
+            let aborts = if is_if {
+                let tail_end = (close + 200).min(chars.len());
+                let tail: String = chars[close + 1..tail_end].iter().collect();
+                let tail = tail.to_ascii_lowercase();
+                tail.contains("revert") || tail.contains("require(") || tail.contains("throw")
+            } else {
+                true
+            };
+
+            out.push(Guard {
+                cond: chars[open + 1..close].iter().collect(),
+                aborts,
+            });
+            i = close + 1;
+        }
+    }
+
+    out
+}
+
+/// Locals initialised from `param`, e.g. `address candidate = validators[i];`.
+fn aliases_of(compact_body: &str, param: &str) -> Vec<String> {
+    let chars: Vec<char> = compact_body.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if !word_at(&chars, i, "address") {
+            i += 1;
+            continue;
+        }
+        let mut j = i + "address".len();
+        let name_start = j;
+        while j < chars.len() && is_ident_char(chars[j]) {
+            j += 1;
+        }
+        if j == name_start || j >= chars.len() || chars[j] != '=' {
+            i += 1;
+            continue;
+        }
+        let mut k = j + 1;
+        while k < chars.len() && chars[k] != ';' {
+            k += 1;
+        }
+        let expr: String = chars[j + 1..k.min(chars.len())].iter().collect();
+        if references(&expr, param) {
+            out.push(chars[name_start..j].iter().collect());
+        }
+        i = k;
+    }
+
+    out
+}
+
+/// `_requireNonZeroAddress(v)` / `nonZeroAddress(v)` style checks — an
+/// identifier mentioning "zero"/"validaddress" applied directly to `name`.
+fn has_zero_helper_call(compact_text: &str, name: &str) -> bool {
+    let chars: Vec<char> = compact_text.chars().collect();
+    let needle: Vec<char> = format!("({})", name).chars().collect();
+    if needle.len() > chars.len() {
+        return false;
+    }
+
+    for i in 0..=chars.len() - needle.len() {
+        if chars[i..i + needle.len()] != needle[..] {
+            continue;
+        }
+        let mut start = i;
+        while start > 0 && is_ident_char(chars[start - 1]) {
+            start -= 1;
+        }
+        let callee: String = chars[start..i].iter().collect::<String>().to_ascii_lowercase();
+        if callee.contains("zero") || callee.contains("validaddress") {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// True when `param` is provably asserted non-zero before use.
+fn has_zero_check(param: &Param, compact_header: &str, compact_body: &str) -> bool {
+    let mut names = vec![param.name.clone()];
+    if param.is_array {
+        // `address candidate = validators[i]; require(candidate != address(0));`
+        names.extend(aliases_of(compact_body, &param.name));
+    }
+
+    for name in &names {
+        // Guarding modifier on the signature, e.g. `nonZeroAddress(validator)`.
+        if has_zero_helper_call(compact_header, name) {
+            return true;
+        }
+        // Internal helper inside the body.
+        if has_zero_helper_call(compact_body, name) {
+            return true;
+        }
+    }
+
+    guards(compact_body).into_iter().any(|g| {
+        g.aborts && mentions_zero_address(&g.cond) && names.iter().any(|n| references(&g.cond, n))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLES: &str = include_str!("../test/fixtures/b002_samples.sol");
+
+    fn flagged(src: &str) -> Vec<String> {
+        analyze(src, "b002_samples.sol")
+            .into_iter()
+            .map(|f| f.function)
+            .collect()
+    }
+
+    #[test]
+    fn flags_validator_updates_missing_zero_assertions() {
+        let names = flagged(SAMPLES);
+        for expected in [
+            "addValidator",
+            "setValidators",
+            "rotateSigner",
+            "addValidatorWithWeight",
+            "_setValidator",
+        ] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "expected B002 to flag `{expected}`; flagged: {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn passes_on_functions_with_valid_input_assertions() {
+        let names = flagged(SAMPLES);
+        for safe in [
+            "addValidatorGuarded",
+            "setValidatorsGuarded",
+            "replaceSignerGuarded",
+            "registerGuardian",
+            "addSignerBatch",
+            "setFeeRecipient",
+        ] {
+            assert!(
+                !names.iter().any(|n| n == safe),
+                "B002 false positive on `{safe}`; flagged: {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reports_every_unchecked_parameter() {
+        let finding = analyze(SAMPLES, "b002_samples.sol")
+            .into_iter()
+            .find(|f| f.function == "rotateSigner")
+            .expect("rotateSigner should be flagged");
+        assert_eq!(finding.unchecked_params, vec!["oldSigner", "newSigner"]);
+        assert_eq!(finding.severity, Severity::High);
+        assert_eq!(finding.rule_id, "B002");
+    }
+
+    #[test]
+    fn ignores_non_validator_routines() {
+        let src = r#"
+            contract C {
+                address public treasury;
+                function setTreasury(address t) external { treasury = t; }
+            }
+        "#;
+        assert!(flagged(src).is_empty());
+    }
+
+    #[test]
+    fn detects_validator_write_without_naming_hint_in_function() {
+        let src = r#"
+            contract C {
+                mapping(address => bool) public isValidator;
+                function grant(address account) external { isValidator[account] = true; }
+            }
+        "#;
+        assert_eq!(flagged(src), vec!["grant".to_string()]);
+    }
+
+    #[test]
+    fn accepts_custom_error_revert_guard() {
+        let src = r#"
+            contract C {
+                error ZeroValidator();
+                mapping(address => bool) public isValidator;
+                function addValidator(address v) external {
+                    if (v == address(0)) revert ZeroValidator();
+                    isValidator[v] = true;
+                }
+            }
+        "#;
+        assert!(flagged(src).is_empty());
+    }
+
+    #[test]
+    fn comment_claiming_a_check_is_not_a_check() {
+        let src = r#"
+            contract C {
+                mapping(address => bool) public isValidator;
+                function addValidator(address v) external {
+                    // require(v != address(0), "zero");
+                    isValidator[v] = true;
+                }
+            }
+        "#;
+        assert_eq!(flagged(src), vec!["addValidator".to_string()]);
+    }
+}

--- a/test/fixtures/b002_samples.sol
+++ b/test/fixtures/b002_samples.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// Fixtures for static rule B002 — "unchecked validator address assignment".
+//
+// `B002Vulnerable` holds routines that MUST be flagged.
+// `B002Safe`       holds routines that MUST NOT be flagged.
+
+contract B002Vulnerable {
+    mapping(address => bool) public isValidator;
+    address[] public validators;
+    uint256 public threshold;
+
+    /// BAD: `validator` is registered without any address(0) assertion.
+    function addValidator(address validator) external {
+        isValidator[validator] = true;
+        validators.push(validator);
+    }
+
+    /// BAD: batch update — elements are never checked element-wise.
+    function setValidators(address[] calldata newValidators) external {
+        for (uint256 i = 0; i < newValidators.length; i++) {
+            isValidator[newValidators[i]] = true;
+        }
+    }
+
+    /// BAD: multi-sig signer rotation, neither argument is checked.
+    function rotateSigner(address oldSigner, address newSigner) external {
+        isValidator[oldSigner] = false;
+        isValidator[newSigner] = true;
+    }
+
+    /// BAD: an assertion exists, but it guards the wrong argument.
+    function addValidatorWithWeight(address validator, uint256 weight) external {
+        require(weight > 0, "B002: zero weight");
+        isValidator[validator] = true;
+        threshold += weight;
+    }
+
+    /// BAD: the comment claims a check that the code never performs.
+    function _setValidator(address validator, bool active) internal {
+        // validator must not be address(0)
+        // require(validator != address(0), "zero validator");
+        isValidator[validator] = active;
+    }
+}
+
+contract B002Safe {
+    mapping(address => bool) public isValidator;
+    address[] public signers;
+    address public feeRecipient;
+
+    error ZeroValidator();
+
+    modifier nonZeroAddress(address account) {
+        require(account != address(0), "B002: zero address");
+        _;
+    }
+
+    /// OK: explicit require on the validator input.
+    function addValidatorGuarded(address validator) external {
+        require(validator != address(0), "B002: zero validator");
+        isValidator[validator] = true;
+    }
+
+    /// OK: custom-error guards on both inputs.
+    function replaceSignerGuarded(address oldSigner, address newSigner) external {
+        if (oldSigner == address(0)) revert ZeroValidator();
+        if (newSigner == address(0)) revert ZeroValidator();
+        isValidator[oldSigner] = false;
+        isValidator[newSigner] = true;
+    }
+
+    /// OK: per-element assertion inside the update loop.
+    function setValidatorsGuarded(address[] calldata newValidators) external {
+        for (uint256 i = 0; i < newValidators.length; i++) {
+            require(newValidators[i] != address(0), "B002: zero validator");
+            isValidator[newValidators[i]] = true;
+        }
+    }
+
+    /// OK: the check lives in a guarding modifier.
+    function registerGuardian(address guardian) external nonZeroAddress(guardian) {
+        isValidator[guardian] = true;
+    }
+
+    /// OK: element is aliased into a local, then asserted.
+    function addSignerBatch(address[] memory candidates) public {
+        for (uint256 i = 0; i < candidates.length; i++) {
+            address candidate = candidates[i];
+            require(candidate != address(0), "B002: zero signer");
+            signers.push(candidate);
+        }
+    }
+
+    /// OK: not a validator-set routine at all — out of scope for B002.
+    function setFeeRecipient(address recipient) external {
+        feeRecipient = recipient;
+    }
+}

--- a/test/utils/SafeNativeTransfer.test.ts
+++ b/test/utils/SafeNativeTransfer.test.ts
@@ -1,0 +1,150 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("SafeNativeTransfer", () => {
+  let ethers: any;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+  });
+
+  async function deploy() {
+    const [deployer] = await ethers.getSigners();
+
+    const Harness = await ethers.getContractFactory("SafeNativeTransferHarness");
+    const harness = await Harness.deploy();
+    await harness.waitForDeployment();
+
+    await deployer.sendTransaction({
+      to: await harness.getAddress(),
+      value: ethers.parseEther("10"),
+    });
+
+    return { harness, deployer };
+  }
+
+  async function deployReceiver(name: string) {
+    const factory = await ethers.getContractFactory(name);
+    const receiver = await factory.deploy();
+    await receiver.waitForDeployment();
+    return receiver;
+  }
+
+  it("uses the NativeTransferFailed() selector hardcoded in the assembly block", () => {
+    expect(ethers.id("NativeTransferFailed()").slice(0, 10)).to.equal("0xf4b3b1bc");
+  });
+
+  it("delivers the exact amount to an EOA", async () => {
+    const { harness } = await deploy();
+    const to = ethers.Wallet.createRandom().address;
+    const amount = ethers.parseEther("1.5");
+
+    const before = await ethers.provider.getBalance(to);
+    await (await harness.releaseSafe(to, amount)).wait();
+
+    expect((await ethers.provider.getBalance(to)) - before).to.equal(amount);
+  });
+
+  it("delivers to a contract with a payable receive()", async () => {
+    const { harness } = await deploy();
+    const receiver = await deployReceiver("PayableReceiver");
+    const amount = ethers.parseEther("2");
+
+    await (await harness.releaseSafe(await receiver.getAddress(), amount)).wait();
+
+    expect(await receiver.received()).to.equal(amount);
+  });
+
+  it("treats a zero-amount transfer as a no-op, not a revert", async () => {
+    const { harness } = await deploy();
+    const to = ethers.Wallet.createRandom().address;
+
+    await expect(harness.releaseSafe(to, 0n)).to.not.be.reverted;
+    expect(await ethers.provider.getBalance(to)).to.equal(0n);
+  });
+
+  // --- Acceptance criterion: failed transfers revert with custom error selectors ---
+
+  it("reverts with NativeTransferFailed when the recipient rejects", async () => {
+    const { harness } = await deploy();
+    const rejecter = await deployReceiver("RejectingReceiver");
+
+    await expect(
+      harness.releaseSafe(await rejecter.getAddress(), ethers.parseEther("1"))
+    ).to.be.revertedWithCustomError(harness, "NativeTransferFailed");
+  });
+
+  it("reverts with NativeTransferFailed when the balance is insufficient", async () => {
+    const { harness } = await deploy();
+    const to = ethers.Wallet.createRandom().address;
+
+    await expect(
+      harness.releaseSafe(to, ethers.parseEther("11"))
+    ).to.be.revertedWithCustomError(harness, "NativeTransferFailed");
+  });
+
+  it("returns exactly 4 bytes of revert data (no reason string)", async () => {
+    const { harness } = await deploy();
+    const rejecter = await deployReceiver("RejectingReceiver");
+
+    try {
+      await harness.releaseSafe.staticCall(await rejecter.getAddress(), ethers.parseEther("1"));
+      expect.fail("expected the transfer to revert");
+    } catch (err: any) {
+      const data = err.data ?? err.error?.data ?? err.info?.error?.data;
+      expect(data).to.equal("0xf4b3b1bc");
+    }
+  });
+
+  it("does not copy a 4 KiB revert bomb into memory", async () => {
+    const { harness } = await deploy();
+    const bomb = await deployReceiver("RevertBombReceiver");
+
+    await expect(
+      harness.releaseSafe(await bomb.getAddress(), ethers.parseEther("1"))
+    ).to.be.revertedWithCustomError(harness, "NativeTransferFailed");
+  });
+
+  // --- Acceptance criterion: gas consumed during successful releases is reduced ---
+
+  it("consumes no more gas than the naked call on the success path", async () => {
+    const { harness, deployer } = await deploy();
+    const to = ethers.Wallet.createRandom().address;
+    const amount = ethers.parseEther("1");
+
+    // Pre-fund so neither measurement pays the 25k empty-account surcharge.
+    await (await deployer.sendTransaction({ to, value: 1n })).wait();
+
+    const nakedGas = (await (await harness.releaseNaked(to, amount)).wait()).gasUsed;
+    const safeGas = (await (await harness.releaseSafe(to, amount)).wait()).gasUsed;
+
+    expect(safeGas, `safe=${safeGas} naked=${nakedGas}`).to.be.at.most(nakedGas);
+  });
+
+  it("consumes materially less gas than the bubbling call on the failure path", async () => {
+    const { harness } = await deploy();
+    const bomb = await deployReceiver("RevertBombReceiver");
+    const bombAddress = await bomb.getAddress();
+    const amount = ethers.parseEther("1");
+
+    async function measure(variant: number): Promise<bigint> {
+      const receipt = await (await harness.measureFailure(variant, bombAddress, amount)).wait();
+      const log = receipt.logs
+        .map((l: any) => {
+          try {
+            return harness.interface.parseLog(l);
+          } catch {
+            return null;
+          }
+        })
+        .find((l: any) => l?.name === "GasMeasured");
+      return log.args.gasUsed;
+    }
+
+    const safeGas = await measure(0);
+    const bubbleGas = await measure(1);
+
+    expect(safeGas, `safe=${safeGas} bubble=${bubbleGas}`).to.be.lessThan(bubbleGas);
+  });
+});

--- a/test/utils/SafeNativeTransferHarness.sol
+++ b/test/utils/SafeNativeTransferHarness.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {SafeNativeTransfer} from "../../contracts/utils/SafeNativeTransfer.sol";
+
+/// @notice Test harness exposing {SafeNativeTransfer} next to the naked baselines it replaces.
+contract SafeNativeTransferHarness {
+    /// @dev Mirrored from {SafeNativeTransfer} so the selector is present in this ABI and
+    ///      `revertedWithCustomError` can resolve it. Identical signature, identical selector.
+    error NativeTransferFailed();
+
+    event GasMeasured(uint8 indexed variant, uint256 gasUsed);
+
+    receive() external payable {}
+
+    /// @notice The utility under test.
+    function releaseSafe(address to, uint256 amount) external {
+        SafeNativeTransfer.safeTransferNative(to, amount);
+    }
+
+    /// @notice Baseline A — the naked pattern, discarding return data.
+    function releaseNaked(address to, uint256 amount) external {
+        (bool ok, ) = to.call{value: amount}("");
+        require(ok, "Native transfer failed");
+    }
+
+    /// @notice Baseline B — the naked pattern that copies the full revert reason to memory.
+    function releaseNakedBubble(address to, uint256 amount) external {
+        (bool ok, bytes memory reason) = to.call{value: amount}("");
+        if (!ok) {
+            if (reason.length == 0) revert("Native transfer failed");
+            assembly {
+                revert(add(reason, 0x20), mload(reason))
+            }
+        }
+    }
+
+    /// @notice Measures the failure path of a variant and reports it via {GasMeasured}.
+    /// @param variant 0 = safeTransferNative, 1 = releaseNakedBubble.
+    function measureFailure(uint8 variant, address to, uint256 amount) external {
+        uint256 start = gasleft();
+        if (variant == 0) {
+            try this.releaseSafe(to, amount) {} catch {}
+        } else {
+            try this.releaseNakedBubble(to, amount) {} catch {}
+        }
+        emit GasMeasured(variant, start - gasleft());
+    }
+}
+
+/// @notice Accepts native transfers.
+contract PayableReceiver {
+    uint256 public received;
+
+    receive() external payable {
+        received += msg.value;
+    }
+}
+
+/// @notice Rejects native transfers with empty revert data.
+contract RejectingReceiver {
+    receive() external payable {
+        revert();
+    }
+}
+
+/// @notice Rejects native transfers with a 4 KiB revert payload.
+contract RevertBombReceiver {
+    receive() external payable {
+        assembly {
+            let size := 4096
+            let ptr := mload(0x40)
+            mstore(0x40, add(ptr, size))
+            revert(ptr, size)
+        }
+    }
+}


### PR DESCRIPTION
closes #819 
closes #820  
closes #821 
closes #823 

<html>
<body>
<!--StartFragment--><h2 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Static rule B002: unchecked validator address assignments</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Commit</strong> <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">95354aad</code></p><h3 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files</h3>
File | Lines | Role
-- | -- | --
rules/b002_validator_zero_check.rs | 710 | Rule implementation + unit tests
test/fixtures/b002_samples.sol | 100 | Vulnerable + safe Solidity samples

<h3 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The helper</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">library</code> with an <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">internal</code> function, so it inlines — no <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DELEGATECALL</code>, no deployment, no linking.</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(18, 19, 20); border-color: rgb(42, 43, 44); border-style: solid; border-width: 0.8px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-solidity" style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">assembly ("memory-safe") {
    if iszero(call(gas(), to, amount, codesize(), 0x00, codesize(), 0x00)) {
        mstore(0x00, 0xf4b3b1bc) // NativeTransferFailed()
        revert(0x1c, 0x04)
    }
}
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">codesize()</code> as both memory offsets is the standard trick: guaranteed non-zero, paired with zero length, so it triggers no memory expansion and no <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">returndatacopy</code> on either path. Failure reverts with the bare 4-byte selector out of scratch space (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">0x1c</code> = the low 4 bytes of the word at <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">0x00</code>).</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">I computed <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">keccak256("NativeTransferFailed()")[0:4]</code> with <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@noble/hashes</code> rather than trusting recall — <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">0xf4b3b1bc</code> — and a test asserts that literal so a typo can't slip through silently.</p><h3 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Call-site migration</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The title said <em>replace</em>, so I did. <a href="vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/contracts/execution/GasEscrow.sol#L37" target="_blank" rel="noopener noreferrer" style="color: rgb(72, 160, 199); text-decoration: rgb(72, 160, 199);">contracts/execution/GasEscrow.sol:37</a> previously had <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">(bool refundSuccess, ) = refundAddress.call{value: refundAmount}(""); require(refundSuccess, "Refund transfer failed");</code>. It was the <strong>only</strong> naked native send in <a href="vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/contracts/" target="_blank" rel="noopener noreferrer" style="color: rgb(72, 160, 199); text-decoration: rgb(72, 160, 199);">contracts/</a> — a grep for <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.call{value</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.transfer(</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">.send(</code> now matches nothing but the library's own doc comment. No existing test asserted the removed revert string.</p><h3 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test design</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Hardhat 3 style (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">hre.network.create()</code>), matching <a href="vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/test/security/TransientReplayGuard.test.ts" target="_blank" rel="noopener noreferrer" style="color: rgb(72, 160, 199); text-decoration: rgb(72, 160, 199);">test/security/TransientReplayGuard.test.ts</a>. Harness exposes the utility plus two baselines — naked-discard and naked-bubble-the-reason — and three receivers: payable, rejecting (empty revert data), and a 4 KiB revert bomb. Failure-path gas is captured via a <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GasMeasured</code> event because a reverting tx has no readable receipt, and <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">staticCall</code> would block the value transfer before the callee ever runs.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Nine tests: selector literal, exact delivery to EOA and to a contract, zero-amount no-op, custom-error revert on rejection and on insufficient balance, revert data is exactly 4 bytes, bomb receiver still reverts cleanly, and the two gas comparisons. Gas measurements pre-fund the recipient so neither side pays the 25k empty-account surcharge.</p><!--EndFragment-->
</body>
</html>Static rule B002: unchecked validator address assignments
Commit 95354aad

Files
File	Lines	Role
[rules/b002_validator_zero_check.rs](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/rules/b002_validator_zero_check.rs)	710	Rule implementation + unit tests
[test/fixtures/b002_samples.sol](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/test/fixtures/b002_samples.sol)	100	Vulnerable + safe Solidity samples
Both paths are exactly as the issue specified.

How it works
Zero external crates — pure std, self-contained.

Noise stripping. Comments and string/char literals are blanked to spaces (line breaks preserved for accurate line numbers). This is why a commented-out require(v != address(0)) cannot be mistaken for a real check.

Function extraction. Scans for the function keyword at identifier boundaries, then paren/brace-matches to recover name, parameter list, header (visibility + modifiers), and body. Interface/abstract stubs ending in ; are skipped, as are functions with no address or address[] parameters.

Targeting — a function is in scope if either:

its name contains validator, signer, guardian, attestor, attester, multisig, quorum, committee, or relayer; or
its body writes to a slot with one of those names — validators[x] = …, signers.push(…), .add/.remove/.pop/.set. The write check distinguishes = from ==, so a comparison doesn't count as a mutation.
The second path is what catches grant(address account) { isValidator[account] = true; } despite the neutral name.

Accepted proofs of a zero check, per parameter:

require(v != address(0), …) / assert(...)
if (v == address(0)) revert …; — the if only counts if its branch actually aborts (revert/require/throw); a bare if is not an assertion
a guarding modifier on the signature (nonZeroAddress(v)) or an internal helper (_requireNonZeroAddress(v)) — matched by an identifier containing zero/validaddress applied directly to the parameter
per-element checks on address[] inputs, including through a local alias (address c = arr[i]; require(c != address(0));)
zero literals recognized: address(0), address(0x0), address(uint160(0)), the 40-zero hex literal
Output. Finding { rule_id: "B002", rule_name, file, line, function, unchecked_params, severity: High, message } — per-parameter, so rotateSigner reports both oldSigner and newSigner in one finding.

Fixture coverage
B002Vulnerable — 5 must-flag: plain add, unchecked batch loop, signer rotation, check-on-the-wrong-argument (require(weight > 0)), comment-only check.
B002Safe — 6 must-pass: require, custom-error revert, per-element loop check, modifier guard, aliased element, plus a non-validator setter that's out of scope.

Function names are deliberately unique across the two contracts so the tests can assert flagged/not-flagged by name without collisions.

Tests
Seven #[cfg(test)] tests pulling the fixture via include_str!("../test/fixtures/b002_samples.sol") — the two acceptance criteria directly, plus per-parameter reporting, non-validator routines ignored, naming-hint-free detection, custom-error guards accepted, and comments-are-not-checks.

- SafeNativeTransfer low-gas native transfer utility
Commit 2fc52f4f

Files
File	Lines	Role
[contracts/utils/SafeNativeTransfer.sol](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/contracts/utils/SafeNativeTransfer.sol)	43	The library
[test/utils/SafeNativeTransfer.test.ts](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/test/utils/SafeNativeTransfer.test.ts)	150	9 tests
[test/utils/SafeNativeTransferHarness.sol](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/test/utils/SafeNativeTransferHarness.sol)	77	Harness + 3 receiver mocks (added — not in the issue's scope list)
[contracts/execution/GasEscrow.sol](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/contracts/execution/GasEscrow.sol)	±5	Migrated call site
The helper
library with an internal function, so it inlines — no DELEGATECALL, no deployment, no linking.


assembly ("memory-safe") {
    if iszero(call(gas(), to, amount, codesize(), 0x00, codesize(), 0x00)) {
        mstore(0x00, 0xf4b3b1bc) // NativeTransferFailed()
        revert(0x1c, 0x04)
    }
}
codesize() as both memory offsets is the standard trick: guaranteed non-zero, paired with zero length, so it triggers no memory expansion and no returndatacopy on either path. Failure reverts with the bare 4-byte selector out of scratch space (0x1c = the low 4 bytes of the word at 0x00).

I computed keccak256("NativeTransferFailed()")[0:4] with @noble/hashes rather than trusting recall — 0xf4b3b1bc — and a test asserts that literal so a typo can't slip through silently.

Call-site migration
The title said replace, so I did. [contracts/execution/GasEscrow.sol:37](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/contracts/execution/GasEscrow.sol#L37) previously had (bool refundSuccess, ) = refundAddress.call{value: refundAmount}(""); require(refundSuccess, "Refund transfer failed");. It was the only naked native send in [contracts/](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/contracts/) — a grep for .call{value, .transfer(, .send( now matches nothing but the library's own doc comment. No existing test asserted the removed revert string.

Test design
Hardhat 3 style (hre.network.create()), matching [test/security/TransientReplayGuard.test.ts](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/test/security/TransientReplayGuard.test.ts). Harness exposes the utility plus two baselines — naked-discard and naked-bubble-the-reason — and three receivers: payable, rejecting (empty revert data), and a 4 KiB revert bomb. Failure-path gas is captured via a GasMeasured event because a reverting tx has no readable receipt, and staticCall would block the value transfer before the callee ever runs.

Nine tests: selector literal, exact delivery to EOA and to a contract, zero-amount no-op, custom-error revert on rejection and on insufficient balance, revert data is exactly 4 bytes, bomb receiver still reverts cleanly, and the two gas comparisons. Gas measurements pre-fund the recipient so neither side pays the 25k empty-account surcharge.