### PR TITLE
Add packed bitmap replay-nonce tracking (issue #822)

### DIFF
--- a/contracts/bridge/NonceBitmap.sol
+++ b/contracts/bridge/NonceBitmap.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title NonceBitmap
+/// @notice Gas-optimized replay-protection library for cross-chain message sequence
+///         nonces. Instead of setting a fresh 32-byte storage slot per processed
+///         message (`mapping(bytes32 => bool)`, ~20,000 cold-write gas every time),
+///         this packs 256 processed-nonce flags into a single `uint256` storage word
+///         (`mapping(uint256 => uint256)`), so sequential nonces that land in the same
+///         word only pay the cold-write cost once per 256 messages.
+/// @dev Word index = `nonce / 256`, bit index = `nonce % 256`. The actual bit read and
+///      bit set both happen inside `assembly` blocks using `shr`/`shl`/`and`/`or`, per
+///      the issue's requirement that bit manipulation happen in Yul rather than via
+///      plain Solidity `|=` on a `uint256`.
+///
+///      Any contract can adopt replay protection by declaring one
+///      `mapping(uint256 => uint256) private _processedNonces;` state variable and
+///      calling `NonceBitmap.markProcessed(_processedNonces, nonce)` — mirroring the
+///      `BitmaskVerifierYul` library pattern already used in this codebase.
+library NonceBitmap {
+    /// @notice Thrown by `markProcessed` when `nonce` has already been marked processed.
+    error AlreadyProcessed(uint256 nonce);
+
+    /// @notice Compute the storage word index and in-word bit index for a nonce.
+    /// @param nonce The message sequence nonce.
+    /// @return wordIndex The key into the `mapping(uint256 => uint256)` bitmap.
+    /// @return bitIndex  The bit position (0-255) within that word.
+    function locate(uint256 nonce) internal pure returns (uint256 wordIndex, uint256 bitIndex) {
+        wordIndex = nonce / 256;
+        bitIndex = nonce % 256;
+    }
+
+    /// @notice Check whether `nonce` has already been marked processed.
+    /// @param bitmap The caller's bitmap storage mapping.
+    /// @param nonce  The message sequence nonce to check.
+    /// @return processed True if the bit for `nonce` is already set.
+    function isProcessed(mapping(uint256 => uint256) storage bitmap, uint256 nonce)
+        internal
+        view
+        returns (bool processed)
+    {
+        (uint256 wordIndex, uint256 bitIndex) = locate(nonce);
+        uint256 word = bitmap[wordIndex];
+
+        assembly {
+            processed := and(shr(bitIndex, word), 1)
+        }
+    }
+
+    /// @notice Atomically check-and-set: mark `nonce` as processed, reverting if it was
+    ///         already marked. This is the primary replay-guard entry point — a single
+    ///         call that closes the check-then-set race a separate read + write pair
+    ///         would otherwise leave open between two external calls.
+    /// @param bitmap The caller's bitmap storage mapping.
+    /// @param nonce  The message sequence nonce to mark processed.
+    function markProcessed(mapping(uint256 => uint256) storage bitmap, uint256 nonce) internal {
+        (uint256 wordIndex, uint256 bitIndex) = locate(nonce);
+        uint256 word = bitmap[wordIndex];
+
+        bool alreadySet;
+        assembly {
+            alreadySet := and(shr(bitIndex, word), 1)
+        }
+        if (alreadySet) revert AlreadyProcessed(nonce);
+
+        uint256 updated;
+        assembly {
+            updated := or(word, shl(bitIndex, 1))
+        }
+        bitmap[wordIndex] = updated;
+    }
+}
+
+/// @dev Thin wrapper contract to expose the library for direct testing, exactly like
+///      `BitmaskVerifierYulWrapper` for `BitmaskVerifierYul`.
+contract NonceBitmapWrapper {
+    using NonceBitmap for mapping(uint256 => uint256);
+
+    /// @notice The packed replay-protection bitmap: wordIndex => 256-bit word of flags.
+    mapping(uint256 => uint256) public bitmap;
+
+    /// @notice Check whether `nonce` has already been marked processed.
+    function isProcessed(uint256 nonce) external view returns (bool) {
+        return bitmap.isProcessed(nonce);
+    }
+
+    /// @notice Mark `nonce` processed, reverting with `NonceBitmap.AlreadyProcessed` if
+    ///         it was already marked.
+    function markProcessed(uint256 nonce) external {
+        bitmap.markProcessed(nonce);
+    }
+
+    /// @notice Mark a batch of nonces processed in a single call, so gas comparisons
+    ///         against a naive per-nonce mapping can isolate the storage bookkeeping
+    ///         cost from fixed per-transaction overhead (21,000 gas base cost, etc.)
+    ///         that both approaches would pay identically anyway.
+    function markProcessedBatch(uint256[] calldata nonces) external {
+        for (uint256 i = 0; i < nonces.length; i++) {
+            bitmap.markProcessed(nonces[i]);
+        }
+    }
+
+    /// @notice Read the raw storage word backing a given word index.
+    function getWord(uint256 wordIndex) external view returns (uint256) {
+        return bitmap[wordIndex];
+    }
+
+    /// @notice Expose the wordIndex/bitIndex split for a given nonce.
+    function locate(uint256 nonce) external pure returns (uint256 wordIndex, uint256 bitIndex) {
+        return NonceBitmap.locate(nonce);
+    }
+}

--- a/test/bridge/NaiveReplayGuard.sol
+++ b/test/bridge/NaiveReplayGuard.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @dev Test-only control contract for the gas-comparison benchmark in
+///      NonceBitmap.test.ts. Mirrors the "naive" boolean-per-message pattern the
+///      issue describes (`mapping(bytes32 => bool) public processedMessages`), just
+///      keyed by `uint256` nonce instead of `bytes32` message hash so the comparison
+///      is apples-to-apples against NonceBitmapWrapper (same nonce sequence, same
+///      cold-storage-slot-per-write cost model). Each processed nonce here always
+///      touches a brand-new storage slot, unlike the packed bitmap which reuses one
+///      word per 256 nonces.
+contract NaiveReplayGuard {
+    error AlreadyProcessed(uint256 nonce);
+
+    mapping(uint256 => bool) public processedMessages;
+
+    function markProcessed(uint256 nonce) external {
+        if (processedMessages[nonce]) revert AlreadyProcessed(nonce);
+        processedMessages[nonce] = true;
+    }
+
+    /// @dev Mirrors NonceBitmapWrapper.markProcessedBatch so the gas comparison
+    ///      isolates storage bookkeeping cost from fixed per-transaction overhead.
+    function markProcessedBatch(uint256[] calldata nonces) external {
+        for (uint256 i = 0; i < nonces.length; i++) {
+            uint256 nonce = nonces[i];
+            if (processedMessages[nonce]) revert AlreadyProcessed(nonce);
+            processedMessages[nonce] = true;
+        }
+    }
+}

--- a/test/bridge/NonceBitmap.test.ts
+++ b/test/bridge/NonceBitmap.test.ts
@@ -1,0 +1,163 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("NonceBitmap", () => {
+  let ethers: any;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+  });
+
+  async function deployWrapper() {
+    const Factory = await ethers.getContractFactory("NonceBitmapWrapper");
+    const wrapper = await Factory.deploy();
+    await wrapper.waitForDeployment();
+    return wrapper;
+  }
+
+  async function deployNaive() {
+    const Factory = await ethers.getContractFactory("NaiveReplayGuard");
+    const naive = await Factory.deploy();
+    await naive.waitForDeployment();
+    return naive;
+  }
+
+  describe("word/bit indexing", () => {
+    it("computes wordIndex = nonce / 256 and bitIndex = nonce % 256", async () => {
+      const wrapper = await deployWrapper();
+
+      let [wordIndex, bitIndex] = await wrapper.locate(0n);
+      expect(wordIndex).to.equal(0n);
+      expect(bitIndex).to.equal(0n);
+
+      [wordIndex, bitIndex] = await wrapper.locate(255n);
+      expect(wordIndex).to.equal(0n);
+      expect(bitIndex).to.equal(255n);
+
+      [wordIndex, bitIndex] = await wrapper.locate(256n);
+      expect(wordIndex).to.equal(1n);
+      expect(bitIndex).to.equal(0n);
+
+      [wordIndex, bitIndex] = await wrapper.locate(300n);
+      expect(wordIndex).to.equal(1n);
+      expect(bitIndex).to.equal(44n);
+    });
+  });
+
+  describe("sequential marking within one word", () => {
+    it("flips isProcessed false -> true for each nonce after marking", async () => {
+      const wrapper = await deployWrapper();
+
+      for (let nonce = 0; nonce < 20; nonce++) {
+        expect(await wrapper.isProcessed(nonce)).to.equal(false);
+        await (await wrapper.markProcessed(nonce)).wait();
+        expect(await wrapper.isProcessed(nonce)).to.equal(true);
+      }
+
+      // Unrelated, unmarked nonce in the same word must remain untouched.
+      expect(await wrapper.isProcessed(20)).to.equal(false);
+    });
+
+    it("packs all 20 flags into the single word-0 storage slot", async () => {
+      const wrapper = await deployWrapper();
+
+      let expectedWord = 0n;
+      for (let nonce = 0; nonce < 20; nonce++) {
+        await (await wrapper.markProcessed(nonce)).wait();
+        expectedWord |= 1n << BigInt(nonce);
+      }
+
+      expect(await wrapper.getWord(0)).to.equal(expectedWord);
+    });
+  });
+
+  describe("cross-word isolation", () => {
+    it("marking a nonce in a different word does not interfere with word 0", async () => {
+      const wrapper = await deployWrapper();
+
+      // Mark some nonces in word 0.
+      await (await wrapper.markProcessed(0)).wait();
+      await (await wrapper.markProcessed(5)).wait();
+      await (await wrapper.markProcessed(19)).wait();
+
+      // nonce 300 -> wordIndex 1, bitIndex 44.
+      expect(await wrapper.isProcessed(300)).to.equal(false);
+      await (await wrapper.markProcessed(300)).wait();
+      expect(await wrapper.isProcessed(300)).to.equal(true);
+
+      // word 0's bits must be unaffected by the word-1 write.
+      expect(await wrapper.isProcessed(0)).to.equal(true);
+      expect(await wrapper.isProcessed(5)).to.equal(true);
+      expect(await wrapper.isProcessed(19)).to.equal(true);
+      expect(await wrapper.isProcessed(1)).to.equal(false);
+      expect(await wrapper.isProcessed(299)).to.equal(false);
+      expect(await wrapper.isProcessed(301)).to.equal(false);
+
+      // word 0 storage itself must not contain bit 44 (that lives in word 1).
+      expect(await wrapper.getWord(0)).to.equal((1n << 0n) | (1n << 5n) | (1n << 19n));
+      expect(await wrapper.getWord(1)).to.equal(1n << 44n);
+    });
+  });
+
+  describe("replay protection", () => {
+    it("reverts with AlreadyProcessed when re-processing an already-marked nonce", async () => {
+      const wrapper = await deployWrapper();
+
+      await (await wrapper.markProcessed(42)).wait();
+      expect(await wrapper.isProcessed(42)).to.equal(true);
+
+      await expect(wrapper.markProcessed(42))
+        .to.be.revertedWithCustomError(wrapper, "AlreadyProcessed")
+        .withArgs(42n);
+    });
+
+    it("does not revert for a fresh nonce even if a different nonce in the same word is marked", async () => {
+      const wrapper = await deployWrapper();
+
+      await (await wrapper.markProcessed(7)).wait();
+      await expect(wrapper.markProcessed(8)).to.not.revert(ethers);
+    });
+  });
+
+  describe("gas comparison: packed bitmap vs naive bool-per-message mapping", () => {
+    // Both contracts expose a batch entry point (`markProcessedBatch`) that marks
+    // all 20 nonces inside ONE transaction/call. That isolates the storage
+    // bookkeeping cost this issue is actually about from the ~21,000 gas base
+    // transaction cost and calldata cost, which both approaches pay identically
+    // and which would otherwise swamp a per-transaction comparison.
+    it("uses substantially less gas for 20 sequential same-word nonces in one call", async () => {
+      const wrapper = await deployWrapper();
+      const naive = await deployNaive();
+      const nonces = Array.from({ length: 20 }, (_, i) => i);
+
+      const bitmapReceipt = await (await wrapper.markProcessedBatch(nonces)).wait();
+      const naiveReceipt = await (await naive.markProcessedBatch(nonces)).wait();
+
+      const bitmapGas: bigint = bitmapReceipt.gasUsed;
+      const naiveGas: bigint = naiveReceipt.gasUsed;
+
+      // Measured on hardhat's in-process EVM (solidity 0.8.24, evmVersion "cancun"),
+      // one transaction marking nonces 0..19 processed via markProcessedBatch:
+      //   naive  mapping(uint256 => bool), 20 nonces        -> naiveGas  = 476,603 gas
+      //   packed mapping(uint256 => uint256) bitmap,
+      //          20 nonces sharing storage word 0           -> bitmapGas =  67,369 gas
+      // ~85.9% reduction (409,234 gas saved). The naive guard pays a fresh cold
+      // SSTORE (20,000 base + 2,100 cold-access surcharge) for every one of the 20
+      // nonces, since each nonce is its own storage slot. The packed bitmap pays
+      // that cold SSTORE once (for word 0, on the first nonce) and then only cheap
+      // warm nonzero->nonzero SSTOREs (~2,900 gas) plus a handful of Yul
+      // SHR/SHL/OR/AND opcodes for the remaining 19 nonces, since they all share
+      // that same word.
+      // eslint-disable-next-line no-console
+      console.log(`      naive  batch gas (20 nonces, 1 word): ${naiveGas.toString()}`);
+      // eslint-disable-next-line no-console
+      console.log(`      bitmap batch gas (20 nonces, 1 word): ${bitmapGas.toString()}`);
+
+      expect(bitmapGas).to.be.lessThan(naiveGas);
+      // "Substantially" lower: require at least a 50% reduction, not just any
+      // improvement, to demonstrate the packed-word saving is meaningful.
+      expect(bitmapGas).to.be.lessThan(naiveGas / 2n);
+    });
+  });
+});


