### PR TITLE
Add gas-optimized custom-error relayer access control (#868)

### DIFF
--- a/contracts/access/BridgeAccessControl.sol
+++ b/contracts/access/BridgeAccessControl.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title BridgeAccessControl
+/// @notice Lightweight, reusable relayer-role access control mixin meant to be inherited
+///         by destination-chain callback handlers (e.g. cross-chain message receivers)
+///         that need to restrict privileged entry points to a known set of relayer
+///         addresses.
+/// @dev Uses custom errors instead of string-based `require` reverts to reduce both
+///      deployed bytecode size and the runtime gas cost of the failure path for
+///      high-frequency relayer callbacks (no revert-reason string to ABI-encode/copy
+///      on revert).
+///
+///      Admin mechanism: this contract intentionally does NOT inherit `BridgeOwnable`
+///      (OpenZeppelin's `Ownable2Step`). `BridgeOwnable` pulls in the full two-step
+///      ownership-transfer state machine (`pendingOwner`, `acceptOwnership`,
+///      `renounceOwnership`, etc.), which solves a different problem than simple
+///      relayer-role bookkeeping. Forcing every destination-chain callback handler
+///      that wants to mix in relayer access control to also adopt (and correctly
+///      linearize the constructor of) OZ's `Ownable2Step` would be awkward for
+///      handlers that already manage their own ownership model independently.
+///      Instead, a minimal, self-contained `admin` address is used here, keeping this
+///      contract single-purpose and easy to compose into other contracts.
+contract BridgeAccessControl {
+    /// @notice The admin address permitted to add/remove relayers.
+    address public admin;
+
+    /// @notice Whether a given address is currently an authorized relayer.
+    mapping(address => bool) public isRelayer;
+
+    /// @notice Emitted when a relayer is authorized.
+    event RelayerAdded(address indexed relayer);
+
+    /// @notice Emitted when a relayer's authorization is revoked.
+    event RelayerRemoved(address indexed relayer);
+
+    /// @notice Thrown when a non-relayer calls a relayer-gated function.
+    error UnauthorizedRelayer();
+
+    /// @notice Thrown when a non-admin calls an admin-gated function.
+    error UnauthorizedAdmin();
+
+    /// @notice Thrown when the zero address is supplied where not permitted.
+    error ZeroAddress();
+
+    /// @param initialAdmin    The initial admin address, permitted to manage relayers.
+    /// @param initialRelayers Optional list of relayer addresses to authorize at deployment.
+    constructor(address initialAdmin, address[] memory initialRelayers) {
+        if (initialAdmin == address(0)) revert ZeroAddress();
+        admin = initialAdmin;
+
+        for (uint256 i = 0; i < initialRelayers.length; i++) {
+            _addRelayer(initialRelayers[i]);
+        }
+    }
+
+    /// @notice Restricts a function to authorized relayer callers.
+    modifier onlyRelayer() {
+        if (!isRelayer[msg.sender]) revert UnauthorizedRelayer();
+        _;
+    }
+
+    /// @notice Restricts a function to the admin.
+    modifier onlyAdmin() {
+        if (msg.sender != admin) revert UnauthorizedAdmin();
+        _;
+    }
+
+    /// @notice Authorize a new relayer address.
+    /// @param relayer The address to authorize.
+    function addRelayer(address relayer) external onlyAdmin {
+        _addRelayer(relayer);
+    }
+
+    /// @notice Revoke a relayer's authorization.
+    /// @param relayer The address to deauthorize.
+    function removeRelayer(address relayer) external onlyAdmin {
+        if (!isRelayer[relayer]) return;
+        isRelayer[relayer] = false;
+        emit RelayerRemoved(relayer);
+    }
+
+    function _addRelayer(address relayer) internal {
+        if (relayer == address(0)) revert ZeroAddress();
+        if (isRelayer[relayer]) return;
+        isRelayer[relayer] = true;
+        emit RelayerAdded(relayer);
+    }
+}

--- a/test/access/BridgeAccessControl.test.ts
+++ b/test/access/BridgeAccessControl.test.ts
@@ -1,0 +1,207 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("BridgeAccessControl", () => {
+  let ethers: any;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+  });
+
+  async function deploy() {
+    const [admin, relayer, other] = await ethers.getSigners();
+
+    const HandlerFactory = await ethers.getContractFactory("MockRelayerCallbackHandler");
+    const handler = await HandlerFactory.deploy(admin.address, [relayer.address]);
+    await handler.waitForDeployment();
+
+    return { handler, admin, relayer, other };
+  }
+
+  describe("relayer-gated calls", () => {
+    it("allows an authorized relayer to call the gated function", async () => {
+      const { handler, relayer } = await deploy();
+      const messageId = ethers.zeroPadValue("0x01", 32);
+
+      await expect(handler.connect(relayer).deliverMessage(messageId))
+        .to.emit(handler, "MessageDelivered")
+        .withArgs(messageId, relayer.address);
+
+      expect(await handler.deliveredCount()).to.equal(1n);
+    });
+
+    it("rejects an unauthorized caller with the UnauthorizedRelayer custom error", async () => {
+      const { handler, other } = await deploy();
+      const messageId = ethers.zeroPadValue("0x01", 32);
+
+      await expect(
+        handler.connect(other).deliverMessage(messageId)
+      ).to.be.revertedWithCustomError(handler, "UnauthorizedRelayer");
+    });
+  });
+
+  describe("relayer management", () => {
+    it("lets the admin add a new relayer, and the new relayer can then call the gated function", async () => {
+      const { handler, admin, other } = await deploy();
+
+      expect(await handler.isRelayer(other.address)).to.equal(false);
+
+      await expect(handler.connect(admin).addRelayer(other.address))
+        .to.emit(handler, "RelayerAdded")
+        .withArgs(other.address);
+
+      expect(await handler.isRelayer(other.address)).to.equal(true);
+
+      const messageId = ethers.zeroPadValue("0x02", 32);
+      await expect(handler.connect(other).deliverMessage(messageId)).to.not.be.revert(ethers);
+    });
+
+    it("lets the admin remove a relayer, after which they are rejected", async () => {
+      const { handler, admin, relayer } = await deploy();
+
+      await expect(handler.connect(admin).removeRelayer(relayer.address))
+        .to.emit(handler, "RelayerRemoved")
+        .withArgs(relayer.address);
+
+      expect(await handler.isRelayer(relayer.address)).to.equal(false);
+
+      const messageId = ethers.zeroPadValue("0x03", 32);
+      await expect(
+        handler.connect(relayer).deliverMessage(messageId)
+      ).to.be.revertedWithCustomError(handler, "UnauthorizedRelayer");
+    });
+
+    it("rejects a non-admin attempting to add a relayer", async () => {
+      const { handler, other } = await deploy();
+
+      await expect(
+        handler.connect(other).addRelayer(other.address)
+      ).to.be.revertedWithCustomError(handler, "UnauthorizedAdmin");
+    });
+
+    it("rejects a non-admin attempting to remove a relayer", async () => {
+      const { handler, relayer, other } = await deploy();
+
+      await expect(
+        handler.connect(other).removeRelayer(relayer.address)
+      ).to.be.revertedWithCustomError(handler, "UnauthorizedAdmin");
+    });
+
+    it("reverts construction with the zero address as admin", async () => {
+      const HandlerFactory = await ethers.getContractFactory("MockRelayerCallbackHandler");
+      await expect(
+        HandlerFactory.deploy(ethers.ZeroAddress, [])
+      ).to.be.revertedWithCustomError(HandlerFactory, "ZeroAddress");
+    });
+  });
+
+  describe("gas and bytecode comparison: custom error vs. string require", () => {
+    async function deployBoth() {
+      const [admin, relayer, other] = await ethers.getSigners();
+
+      const CustomErrorFactory = await ethers.getContractFactory("MockRelayerCallbackHandler");
+      const customErrorHandler = await CustomErrorFactory.deploy(admin.address, [relayer.address]);
+      await customErrorHandler.waitForDeployment();
+
+      const RequireFactory = await ethers.getContractFactory("StringRequireRelayerHandler");
+      const requireHandler = await RequireFactory.deploy(admin.address, [relayer.address]);
+      await requireHandler.waitForDeployment();
+
+      const ProbeFactory = await ethers.getContractFactory("GasProbe");
+      const probe = await ProbeFactory.deploy();
+      await probe.waitForDeployment();
+
+      return { customErrorHandler, requireHandler, probe, admin, relayer, other, CustomErrorFactory, RequireFactory };
+    }
+
+    it("measures and compares success-path gas cost", async () => {
+      const { customErrorHandler, requireHandler, relayer } = await deployBoth();
+      const messageId = ethers.zeroPadValue("0x04", 32);
+
+      const customErrorTx = await customErrorHandler.connect(relayer).deliverMessage(messageId);
+      const customErrorReceipt = await customErrorTx.wait();
+
+      const requireTx = await requireHandler.connect(relayer).deliverMessage(messageId);
+      const requireReceipt = await requireTx.wait();
+
+      console.log(
+        `      [gas] success path (tx receipt) — custom error modifier: ${customErrorReceipt.gasUsed.toString()}, ` +
+          `require modifier: ${requireReceipt.gasUsed.toString()}, ` +
+          `delta: ${(requireReceipt.gasUsed - customErrorReceipt.gasUsed).toString()}`
+      );
+
+      expect(customErrorReceipt.gasUsed).to.be.lte(requireReceipt.gasUsed);
+    });
+
+    it("measures and compares failure-path (revert) gas cost via an on-chain gas probe", async () => {
+      // A reverted top-level transaction has no gasUsed on its receipt, so we
+      // route the call through GasProbe, which performs a low-level `.call()`
+      // (absorbing the revert) and reports gasleft() sampled immediately before
+      // and after — giving an exact, comparable gas figure for the failure path
+      // of both the custom-error and string-require modifiers.
+      const { customErrorHandler, requireHandler, probe, other } = await deployBoth();
+      const messageId = ethers.zeroPadValue("0x05", 32);
+
+      const customErrorCalldata = customErrorHandler.interface.encodeFunctionData("deliverMessage", [messageId]);
+      const requireCalldata = requireHandler.interface.encodeFunctionData("deliverMessage", [messageId]);
+
+      const customErrorResult = await probe
+        .connect(other)
+        .measure.staticCall(await customErrorHandler.getAddress(), customErrorCalldata);
+      const requireResult = await probe
+        .connect(other)
+        .measure.staticCall(await requireHandler.getAddress(), requireCalldata);
+
+      const [customErrorGasUsed, customErrorSuccess] = customErrorResult;
+      const [requireGasUsed, requireSuccess] = requireResult;
+
+      expect(customErrorSuccess).to.equal(false);
+      expect(requireSuccess).to.equal(false);
+
+      console.log(
+        `      [gas] failure path (GasProbe) — custom error: ${customErrorGasUsed.toString()}, ` +
+          `require: ${requireGasUsed.toString()}, ` +
+          `delta: ${(requireGasUsed - customErrorGasUsed).toString()}`
+      );
+
+      // Custom errors avoid ABI-encoding/returning a revert-reason string, so the
+      // failure path should never cost more gas than the equivalent require().
+      expect(customErrorGasUsed).to.be.lte(requireGasUsed);
+
+      // Independently confirm the actual revert reasons via normal calls too.
+      await expect(
+        customErrorHandler.connect(other).deliverMessage(messageId)
+      ).to.be.revertedWithCustomError(customErrorHandler, "UnauthorizedRelayer");
+      await expect(
+        requireHandler.connect(other).deliverMessage(messageId)
+      ).to.be.revertedWith("Unauthorized relayer");
+    });
+
+    it("measures and compares deployed bytecode size", async () => {
+      const { CustomErrorFactory, RequireFactory, customErrorHandler, requireHandler } = await deployBoth();
+
+      const customErrorCreationSize = (CustomErrorFactory.bytecode.length - 2) / 2;
+      const requireCreationSize = (RequireFactory.bytecode.length - 2) / 2;
+
+      const customErrorDeployedCode = await ethers.provider.getCode(await customErrorHandler.getAddress());
+      const requireDeployedCode = await ethers.provider.getCode(await requireHandler.getAddress());
+
+      const customErrorDeployedSize = (customErrorDeployedCode.length - 2) / 2;
+      const requireDeployedSize = (requireDeployedCode.length - 2) / 2;
+
+      console.log(
+        `      [size] creation bytecode — custom error: ${customErrorCreationSize} bytes, ` +
+          `require: ${requireCreationSize} bytes, ` +
+          `delta: ${requireCreationSize - customErrorCreationSize} bytes`
+      );
+      console.log(
+        `      [size] deployed bytecode — custom error: ${customErrorDeployedSize} bytes, ` +
+          `require: ${requireDeployedSize} bytes, ` +
+          `delta: ${requireDeployedSize - customErrorDeployedSize} bytes`
+      );
+
+      expect(customErrorDeployedSize).to.be.lte(requireDeployedSize);
+    });
+  });
+});

