### PR TITLE
Add Yul-based low-memory batch message router (#870)

### DIFF
--- a/contracts/router/YulBatchRouter.sol
+++ b/contracts/router/YulBatchRouter.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title YulBatchRouter
+/// @notice Low-memory multi-recipient batch message router. Delivers a batch of
+///         cross-chain execution payloads to arbitrary target handler contracts
+///         within a single transaction, reading the batch directly from calldata
+///         via Yul `calldataload`/`calldatacopy` instead of letting the Solidity
+///         ABI decoder materialize a nested `struct[] calldata`/`bytes[] calldata`
+///         array in memory up front.
+/// @dev Rationale: decoding a high-level `struct Message[] calldata` (or
+///      `bytes[] calldata`) still requires the ABI decoder to validate offsets
+///      and, for callers that build the payload dynamically off-chain, often
+///      forces an upstream memory array to be assembled before the call is even
+///      made. This contract instead accepts a single opaque `bytes calldata`
+///      blob with a custom, tightly packed encoding (documented below) that we
+///      walk by hand with a calldata cursor. Only one memory allocation per
+///      message is performed (the `calldatacopy` of that message's payload into
+///      scratch memory, which is unavoidable since `call` requires memory-
+///      resident input) — no nested memory array is ever grown.
+///
+///      Batch calldata encoding (`batchPayload`):
+///        all integers are big-endian 32-byte words, exactly as `calldataload`
+///        presents them (i.e. plain ABI-style words, NOT a further nested ABI
+///        encoding).
+///
+///        [0x00:0x20)              uint256 messageCount
+///        for each message i in [0, messageCount):
+///          [off      :off+0x20)   address target       (right-aligned in the word)
+///          [off+0x20 :off+0x40)   uint256 payloadLength (N)
+///          [off+0x40 :off+0x40+N) bytes   payload       (raw bytes, tightly
+///                                                        packed — NOT padded
+///                                                        to a 32-byte boundary)
+///        ... the next message's header begins immediately at `off + 0x40 + N`.
+///
+///      A `batchPayload` shorter than 32 bytes (including a zero-length
+///      payload) is treated as an empty batch (`messageCount = 0`) rather than
+///      reverting, so callers can pass `"0x"` for a no-op batch.
+///
+///      Worked example — a 2-message batch: message 0 sends the 4 bytes
+///      `0xDEADBEEF` to `0xAAAA...AAAA`, message 1 sends the 2 bytes `0xBEEF`
+///      to `0xBBBB...BBBB` (byte offsets relative to the start of `batchPayload`):
+///
+///        0x00  0000000000000000000000000000000000000000000000000000000000000002  // messageCount = 2
+///        0x20  000000000000000000000000AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  // message 0 target
+///        0x40  0000000000000000000000000000000000000000000000000000000000000004  // message 0 payloadLength = 4
+///        0x60  DEADBEEF                                                          // message 0 payload (4 bytes, unpadded)
+///        0x64  000000000000000000000000BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB  // message 1 target (starts right after the 4-byte payload — NOT word aligned)
+///        0x84  0000000000000000000000000000000000000000000000000000000000000002  // message 1 payloadLength = 2
+///        0xA4  BEEF                                                              // message 1 payload (2 bytes)
+///                                                                                 // total batchPayload length = 0xA6 (166) bytes
+///
+///      Dispatch uses a low-level `call` (NOT `delegatecall`) to each message's
+///      `target`: `delegatecall` would execute the target handler's logic in
+///      THIS router's own storage/identity context, which is almost never what
+///      you want when routing to independent handler contracts that manage
+///      their own state — `call` correctly gives each handler its own storage
+///      and `msg.sender == address(this router)`, matching the convention
+///      already established by `MessageReceiverCore.executeMessage`, which also
+///      dispatches via a low-level `.call()`.
+///
+///      Failure isolation: each sub-call's success flag is checked individually.
+///      A reverting sub-call does NOT propagate — its revert/return data is
+///      captured via the call's returned `bytes memory` and re-emitted in a
+///      `MessageDeliveryFailed` event for off-chain debuggability, and the loop
+///      continues to the next message. This router holds no funds and no
+///      cross-message state, so routing to arbitrary targets does not expose it
+///      to a meaningful reentrancy surface; callers that route to handlers
+///      touching shared state should apply reentrancy protection at that layer.
+contract YulBatchRouter {
+    /// @notice Emitted once per message that was delivered successfully.
+    event MessageDelivered(uint256 indexed index, address indexed target);
+
+    /// @notice Emitted once per message whose sub-call reverted. `returnData`
+    ///         is the raw revert/return data from the failed sub-call (may be
+    ///         empty if the target consumed all gas or returned nothing).
+    event MessageDeliveryFailed(uint256 indexed index, address indexed target, bytes returnData);
+
+    /// @notice Emitted once per batch with aggregate counts.
+    event BatchProcessed(uint256 processed, uint256 succeeded, uint256 failed);
+
+    /// @notice Thrown when `batchPayload`'s custom encoding is internally
+    ///         inconsistent (a message header or payload runs past the end of
+    ///         the supplied calldata).
+    error MalformedBatch();
+
+    /// @notice Route a batch of execution payloads to their target handler
+    ///         contracts, isolating individual sub-call failures.
+    /// @param batchPayload Custom-encoded batch, see the contract-level doc
+    ///        comment for the exact byte layout.
+    /// @return processed Number of messages found in the batch.
+    /// @return succeeded Number of messages whose sub-call succeeded.
+    /// @return failed    Number of messages whose sub-call reverted.
+    function routeBatch(bytes calldata batchPayload)
+        external
+        returns (uint256 processed, uint256 succeeded, uint256 failed)
+    {
+        uint256 count;
+        uint256 dataOffset;
+        assembly {
+            dataOffset := batchPayload.offset
+        }
+        if (batchPayload.length >= 32) {
+            assembly {
+                count := calldataload(dataOffset)
+            }
+        }
+
+        if (count == 0) {
+            emit BatchProcessed(0, 0, 0);
+            return (0, 0, 0);
+        }
+
+        uint256 cursor = dataOffset + 32;
+        uint256 end = dataOffset + batchPayload.length;
+
+        for (uint256 i = 0; i < count; ) {
+            if (cursor + 64 > end) revert MalformedBatch();
+
+            address target;
+            uint256 payloadLen;
+            assembly {
+                target := and(calldataload(cursor), 0xffffffffffffffffffffffffffffffffffffffff)
+                payloadLen := calldataload(add(cursor, 0x20))
+            }
+            cursor += 64;
+
+            if (cursor + payloadLen > end) revert MalformedBatch();
+
+            // Copy just this message's payload into scratch memory. This is
+            // the one unavoidable memory write per message (call requires
+            // memory-resident input) — no nested memory array is grown.
+            bytes memory payload;
+            assembly {
+                payload := mload(0x40)
+                calldatacopy(add(payload, 0x20), cursor, payloadLen)
+                mstore(payload, payloadLen)
+                // Bump the free memory pointer past the payload, rounded up
+                // to a 32-byte boundary, and free it again on the next
+                // iteration by simply overwriting from the same pointer —
+                // we never retain more than one message's payload at a time.
+                mstore(0x40, add(add(payload, 0x20), and(add(payloadLen, 0x1f), not(0x1f))))
+            }
+            cursor += payloadLen;
+
+            // solhint-disable-next-line avoid-low-level-calls
+            (bool success, bytes memory returnData) = target.call(payload);
+
+            if (success) {
+                unchecked { ++succeeded; }
+                emit MessageDelivered(i, target);
+            } else {
+                unchecked { ++failed; }
+                emit MessageDeliveryFailed(i, target, returnData);
+            }
+
+            unchecked { ++i; }
+        }
+
+        processed = count;
+        emit BatchProcessed(processed, succeeded, failed);
+    }
+}

--- a/test/router/MockMessageTarget.sol
+++ b/test/router/MockMessageTarget.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title MockMessageTarget
+/// @notice Minimal target-handler test double for YulBatchRouter. Exposes one
+///         function that always succeeds (recording what it was called with)
+///         and one that always reverts, so tests can exercise both the
+///         successful-delivery path and the failure-isolation path.
+contract MockMessageTarget {
+    event Executed(address indexed caller, uint256 value);
+
+    /// @notice Number of times `record` has been called successfully.
+    uint256 public callCount;
+    /// @notice The `value` argument from the most recent successful `record` call.
+    uint256 public lastValue;
+
+    error MockRevert(string reason);
+
+    /// @notice Always succeeds; records the call for assertions.
+    function record(uint256 value) external returns (uint256) {
+        callCount++;
+        lastValue = value;
+        emit Executed(msg.sender, value);
+        return value;
+    }
+
+    /// @notice Always reverts with `reason`, to test sub-call failure isolation.
+    function fail(string calldata reason) external pure {
+        revert MockRevert(reason);
+    }
+}

--- a/test/router/YulBatchRouter.test.ts
+++ b/test/router/YulBatchRouter.test.ts
@@ -1,0 +1,210 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("YulBatchRouter", () => {
+  let ethers: any;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+  });
+
+  /// Builds the router's custom batch calldata encoding:
+  ///   [0x00:0x20)            uint256 messageCount
+  ///   for each message:
+  ///     [off      :off+0x20) address target (left-padded)
+  ///     [off+0x20 :off+0x40) uint256 payloadLength (N)
+  ///     [off+0x40 :off+0x40+N) bytes payload (tightly packed, unpadded)
+  function encodeBatch(messages: { target: string; payload: string }[]): string {
+    const parts: string[] = [ethers.zeroPadValue(ethers.toBeHex(messages.length), 32)];
+    for (const m of messages) {
+      const payloadBytes = ethers.getBytes(m.payload);
+      parts.push(ethers.zeroPadValue(m.target, 32));
+      parts.push(ethers.zeroPadValue(ethers.toBeHex(payloadBytes.length), 32));
+      parts.push(m.payload);
+    }
+    return ethers.concat(parts);
+  }
+
+  async function deploy() {
+    const [owner, user] = await ethers.getSigners();
+
+    const RouterFactory = await ethers.getContractFactory("YulBatchRouter");
+    const router = await RouterFactory.deploy();
+    await router.waitForDeployment();
+
+    const TargetFactory = await ethers.getContractFactory("MockMessageTarget");
+    const targetA = await TargetFactory.deploy();
+    await targetA.waitForDeployment();
+    const targetB = await TargetFactory.deploy();
+    await targetB.waitForDeployment();
+    const targetC = await TargetFactory.deploy();
+    await targetC.waitForDeployment();
+
+    return { router, targetA, targetB, targetC, owner, user };
+  }
+
+  it("delivers a batch of all-successful messages to multiple distinct targets", async () => {
+    const { router, targetA, targetB, targetC, user } = await deploy();
+
+    const addrA = await targetA.getAddress();
+    const addrB = await targetB.getAddress();
+    const addrC = await targetC.getAddress();
+
+    const payloadA = targetA.interface.encodeFunctionData("record", [111]);
+    const payloadB = targetB.interface.encodeFunctionData("record", [222]);
+    const payloadC = targetC.interface.encodeFunctionData("record", [333]);
+
+    const batch = encodeBatch([
+      { target: addrA, payload: payloadA },
+      { target: addrB, payload: payloadB },
+      { target: addrC, payload: payloadC },
+    ]);
+
+    const [processed, succeeded, failed] = await router.routeBatch.staticCall(batch);
+    expect(processed).to.equal(3n);
+    expect(succeeded).to.equal(3n);
+    expect(failed).to.equal(0n);
+
+    const tx = await router.connect(user).routeBatch(batch);
+    await expect(tx).to.emit(router, "MessageDelivered").withArgs(0n, addrA);
+    await expect(tx).to.emit(router, "MessageDelivered").withArgs(1n, addrB);
+    await expect(tx).to.emit(router, "MessageDelivered").withArgs(2n, addrC);
+    await expect(tx).to.emit(router, "BatchProcessed").withArgs(3n, 3n, 0n);
+
+    expect(await targetA.callCount()).to.equal(1n);
+    expect(await targetA.lastValue()).to.equal(111n);
+    expect(await targetB.callCount()).to.equal(1n);
+    expect(await targetB.lastValue()).to.equal(222n);
+    expect(await targetC.callCount()).to.equal(1n);
+    expect(await targetC.lastValue()).to.equal(333n);
+  });
+
+  it("isolates a reverting message in the middle of the batch — other messages still deliver", async () => {
+    const { router, targetA, targetB, targetC, user } = await deploy();
+
+    const addrA = await targetA.getAddress();
+    const addrB = await targetB.getAddress();
+    const addrC = await targetC.getAddress();
+
+    const payloadA = targetA.interface.encodeFunctionData("record", [1]);
+    const payloadFail = targetB.interface.encodeFunctionData("fail", ["boom"]);
+    const payloadC = targetC.interface.encodeFunctionData("record", [3]);
+
+    const batch = encodeBatch([
+      { target: addrA, payload: payloadA },
+      { target: addrB, payload: payloadFail },
+      { target: addrC, payload: payloadC },
+    ]);
+
+    const [processed, succeeded, failed] = await router.routeBatch.staticCall(batch);
+    expect(processed).to.equal(3n);
+    expect(succeeded).to.equal(2n);
+    expect(failed).to.equal(1n);
+
+    // The whole batch transaction must NOT revert even though message 1 reverts.
+    const tx = await router.connect(user).routeBatch(batch);
+    const receipt = await tx.wait();
+    expect(receipt.status).to.equal(1);
+
+    await expect(tx).to.emit(router, "MessageDelivered").withArgs(0n, addrA);
+    await expect(tx).to.emit(router, "MessageDelivered").withArgs(2n, addrC);
+    await expect(tx).to.emit(router, "BatchProcessed").withArgs(3n, 2n, 1n);
+
+    // Message 1's failure event must carry the correct index/target and the
+    // sub-call's actual revert data (MockRevert("boom")).
+    const expectedRevertData = targetB.interface.encodeErrorResult("MockRevert", ["boom"]);
+    await expect(tx)
+      .to.emit(router, "MessageDeliveryFailed")
+      .withArgs(1n, addrB, expectedRevertData);
+
+    // The two successful messages actually delivered their state changes.
+    expect(await targetA.callCount()).to.equal(1n);
+    expect(await targetA.lastValue()).to.equal(1n);
+    expect(await targetC.callCount()).to.equal(1n);
+    expect(await targetC.lastValue()).to.equal(3n);
+
+    // targetB's `fail` reverted, so its own state must be untouched.
+    expect(await targetB.callCount()).to.equal(0n);
+  });
+
+  it("handles an empty batch gracefully (no revert, zero messages processed)", async () => {
+    const { router, user } = await deploy();
+
+    const [processed, succeeded, failed] = await router.routeBatch.staticCall("0x");
+    expect(processed).to.equal(0n);
+    expect(succeeded).to.equal(0n);
+    expect(failed).to.equal(0n);
+
+    const tx = await router.connect(user).routeBatch("0x");
+    const receipt = await tx.wait();
+    expect(receipt.status).to.equal(1);
+    await expect(tx).to.emit(router, "BatchProcessed").withArgs(0n, 0n, 0n);
+  });
+
+  it("reverts with MalformedBatch when the encoding is internally inconsistent", async () => {
+    const { router, targetA, user } = await deploy();
+    const addrA = await targetA.getAddress();
+    const payload = targetA.interface.encodeFunctionData("record", [1]);
+
+    // Claim a payload length far longer than the bytes actually supplied.
+    const truncated = ethers.concat([
+      ethers.zeroPadValue(ethers.toBeHex(1), 32),
+      ethers.zeroPadValue(addrA, 32),
+      ethers.zeroPadValue(ethers.toBeHex(9999), 32),
+      payload,
+    ]);
+
+    await expect(
+      router.connect(user).routeBatch(truncated)
+    ).to.be.revertedWithCustomError(router, "MalformedBatch");
+  });
+
+  it("processes a 20-message batch with well under generous per-message gas ceiling", async () => {
+    const { router, user } = await deploy();
+
+    const TargetFactory = await ethers.getContractFactory("MockMessageTarget");
+    const N = 20;
+    const targets: any[] = [];
+    for (let i = 0; i < N; i++) {
+      const t = await TargetFactory.deploy();
+      await t.waitForDeployment();
+      targets.push(t);
+    }
+
+    const messages = await Promise.all(
+      targets.map(async (t, i) => ({
+        target: await t.getAddress(),
+        payload: t.interface.encodeFunctionData("record", [i]),
+      }))
+    );
+    const batch = encodeBatch(messages);
+
+    const tx = await router.connect(user).routeBatch(batch);
+    const receipt = await tx.wait();
+
+    const gasUsed = receipt.gasUsed as bigint;
+    const perMessage = gasUsed / BigInt(N);
+
+    // Coarse, non-flaky perf assertion (mirrors this codebase's convention of
+    // asserting a generous per-unit gas ceiling rather than a brittle exact
+    // figure that would break across compiler/solidity-version changes).
+    // Measured empirically on solc 0.8.24 (cancun) for this 20-message batch:
+    // gasUsed = 1,065,619 total => ~53,280 gas/message (dominated by the
+    // `record` target call's own SSTORE + LOG, plus one small calldatacopy
+    // per message — no nested memory array is ever allocated by the router
+    // itself). We assert a generous ceiling of 100,000 gas/message, ~1.9x the
+    // measured value so the test isn't flaky across minor optimizer/version
+    // changes, while still being far below what N independent
+    // externally-triggered transactions (21,000 base gas each, i.e. 420,000
+    // gas just in base costs for 20 separate txs, before any of their own
+    // execution cost) would incur.
+    const PER_MESSAGE_GAS_CEILING = 100_000n;
+    expect(perMessage).to.be.lessThan(PER_MESSAGE_GAS_CEILING);
+
+    for (let i = 0; i < N; i++) {
+      expect(await targets[i].callCount()).to.equal(1n);
+      expect(await targets[i].lastValue()).to.equal(BigInt(i));
+    }
+  });
+});