### PR DESCRIPTION
Closes #822

## Summary
- No existing `processedMessages` mapping to refactor — `contracts/execution/MessageReceiverCore.sol`'s `executeMessage(...)` takes a `messageId` but has zero replay protection today. Built `contracts/bridge/NonceBitmap.sol` as a standalone library (mirroring `contracts/crypto/BitmaskVerifierYul.sol`'s library + thin wrapper style) any contract can adopt by declaring one `mapping(uint256 => uint256)` state variable
- `wordIndex = nonce / 256`, `bitIndex = nonce % 256`; `isProcessed`/`markProcessed` both do the actual bit read/set inside `assembly` (`and(shr(...))` / `or(word, shl(...))`), per the issue's explicit requirement
- `markProcessed` is atomic check-and-set, reverting `AlreadyProcessed(nonce)` on replay — enforced protection, not just a queryable flag a caller could ignore

## Acceptance criteria
- [x] Replay verification gas drops substantially for sequential message execution — measured: naive `mapping(uint256 => bool)` at 476,603 gas for 20 nonces sharing a word vs. 67,369 gas packed (~86% reduction)
- [x] Replay protection prevents double-processing of identical nonces

## Test plan
- [x] `test/bridge/NonceBitmap.test.ts` — 7/7 passing (indexing math at boundaries, same-word/cross-word isolation, replay revert, the gas benchmark)
- [x] `npx hardhat compile` — clean, no new warnings
- [x] `MessageReceiverCore.sol` and all other existing files untouched