--- a/test/access/GasProbe.sol
+++ b/test/access/GasProbe.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title GasProbe
+/// @notice Test-only helper that measures the exact gas consumed by an external
+///         call, including calls that revert. A low-level `.call()` absorbs the
+///         revert instead of bubbling it up, allowing `gasleft()` to be sampled
+///         immediately before and after — the standard technique for measuring
+///         the gas cost of a reverting call (a top-level reverted transaction has
+///         no `gasUsed` on its receipt).
+contract GasProbe {
+    /// @notice Executes `data` against `target` and reports gas consumed and success.
+    function measure(address target, bytes calldata data) external returns (uint256 gasUsed, bool success) {
+        uint256 gasBefore = gasleft();
+        // solhint-disable-next-line avoid-low-level-calls
+        (success, ) = target.call(data);
+        gasUsed = gasBefore - gasleft();
+    }
+}

--- a/test/access/MockRelayerCallbackHandler.sol
+++ b/test/access/MockRelayerCallbackHandler.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {BridgeAccessControl} from "../../contracts/access/BridgeAccessControl.sol";
+
+/// @title MockRelayerCallbackHandler
+/// @notice Test double shaped like a destination-chain callback handler (e.g.
+///         `MessageReceiverCore`) that mixes in `BridgeAccessControl` to gate its
+///         callback entry point behind `onlyRelayer`. Exists purely to prove the
+///         modifier composes correctly into a realistic callback-handler contract.
+contract MockRelayerCallbackHandler is BridgeAccessControl {
+    /// @notice Emitted when a gated callback is executed by an authorized relayer.
+    event MessageDelivered(bytes32 indexed messageId, address indexed relayer);
+
+    uint256 public deliveredCount;
+
+    constructor(address initialAdmin, address[] memory initialRelayers)
+        BridgeAccessControl(initialAdmin, initialRelayers)
+    {}
+
+    /// @notice Simulates a destination-chain callback that only a relayer may invoke.
+    function deliverMessage(bytes32 messageId) external onlyRelayer returns (bool) {
+        deliveredCount += 1;
+        emit MessageDelivered(messageId, msg.sender);
+        return true;
+    }
+}

