### PR TITLE
Add Yul multi-signature batch recovery verifier for validator quorums

### DIFF
--- a/contracts/verifiers/YulMultiSigVerifier.sol
+++ b/contracts/verifiers/YulMultiSigVerifier.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title YulMultiSigVerifier
+/// @notice Gas-optimized Yul/Assembly multi-signature quorum verification engine.
+///         Iterates over validator signature arrays directly in calldata,
+///         without dynamic ABI decoding, and enforces a strict-ascending
+///         recovered-signer order to simultaneously prove signature ordering
+///         and reject duplicate signers.
+/// @dev Distinct from `BitmaskVerifierYul`: that contract tracks which
+///      validators have already matched via a `uint256` bitmask (clearing a
+///      bit once consumed). This contract instead requires the CALLER to
+///      supply signatures pre-sorted so that recovered signer addresses are
+///      strictly increasing (`recovered > lastSigner`). That single check
+///      is sufficient to reject both out-of-order submissions and duplicate
+///      signatures (a repeated address can never satisfy a strict `>`
+///      comparison against itself), with no bitmask/set bookkeeping needed.
+///      Reference validator membership is checked against a caller-supplied
+///      `sortedValidators` calldata array (also expected sorted ascending)
+///      using binary search, since it is sorted.
+library YulMultiSigVerifier {
+    /// @notice `packedSignatures.length` is not a multiple of 65 bytes.
+    error InvalidSignatureLength();
+
+    /// @notice The signature at `index` failed to recover a valid (non-zero) address.
+    error InvalidSignature(uint256 index);
+
+    /// @notice The signer recovered at `index` is not strictly greater than the
+    ///         previously recovered signer, i.e. the signatures were not
+    ///         supplied in strictly-ascending signer-address order. This is
+    ///         also the mechanism that rejects an outright duplicate
+    ///         signature/signer, since a repeated address cannot be strictly
+    ///         greater than itself.
+    error UnsortedOrDuplicateSignature(uint256 index);
+
+    /// @notice Fewer than `threshold` recovered signers matched the reference
+    ///         validator set.
+    error QuorumNotMet(uint256 validCount, uint256 threshold);
+
+    /// @notice Verify that at least `threshold` signatures in `packedSignatures`
+    ///         recover to distinct, strictly-ordered addresses that belong to
+    ///         `sortedValidators`.
+    /// @param messageHash        The raw (unprefixed) message hash that each
+    ///                            validator signed via the standard
+    ///                            `\x19Ethereum Signed Message:\n32` prefix.
+    /// @param packedSignatures   Concatenated [r(32), s(32), v(1)] tuples,
+    ///                           65 bytes per signature, read directly from
+    ///                           calldata (no memory array is ever built).
+    /// @param sortedValidators   Reference validator set, sorted ascending by
+    ///                           address, supplied as a calldata array so
+    ///                           membership can be checked via binary search
+    ///                           without copying it into memory.
+    /// @param threshold          Minimum number of valid, sorted, distinct
+    ///                           validator signatures required.
+    /// @return True if the quorum threshold is met.
+    function verifyQuorum(
+        bytes32 messageHash,
+        bytes calldata packedSignatures,
+        address[] calldata sortedValidators,
+        uint256 threshold
+    ) internal view returns (bool) {
+        if (packedSignatures.length % 65 != 0) revert InvalidSignatureLength();
+        uint256 sigCount = packedSignatures.length / 65;
+
+        // Computed once, outside the loop: every signature is over the same
+        // message, so there is nothing to recompute per-iteration (unlike a
+        // per-index challenge scheme).
+        bytes32 ethSignedMessageHash = keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash)
+        );
+
+        address lastSigner = address(0);
+        uint256 validCount = 0;
+
+        // The ecrecover scratch-space trick below deliberately writes into
+        // 0x00-0x80, which OVERLAPS Solidity's reserved free-memory-pointer
+        // slot at 0x40. If left clobbered, every later Solidity-level
+        // memory operation in this call (ABI-encoding a custom error on
+        // revert, or ABI-encoding the final `bool` return value) would read
+        // a corrupted pointer and attempt a huge, gas-exhausting memory
+        // expansion. We snapshot the genuine free-memory pointer once,
+        // before the loop, and restore it after every scratch-space use so
+        // the rest of the function keeps behaving normally.
+        uint256 freeMemPtr;
+        assembly {
+            freeMemPtr := mload(0x40)
+        }
+
+        for (uint256 i = 0; i < sigCount; ) {
+            bytes32 r;
+            bytes32 s;
+            uint8 v;
+
+            assembly {
+                // 65 bytes per signature: r(32) || s(32) || v(1).
+                let sigOffset := add(packedSignatures.offset, mul(i, 65))
+                r := calldataload(sigOffset)
+                s := calldataload(add(sigOffset, 32))
+                v := byte(0, calldataload(add(sigOffset, 64)))
+            }
+
+            address signer;
+            assembly {
+                // Scratch space layout for the ecrecover precompile call:
+                //   0x00: hash, 0x20: v, 0x40: r, 0x60: s -> input (0x00..0x80)
+                //   0x80: recovered address                -> output (0x80..0xa0)
+                // Every iteration reuses these same fixed offsets, so memory
+                // is only ever expanded to 0xa0 once (on the first
+                // iteration) and never grows again as the loop continues —
+                // this is what gives zero incremental memory-expansion cost
+                // per additional signature.
+                mstore(0x00, ethSignedMessageHash)
+                mstore(0x20, v)
+                mstore(0x40, r)
+                mstore(0x60, s)
+                let success := staticcall(gas(), 0x01, 0x00, 0x80, 0x80, 0x20)
+                signer := mload(0x80)
+                if iszero(success) { signer := 0 }
+                // Restore the free-memory pointer we just overwrote via
+                // `mstore(0x40, r)` above.
+                mstore(0x40, freeMemPtr)
+            }
+
+            if (signer == address(0)) revert InvalidSignature(i);
+
+            // Strict ascending check: simultaneously enforces sort order and
+            // rejects duplicates (a repeated signer can't be > itself).
+            if (signer <= lastSigner) revert UnsortedOrDuplicateSignature(i);
+            lastSigner = signer;
+
+            if (_isValidator(sortedValidators, signer)) {
+                unchecked { ++validCount; }
+            }
+
+            unchecked { ++i; }
+        }
+
+        if (validCount < threshold) revert QuorumNotMet(validCount, threshold);
+        return true;
+    }
+
+    /// @dev Binary search over `sortedValidators` (assumed sorted ascending
+    ///      by the caller, as documented on `verifyQuorum`). Reads elements
+    ///      directly out of calldata; no copy into memory is made.
+    function _isValidator(address[] calldata sortedValidators, address signer)
+        private
+        pure
+        returns (bool)
+    {
+        uint256 lo = 0;
+        uint256 hi = sortedValidators.length;
+
+        while (lo < hi) {
+            uint256 mid = (lo + hi) / 2;
+            address candidate = sortedValidators[mid];
+            if (candidate == signer) {
+                return true;
+            }
+            if (candidate < signer) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+
+        return false;
+    }
+}
+
+/// @dev Wrapper contract to expose the library for testing.
+contract YulMultiSigVerifierWrapper {
+    function verifyQuorum(
+        bytes32 messageHash,
+        bytes calldata packedSignatures,
+        address[] calldata sortedValidators,
+        uint256 threshold
+    ) external view returns (bool) {
+        return YulMultiSigVerifier.verifyQuorum(
+            messageHash, packedSignatures, sortedValidators, threshold
+        );
+    }
+}