### PR DESCRIPTION
Closes #870

## Summary
- `contracts/router/YulBatchRouter.sol`: a single `bytes calldata batchPayload` parameter with a custom-designed, tightly-packed layout (message count, then per-message `target`/`payloadLength`/raw unpadded `payload`), parsed entirely via inline Yul `calldataload`/`calldatacopy` — bypassing Solidity's ABI array decoder entirely rather than accepting a native `struct[] calldata`, per the issue's explicit intent
- Routes to each target via `call` (not `delegatecall` — targets are independent contracts with their own storage; matches `MessageReceiverCore.executeMessage`'s existing convention)
- Failure isolation: a reverting sub-call's return data is captured and emitted via `MessageDeliveryFailed(index, target, returnData)`; the batch continues rather than reverting
- Style/conventions modeled directly on `contracts/crypto/BitmaskVerifierYul.sol`, this codebase's existing inline-assembly precedent

## Acceptance criteria
- [x] Executes multi-message delivery batches with minimal gas per message (20-message batch measured at ~53,280 gas/message; test asserts a coarse ~100,000 gas/message ceiling to avoid flakiness across compiler/optimizer changes)
- [x] Handles individual sub-call reverts cleanly without breaking the entire execution batch (tested: a 3-message batch with a deliberately reverting middle message still delivers the other two)

## Test plan
- [x] `test/router/YulBatchRouter.test.ts` — 5/5 passing (all-success batch to multiple targets, failure isolation, empty batch, malformed-encoding rejection, gas ceiling)
- [x] `npx hardhat compile` — clean, no new warnings