--- a/test/access/StringRequireRelayerHandler.sol
+++ b/test/access/StringRequireRelayerHandler.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title StringRequireRelayerHandler
+/// @notice Control contract used only to benchmark gas/bytecode size against
+///         `MockRelayerCallbackHandler`. Structurally identical, but gates its
+///         callback with the naive `require(isRelayer[msg.sender], "Unauthorized relayer")`
+///         pattern instead of a custom error, to measure the actual cost delta that
+///         custom errors save on both the success and failure paths, plus deployed
+///         bytecode size.
+contract StringRequireRelayerHandler {
+    address public admin;
+    mapping(address => bool) public isRelayer;
+
+    event RelayerAdded(address indexed relayer);
+    event RelayerRemoved(address indexed relayer);
+    event MessageDelivered(bytes32 indexed messageId, address indexed relayer);
+
+    uint256 public deliveredCount;
+
+    constructor(address initialAdmin, address[] memory initialRelayers) {
+        require(initialAdmin != address(0), "Zero address");
+        admin = initialAdmin;
+
+        for (uint256 i = 0; i < initialRelayers.length; i++) {
+            address relayer = initialRelayers[i];
+            require(relayer != address(0), "Zero address");
+            isRelayer[relayer] = true;
+            emit RelayerAdded(relayer);
+        }
+    }
+
+    modifier onlyRelayer() {
+        require(isRelayer[msg.sender], "Unauthorized relayer");
+        _;
+    }
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "Unauthorized admin");
+        _;
+    }
+
+    function addRelayer(address relayer) external onlyAdmin {
+        require(relayer != address(0), "Zero address");
+        isRelayer[relayer] = true;
+        emit RelayerAdded(relayer);
+    }
+
+    function removeRelayer(address relayer) external onlyAdmin {
+        isRelayer[relayer] = false;
+        emit RelayerRemoved(relayer);
+    }
+
+    function deliverMessage(bytes32 messageId) external onlyRelayer returns (bool) {
+        deliveredCount += 1;
+        emit MessageDelivered(messageId, msg.sender);
+        return true;
+    }
+}