--- a/test/verifiers/YulMultiSigVerifier.test.ts
+++ b/test/verifiers/YulMultiSigVerifier.test.ts
@@ -1,0 +1,216 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("YulMultiSigVerifier", () => {
+  let ethers: any;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+  });
+
+  async function deploy() {
+    const Factory = await ethers.getContractFactory("YulMultiSigVerifierWrapper");
+    const wrapper = await Factory.deploy();
+    await wrapper.waitForDeployment();
+    return { wrapper };
+  }
+
+  function randomWallets(count: number) {
+    const wallets = [];
+    for (let i = 0; i < count; i++) {
+      wallets.push(ethers.Wallet.createRandom());
+    }
+    return wallets;
+  }
+
+  function byAddressAscending(a: any, b: any) {
+    return a.address.toLowerCase() < b.address.toLowerCase() ? -1 : 1;
+  }
+
+  // Signs `messageHash` (personal_sign / EIP-191 style, matching the
+  // contract's "\x19Ethereum Signed Message:\n32" prefix) with each wallet
+  // in `wallets`, IN THE ORDER GIVEN, and packs the resulting signatures as
+  // 65-byte [r(32) || s(32) || v(1)] tuples concatenated together. The
+  // caller is responsible for ordering `wallets` however the test scenario
+  // requires (ascending-by-address for the happy path, or deliberately out
+  // of order / duplicated to exercise rejection paths).
+  async function packSignatures(wallets: any[], messageHash: string) {
+    const chunks: string[] = [];
+    for (const wallet of wallets) {
+      const sig = await wallet.signMessage(ethers.getBytes(messageHash));
+      const { r, s, v } = ethers.Signature.from(sig);
+      chunks.push(ethers.solidityPacked(["bytes32", "bytes32", "uint8"], [r, s, v]));
+    }
+    return ethers.concat(chunks);
+  }
+
+  let messageHash: string;
+
+  beforeEach(() => {
+    messageHash = ethers.keccak256(ethers.toUtf8Bytes("YulMultiSigVerifier quorum payload"));
+  });
+
+  it("accepts a valid quorum of correctly-sorted, distinct validator signatures", async () => {
+    const { wrapper } = await deploy();
+
+    const validators = randomWallets(5).sort(byAddressAscending);
+    const sortedValidatorAddresses = validators.map((w) => w.address);
+
+    // Take a subset (3 of 5) in ascending-address order to meet a threshold of 3.
+    const signingSet = [validators[0], validators[2], validators[4]];
+    const packedSignatures = await packSignatures(signingSet, messageHash);
+
+    const result = await wrapper.verifyQuorum(
+      messageHash,
+      packedSignatures,
+      sortedValidatorAddresses,
+      3
+    );
+    expect(result).to.equal(true);
+  });
+
+  it("rejects signatures not in strictly-ascending recovered-address order", async () => {
+    const { wrapper } = await deploy();
+
+    const validators = randomWallets(5).sort(byAddressAscending);
+    const sortedValidatorAddresses = validators.map((w) => w.address);
+
+    const signingSet = [validators[0], validators[2], validators[4]];
+    // Reverse the signing order: descending instead of ascending. The
+    // first comparison (index 0) always passes (lastSigner starts at 0),
+    // so the violation is detected at index 1.
+    const packedSignatures = await packSignatures([...signingSet].reverse(), messageHash);
+
+    await expect(
+      wrapper.verifyQuorum(messageHash, packedSignatures, sortedValidatorAddresses, 3)
+    )
+      .to.be.revertedWithCustomError(wrapper, "UnsortedOrDuplicateSignature")
+      .withArgs(1);
+  });
+
+  it("rejects a duplicate signature (same signer twice)", async () => {
+    const { wrapper } = await deploy();
+
+    const validators = randomWallets(3).sort(byAddressAscending);
+    const sortedValidatorAddresses = validators.map((w) => w.address);
+
+    // Same validator's signature repeated: the second recovers the same
+    // address as the first, so `signer <= lastSigner` trips at index 1.
+    const packedSignatures = await packSignatures(
+      [validators[0], validators[0]],
+      messageHash
+    );
+
+    await expect(
+      wrapper.verifyQuorum(messageHash, packedSignatures, sortedValidatorAddresses, 1)
+    )
+      .to.be.revertedWithCustomError(wrapper, "UnsortedOrDuplicateSignature")
+      .withArgs(1);
+  });
+
+  it("excludes a non-validator signer from the valid count and fails quorum", async () => {
+    const { wrapper } = await deploy();
+
+    const validators = randomWallets(2).sort(byAddressAscending);
+    const sortedValidatorAddresses = validators.map((w) => w.address);
+
+    const outsider = ethers.Wallet.createRandom();
+
+    // Sign with both real validators plus an outsider, all packed in
+    // strictly-ascending address order so the ordering check passes and
+    // only the membership check filters the outsider out.
+    const signingSet = [...validators, outsider].sort(byAddressAscending);
+    const packedSignatures = await packSignatures(signingSet, messageHash);
+
+    // 3 signatures recovered and sorted correctly, but only 2 are actual
+    // validators -> validCount = 2, which is below a threshold of 3.
+    await expect(
+      wrapper.verifyQuorum(messageHash, packedSignatures, sortedValidatorAddresses, 3)
+    )
+      .to.be.revertedWithCustomError(wrapper, "QuorumNotMet")
+      .withArgs(2, 3);
+  });
+
+  it("rejects when quorum threshold is not met", async () => {
+    const { wrapper } = await deploy();
+
+    const validators = randomWallets(5).sort(byAddressAscending);
+    const sortedValidatorAddresses = validators.map((w) => w.address);
+
+    // Only 1 signature submitted against a threshold of 3.
+    const packedSignatures = await packSignatures([validators[0]], messageHash);
+
+    await expect(
+      wrapper.verifyQuorum(messageHash, packedSignatures, sortedValidatorAddresses, 3)
+    )
+      .to.be.revertedWithCustomError(wrapper, "QuorumNotMet")
+      .withArgs(1, 3);
+  });
+
+  describe("zero memory-expansion overhead", () => {
+    // Rather than asserting an exact gas figure (fragile across compiler /
+    // optimizer versions), we assert that gas scales roughly LINEARLY with
+    // the number of signatures rather than super-linearly, which is what
+    // would happen if a `bytes[]` / tuple array were being built up in
+    // memory per-signature (memory expansion cost is quadratic-ish: cost
+    // grows with the square of the highest memory word touched). Because
+    // this contract only ever touches a fixed 0x00-0xa0 scratch window
+    // regardless of loop index, the marginal cost per extra signature
+    // should stay essentially flat (dominated by the ~3000 gas ecrecover
+    // precompile charge + calldata reads + a small binary-search cost),
+    // not grow with `i`.
+    async function measureGas(sigCounts: number[]) {
+      const { wrapper } = await deploy();
+      const results: Record<number, bigint> = {};
+
+      for (const count of sigCounts) {
+        const validators = randomWallets(count).sort(byAddressAscending);
+        const sortedValidatorAddresses = validators.map((w) => w.address);
+        const packedSignatures = await packSignatures(validators, messageHash);
+
+        const gas: bigint = await wrapper.verifyQuorum.estimateGas(
+          messageHash,
+          packedSignatures,
+          sortedValidatorAddresses,
+          count
+        );
+        results[count] = gas;
+      }
+
+      return results;
+    }
+
+    it("scales roughly linearly (flat marginal cost) from 5 to 20 signatures", async () => {
+      const gasByCount = await measureGas([5, 10, 20]);
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `Measured gas — 5 sigs: ${gasByCount[5]}, 10 sigs: ${gasByCount[10]}, 20 sigs: ${gasByCount[20]}`
+      );
+
+      const marginal5to10 = (gasByCount[10] - gasByCount[5]) / 5n;
+      const marginal10to20 = (gasByCount[20] - gasByCount[10]) / 10n;
+
+      console.log(
+        `Marginal gas/signature — 5->10: ${marginal5to10}, 10->20: ${marginal10to20}`
+      );
+
+      // If memory were being expanded per-signature (e.g. building a
+      // decoded array in memory), the marginal cost of the *second* half
+      // of the batch would be visibly larger than the first half's,
+      // because memory-expansion cost grows with the square of the
+      // highest word touched. With zero per-iteration memory growth, the
+      // two marginal rates should be close to each other. We allow a
+      // generous 2x band to absorb the binary-search's O(log n) growth
+      // and any incidental variance.
+      expect(marginal10to20).to.be.lessThan(marginal5to10 * 2n);
+
+      // Absolute, coarse ceiling: a naive per-signature memory-expanding
+      // implementation at 20 signatures would blow well past this (each
+      // additional 32/65-byte memory allocation compounds quadratically).
+      // A flat-scratch-space implementation comfortably clears it.
+      expect(gasByCount[20]).to.be.lessThan(500_000n);
+    });
+  });
+});


