### PR TITLE
feat: implement low-gas wrapped token minting handler in Yul (#827)

### DIFF
--- a/contracts/tokens/YulWrappedToken.sol
+++ b/contracts/tokens/YulWrappedToken.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title YulWrappedToken
+/// @notice Custom Yul execution handler for minting wrapped cross-chain tokens.
+contract YulWrappedToken {
+    address public immutable bridge;
+    
+    error Unauthorized();
+    error MintFailed();
+
+    constructor(address _bridge) {
+        bridge = _bridge;
+    }
+
+    /// @notice Mints wrapped tokens by making a low-level call to the token contract.
+    /// @dev Uses inline assembly to minimize gas overhead by formatting calldata in scratch memory.
+    function mint(address token, address to, uint256 amount) external {
+        if (msg.sender != bridge) {
+            revert Unauthorized();
+        }
+        
+        bool success;
+        assembly {
+            // Function selector for mint(address,uint256): 0x40c10f19
+            mstore(0x00, 0x40c10f1900000000000000000000000000000000000000000000000000000000)
+            mstore(0x04, and(to, 0xffffffffffffffffffffffffffffffffffffffff))
+            mstore(0x24, amount)
+            
+            // Execute the low-level call to mint tokens
+            // gas(), token, value, in_offset, in_size, out_offset, out_size
+            success := call(gas(), token, 0, 0x00, 0x44, 0, 0)
+        }
+        
+        if (!success) {
+            revert MintFailed();
+        }
+    }
+}

--- a/test/tokens/YulWrappedToken.test.ts
+++ b/test/tokens/YulWrappedToken.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("YulWrappedToken", function () {
+    let yulWrappedToken: any;
+    let mockToken: any;
+    let owner: any;
+    let bridge: any;
+    let user: any;
+
+    beforeEach(async function () {
+        [owner, bridge, user] = await ethers.getSigners();
+
+        // We use BridgeWrappedToken as the token to mint
+        const MockTokenFactory = await ethers.getContractFactory("BridgeWrappedToken");
+        mockToken = await MockTokenFactory.deploy("Mock Wrapped Token", "mWTKN", await bridge.getAddress(), await owner.getAddress());
+        await mockToken.waitForDeployment();
+
+        const YulWrappedTokenFactory = await ethers.getContractFactory("YulWrappedToken");
+        yulWrappedToken = await YulWrappedTokenFactory.deploy(await bridge.getAddress());
+        await yulWrappedToken.waitForDeployment();
+        
+        // Grant minter role to our YulWrappedToken handler
+        const MINTER_ROLE = await mockToken.MINTER_ROLE();
+        await mockToken.connect(owner).grantRole(MINTER_ROLE, await yulWrappedToken.getAddress());
+    });
+
+    it("should mint successfully when called by the bridge", async function () {
+        const userAddress = await user.getAddress();
+        const amount = ethers.parseEther("100");
+
+        const tx = await yulWrappedToken.connect(bridge).mint(
+            await mockToken.getAddress(),
+            userAddress,
+            amount
+        );
+
+        await tx.wait();
+
+        const balance = await mockToken.balanceOf(userAddress);
+        expect(balance).to.equal(amount);
+    });
+
+    it("should revert when called by unauthorized account", async function () {
+        const userAddress = await user.getAddress();
+        const amount = ethers.parseEther("100");
+
+        await expect(
+            yulWrappedToken.connect(user).mint(
+                await mockToken.getAddress(),
+                userAddress,
+                amount
+            )
+        ).to.be.revertedWithCustomError(yulWrappedToken, "Unauthorized");
+    });
+    
+    it("should revert when minting fails (e.g. not a minter)", async function () {
+        const userAddress = await user.getAddress();
+        const amount = ethers.parseEther("100");
+        
+        // revoke minter role
+        const MINTER_ROLE = await mockToken.MINTER_ROLE();
+        await mockToken.connect(owner).revokeRole(MINTER_ROLE, await yulWrappedToken.getAddress());
+
+        await expect(
+            yulWrappedToken.connect(bridge).mint(
+                await mockToken.getAddress(),
+                userAddress,
+                amount
+            )
+        ).to.be.revertedWithCustomError(yulWrappedToken, "MintFailed");
+    });
+});


### PR DESCRIPTION
## Description
Closes #827 

This PR introduces a custom Yul execution handler for minting wrapped cross-chain tokens (`bwERC20`) upon target-chain message delivery, which significantly reduces the execution gas overhead for token mints. 

## Changes Made
- **`contracts/tokens/YulWrappedToken.sol`**: Implemented the `YulWrappedToken` contract with a `mint(address, address, uint256)` function. The function formats the `mint(address,uint256)` calldata directly in scratch memory and executes a low-level call, leveraging Yul for gas optimization. Added access control restrictions ensuring that only the assigned bridge contract can trigger the mints.
- **`test/tokens/YulWrappedToken.test.ts`**: Added a comprehensive test suite using Hardhat and Chai. It validates successful minting execution by the bridge, verifies token balances are accurately updated, and ensures appropriate custom errors are thrown when unauthorized accounts attempt to mint or if the low-level minting call fails.

## Acceptance Criteria Met
- [x] Reduces execution gas during wrapped token minting operations by utilizing inline Yul and scratch memory formatting.
- [x] Maintains full access restrictions ensuring only target bridge contracts can trigger minting.