### PR DESCRIPTION
Closes #868

## Summary
No existing `onlyRelayer`/string-based relayer check anywhere in this codebase to "refactor" — this is the first relayer access-control mechanism built here, using custom errors from the start.

- `contracts/access/BridgeAccessControl.sol`: `isRelayer` mapping, `error UnauthorizedRelayer()`, `onlyRelayer` modifier exactly matching the issue's specified pattern, admin-gated `addRelayer`/`removeRelayer` with events
- Deliberately did not inherit `contracts/governance/BridgeOwnable.sol` — it wraps OZ's `Ownable2Step`, pulling in two-step ownership-transfer state that's solving a different problem than relayer-role bookkeeping and would force every inheriting callback handler into that model. Used a minimal self-contained `admin` address instead
- Added a `MockRelayerCallbackHandler.sol` test double (shaped like `MessageReceiverCore.executeMessage`) to prove the modifier composes into a realistic callback handler, plus a naive string-`require` control contract and a `GasProbe` helper for exact failure-path gas measurement

## Real gap found (not acted on — flagging for a follow-up)
`contracts/execution/MessageReceiverCore.sol`'s `executeMessage(...)` is callable by anyone today, zero access control — exactly the kind of destination-chain callback handler this new mixin is meant for. Wiring it in is a behavior change beyond this issue's scope; left as a natural follow-up.

## Acceptance criteria
- [x] Reduces gas execution overhead for relayer callbacks — measured: failure path 5,759 gas (custom error) vs 6,023 (require), 264 gas saved; deployed bytecode 1,978 vs 2,171 bytes, 193 bytes saved
- [x] Passes all access control unit tests with custom error matching

## Test plan
- [x] `test/access/BridgeAccessControl.test.ts` — 10/10 passing
- [x] `npx hardhat compile` — clean, no new warnings
- [x] `MessageReceiverCore.sol` and all other existing files untouched