### PR DESCRIPTION
Closes #824

## Summary
`contracts/crypto/BitmaskVerifierYul.sol` already does something similar but via a validator bitmask, not a sorted list — the issue explicitly asks for the sorted-ascending-address technique (classic multisig pattern), so this is a deliberately distinct contract reusing that file's low-level calldata-reading/ecrecover-via-scratch-space Yul techniques, not a copy of its verification strategy.

- `verifyQuorum(messageHash, packedSignatures, sortedValidators, threshold)`: reads 65-byte signatures directly from `calldata` via `calldataload` (no memory array), recovers each signer via manual `ecrecover` scratch-space `staticcall`
- Ordering/duplicate check: tracks `lastSigner`, requires strictly `signer > lastSigner` at each step — one check proves both ascending order and absence of duplicates
- Validator membership: binary search over the sorted `sortedValidators` calldata array
- Custom errors: `InvalidSignatureLength`, `InvalidSignature(index)`, `UnsortedOrDuplicateSignature(index)`, `QuorumNotMet(validCount, threshold)`

## Real bug found in existing code (not fixed here — flagging for a follow-up)
`BitmaskVerifierYul.sol`'s ecrecover scratch-space code writes `mstore(0x40, r)`, clobbering Solidity's free-memory-pointer slot. Its own test suite never exercises `verifyThreshold` with real signatures, so this was never caught. Fixed only in this new contract (snapshot/restore the free-memory pointer around scratch-space use) — the existing file itself is untouched and still has this latent bug.

## Acceptance criteria
- [x] Verifies validator quorum thresholds with zero memory expansion overhead — measured 5/10/20-signature gas (58,743 / 99,347 / 189,141), marginal cost per signature stays flat (~8-9k), no quadratic blowup
- [x] Rejects invalid, unsorted, or duplicate validator signatures

## Test plan
- [x] `test/verifiers/YulMultiSigVerifier.test.ts` — 6/6 passing
- [x] `npx hardhat compile` — clean, no new warnings
- [x] `BitmaskVerifierYul.sol` and all other existing files untouched
