### PR TITLE
feat(crypto): add Yul Groth16 pairing-precompile verification wrapper

### DIFF
--- a/contracts/crypto/YulGroth16Verifier.sol
+++ b/contracts/crypto/YulGroth16Verifier.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title YulGroth16Verifier
+/// @notice Gas-optimized Groth16 proof verification over BN254 (alt_bn128).
+///         Proof points, the verifying key and the accumulated public-input
+///         commitment are staged directly into a single contiguous memory
+///         buffer and handed to the pairing precompile at `0x08`, avoiding the
+///         stack shuffling and repeated memory allocation that a high-level
+///         Solidity verifier emits when assembling the same call.
+///
+/// @dev Verification checks the standard Groth16 equation
+///
+///          e(A, B) == e(alpha, beta) * e(vk_x, gamma) * e(C, delta)
+///
+///      rearranged into the single product the pairing precompile evaluates:
+///
+///          e(-A, B) * e(alpha, beta) * e(vk_x, gamma) * e(C, delta) == 1
+///
+///      where `vk_x = IC[0] + sum(input[i] * IC[i+1])`.
+///
+///      All points are encoded exactly as EIP-197 expects. G1 points are
+///      `(x, y)`. G2 coordinates live in Fp2 and are serialised
+///      imaginary-part-first, i.e. `(x_c1, x_c0, y_c1, y_c0)`.
+library YulGroth16Verifier {
+    /// @dev BN254 base field modulus. Used to negate A.
+    uint256 internal constant FIELD_MODULUS =
+        21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    /// @dev BN254 scalar field order. Public inputs must be reduced mod this.
+    uint256 internal constant SCALAR_MODULUS =
+        21888242871839275222246405745257275088548364400416034343698204186575808495617;
+
+    /// @dev Precompile addresses.
+    uint256 private constant EC_ADD = 0x06;
+    uint256 private constant EC_MUL = 0x07;
+    uint256 private constant EC_PAIRING = 0x08;
+
+    /// @dev Bytes per (G1, G2) pairing operand: 64 + 128.
+    uint256 private constant PAIR_SIZE = 0xC0;
+
+    /// @dev Four pairs are staged: (-A,B), (alpha,beta), (vk_x,gamma), (C,delta).
+    uint256 private constant PAIRING_INPUT_SIZE = 0x300;
+
+    error InvalidVerifyingKeyLength();
+    error PublicInputOutOfField();
+    error PrecompileFailed();
+
+    /// @notice Verify a Groth16 proof.
+    /// @param proof  Flattened proof: `[A.x, A.y, B.x_c1, B.x_c0, B.y_c1, B.y_c0, C.x, C.y]`.
+    /// @param vk     Flattened verifying key: `alpha(2) || beta(4) || gamma(4) || delta(4)`.
+    /// @param ic     Flattened IC points, `2 * (input.length + 1)` words long.
+    /// @param input  Public inputs, each strictly less than the scalar field order.
+    /// @return ok    True when the proof satisfies the verification equation.
+    function verifyProof(
+        uint256[8] memory proof,
+        uint256[14] memory vk,
+        uint256[] memory ic,
+        uint256[] memory input
+    ) internal view returns (bool ok) {
+        // IC must hold exactly one point per public input, plus the constant term.
+        if (ic.length != (input.length + 1) * 2) {
+            revert InvalidVerifyingKeyLength();
+        }
+
+        // Reject inputs outside the scalar field. An unreduced scalar would be
+        // silently reduced by the ecMul precompile, letting two distinct input
+        // vectors verify against the same proof.
+        uint256 scalarModulus = SCALAR_MODULUS;
+        for (uint256 i = 0; i < input.length; ) {
+            if (input[i] >= scalarModulus) revert PublicInputOutOfField();
+            unchecked {
+                ++i;
+            }
+        }
+
+        // vk_x = IC[0] + sum(input[i] * IC[i+1])
+        (uint256 vkX, uint256 vkY) = _accumulatePublicInputs(ic, input);
+
+        assembly ("memory-safe") {
+            // Claim one contiguous buffer for the whole pairing call. Nothing
+            // below allocates again, so the free memory pointer moves once.
+            let buf := mload(0x40)
+            mstore(0x40, add(buf, PAIRING_INPUT_SIZE))
+
+            // ---- pair 0: (-A, B) -------------------------------------------
+            // Negating A on the G1 side is cheaper than negating the Fp2
+            // coordinates of B, and (x, 0) is its own negation.
+            let ax := mload(proof)
+            let ay := mload(add(proof, 0x20))
+            mstore(buf, ax)
+            switch ay
+            case 0 {
+                mstore(add(buf, 0x20), 0)
+            }
+            default {
+                mstore(add(buf, 0x20), sub(FIELD_MODULUS, ay))
+            }
+            mstore(add(buf, 0x40), mload(add(proof, 0x40)))
+            mstore(add(buf, 0x60), mload(add(proof, 0x60)))
+            mstore(add(buf, 0x80), mload(add(proof, 0x80)))
+            mstore(add(buf, 0xA0), mload(add(proof, 0xA0)))
+
+            // ---- pair 1: (alpha, beta) -------------------------------------
+            let p1 := add(buf, PAIR_SIZE)
+            mstore(p1, mload(vk))
+            mstore(add(p1, 0x20), mload(add(vk, 0x20)))
+            mstore(add(p1, 0x40), mload(add(vk, 0x40)))
+            mstore(add(p1, 0x60), mload(add(vk, 0x60)))
+            mstore(add(p1, 0x80), mload(add(vk, 0x80)))
+            mstore(add(p1, 0xA0), mload(add(vk, 0xA0)))
+
+            // ---- pair 2: (vk_x, gamma) -------------------------------------
+            let p2 := add(p1, PAIR_SIZE)
+            mstore(p2, vkX)
+            mstore(add(p2, 0x20), vkY)
+            mstore(add(p2, 0x40), mload(add(vk, 0xC0)))
+            mstore(add(p2, 0x60), mload(add(vk, 0xE0)))
+            mstore(add(p2, 0x80), mload(add(vk, 0x100)))
+            mstore(add(p2, 0xA0), mload(add(vk, 0x120)))
+
+            // ---- pair 3: (C, delta) ----------------------------------------
+            let p3 := add(p2, PAIR_SIZE)
+            mstore(p3, mload(add(proof, 0xC0)))
+            mstore(add(p3, 0x20), mload(add(proof, 0xE0)))
+            mstore(add(p3, 0x40), mload(add(vk, 0x140)))
+            mstore(add(p3, 0x60), mload(add(vk, 0x160)))
+            mstore(add(p3, 0x80), mload(add(vk, 0x180)))
+            mstore(add(p3, 0xA0), mload(add(vk, 0x1A0)))
+
+            // Reuse scratch space for the single-word result.
+            let success := staticcall(
+                gas(),
+                EC_PAIRING,
+                buf,
+                PAIRING_INPUT_SIZE,
+                0x00,
+                0x20
+            )
+            if iszero(success) {
+                // Malformed points make the precompile fail rather than return
+                // zero; surface that as an explicit revert.
+                mstore(0x00, 0x84e81692) // PrecompileFailed()
+                revert(0x1c, 0x04)
+            }
+            ok := eq(mload(0x00), 1)
+        }
+    }
+
+    /// @dev Accumulate `IC[0] + sum(input[i] * IC[i+1])` using the ecMul and
+    ///      ecAdd precompiles. Each iteration reuses one 128-byte scratch
+    ///      buffer instead of allocating per operation.
+    function _accumulatePublicInputs(
+        uint256[] memory ic,
+        uint256[] memory input
+    ) private view returns (uint256 x, uint256 y) {
+        assembly ("memory-safe") {
+            let icData := add(ic, 0x20)
+            let inputData := add(input, 0x20)
+            let n := mload(input)
+
+            // Scratch: 0x00..0x80 holds ecAdd operands, 0x80..0xE0 holds ecMul.
+            let scratch := mload(0x40)
+            mstore(0x40, add(scratch, 0xE0))
+
+            // Start the accumulator at IC[0].
+            x := mload(icData)
+            y := mload(add(icData, 0x20))
+
+            for {
+                let i := 0
+            } lt(i, n) {
+                i := add(i, 1)
+            } {
+                // ecMul(IC[i+1], input[i]) -> scratch[0x80..0xC0]
+                let icOffset := add(icData, mul(add(i, 1), 0x40))
+                mstore(add(scratch, 0x80), mload(icOffset))
+                mstore(add(scratch, 0xA0), mload(add(icOffset, 0x20)))
+                mstore(add(scratch, 0xC0), mload(add(inputData, mul(i, 0x20))))
+
+                if iszero(
+                    staticcall(
+                        gas(),
+                        EC_MUL,
+                        add(scratch, 0x80),
+                        0x60,
+                        add(scratch, 0x40),
+                        0x40
+                    )
+                ) {
+                    mstore(0x00, 0x84e81692) // PrecompileFailed()
+                    revert(0x1c, 0x04)
+                }
+
+                // ecAdd(accumulator, product) -> accumulator
+                mstore(scratch, x)
+                mstore(add(scratch, 0x20), y)
+
+                if iszero(
+                    staticcall(gas(), EC_ADD, scratch, 0x80, scratch, 0x40)
+                ) {
+                    mstore(0x00, 0x84e81692) // PrecompileFailed()
+                    revert(0x1c, 0x04)
+                }
+
+                x := mload(scratch)
+                y := mload(add(scratch, 0x20))
+            }
+        }
+    }
+}
+
+/// @dev Wrapper contract to expose the library for testing and gas measurement.
+contract YulGroth16VerifierWrapper {
+    function verify(
+        uint256[8] memory proof,
+        uint256[14] memory vk,
+        uint256[] memory ic,
+        uint256[] memory input
+    ) external view returns (bool) {
+        return YulGroth16Verifier.verifyProof(proof, vk, ic, input);
+    }
+}

--- a/test/crypto/YulGroth16Verifier.test.ts
+++ b/test/crypto/YulGroth16Verifier.test.ts
@@ -1,0 +1,135 @@
+import { expect } from "chai";
+import { network } from "hardhat";
+
+let ethers: any;
+
+// BN254 (alt_bn128) generators and moduli.
+const G1 = { x: 1n, y: 2n };
+
+// G2 generator, serialised imaginary-part-first as EIP-197 expects.
+const G2 = {
+  xC1: 11559732032986387107991004021392285783925812861821192530917403151452391805634n,
+  xC0: 10857046999023057135944570762232829481370756359578518086990519993285655852781n,
+  yC1: 4082367875863433681332203403145435568316851327593401208105741076214120093531n,
+  yC0: 8495653923123431417604973247489272438418190587263600148770280649306958101930n,
+};
+
+const SCALAR_MODULUS =
+  21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+
+const INFINITY: [bigint, bigint] = [0n, 0n];
+
+const g2Words = (): [bigint, bigint, bigint, bigint] => [G2.xC1, G2.xC0, G2.yC1, G2.yC0];
+
+/**
+ * Build a verifying key whose pairing product is 1 by construction.
+ *
+ * With A = alpha and B = beta the first two terms cancel:
+ *     e(-A, B) * e(alpha, beta) = e(-alpha, beta) * e(alpha, beta) = 1
+ * and with vk_x and C both the point at infinity the remaining terms are 1:
+ *     e(O, gamma) = e(O, delta) = 1
+ *
+ * This is a genuine pairing instance rather than a circuit proof: it exercises
+ * the full precompile path — negation, staging, and the 0x08 call — without
+ * needing a trusted setup to produce fixtures.
+ */
+function validCase() {
+  const proof: bigint[] = [G1.x, G1.y, ...g2Words(), ...INFINITY]; // A, B, C
+  const vk: bigint[] = [
+    G1.x,
+    G1.y, // alpha
+    ...g2Words(), // beta
+    ...g2Words(), // gamma
+    ...g2Words(), // delta
+  ];
+  const ic: bigint[] = [...INFINITY]; // IC[0] only
+  const input: bigint[] = [];
+  return { proof, vk, ic, input };
+}
+
+describe("YulGroth16Verifier", () => {
+  before(async () => {
+    ({ ethers } = await network.connect());
+  });
+
+  async function deploy() {
+    const Factory = await ethers.getContractFactory("YulGroth16VerifierWrapper");
+    const verifier = await Factory.deploy();
+    await verifier.waitForDeployment();
+    return verifier;
+  }
+
+  it("accepts a proof satisfying the pairing equation", async () => {
+    const verifier = await deploy();
+    const { proof, vk, ic, input } = validCase();
+
+    expect(await verifier.verify(proof, vk, ic, input)).to.equal(true);
+  });
+
+  it("rejects a proof whose C term breaks the equation", async () => {
+    const verifier = await deploy();
+    const { proof, vk, ic, input } = validCase();
+
+    // C moves from the identity to the generator, so e(C, delta) != 1.
+    proof[6] = G1.x;
+    proof[7] = G1.y;
+
+    expect(await verifier.verify(proof, vk, ic, input)).to.equal(false);
+  });
+
+  it("rejects a proof whose A term breaks the equation", async () => {
+    const verifier = await deploy();
+    const { proof, vk, ic, input } = validCase();
+
+    // A no longer matches alpha, so the first two terms stop cancelling.
+    proof[0] = INFINITY[0];
+    proof[1] = INFINITY[1];
+
+    expect(await verifier.verify(proof, vk, ic, input)).to.equal(false);
+  });
+
+  it("accumulates public inputs through ecMul and ecAdd", async () => {
+    const verifier = await deploy();
+    const { proof, vk } = validCase();
+
+    // IC[1] is a real curve point, but the input scalar is zero, so
+    // vk_x = IC[0] + 0 * IC[1] = O and the equation still holds. This drives
+    // the ecMul (0x07) and ecAdd (0x06) path rather than skipping it.
+    const ic = [...INFINITY, G1.x, G1.y];
+    const input = [0n];
+
+    expect(await verifier.verify(proof, vk, ic, input)).to.equal(true);
+  });
+
+  it("reverts when a public input is not reduced mod the scalar field", async () => {
+    const verifier = await deploy();
+    const { proof, vk } = validCase();
+    const ic = [...INFINITY, G1.x, G1.y];
+
+    await expect(
+      verifier.verify(proof, vk, ic, [SCALAR_MODULUS]),
+    ).to.be.revertedWithCustomError(verifier, "PublicInputOutOfField");
+  });
+
+  it("reverts when IC length does not match the public input count", async () => {
+    const verifier = await deploy();
+    const { proof, vk, ic } = validCase();
+
+    await expect(
+      verifier.verify(proof, vk, ic, [1n]),
+    ).to.be.revertedWithCustomError(verifier, "InvalidVerifyingKeyLength");
+  });
+
+  it("reports gas for a verification with one public input", async () => {
+    const verifier = await deploy();
+    const { proof, vk } = validCase();
+    const ic = [...INFINITY, G1.x, G1.y];
+
+    const gas = await verifier.verify.estimateGas(proof, vk, ic, [0n]);
+    console.log(`      gas for verify (1 public input): ${gas.toString()}`);
+
+    // The pairing precompile alone costs 45000 + 34000 per pair = 181000 for
+    // four pairs. Anything near that floor means the wrapper is adding little.
+    expect(gas).to.be.lessThan(260000n);
+  });
+});


### PR DESCRIPTION
Closes #848

## Summary

Adds `contracts/crypto/YulGroth16Verifier.sol` — a library that stages a Groth16 proof, its verifying key, and the accumulated public-input commitment directly into one contiguous memory buffer and hands it to the pairing precompile at `0x08`.

Verification evaluates the standard equation

```
e(A, B) == e(alpha, beta) * e(vk_x, gamma) * e(C, delta)
```

rearranged into the single product the precompile checks:

```
e(-A, B) * e(alpha, beta) * e(vk_x, gamma) * e(C, delta) == 1
```

with `vk_x = IC[0] + sum(input[i] * IC[i+1])` accumulated through ecMul (`0x07`) and ecAdd (`0x06`).

## Implementation notes

- **One allocation.** All four pairs go into a single 768-byte buffer; the free memory pointer moves once for the entire call. The input accumulator reuses one 224-byte scratch region across every public input rather than allocating per operation.
- **A is negated on the G1 side** instead of negating B's Fp2 coordinates — one `sub` versus two — and `(x, 0)` is handled as its own negation.
- **Flat fixed-size array parameters.** Solidity stores nested memory arrays such as `uint256[2][2]` as *pointers* rather than inline words, which makes Yul offset arithmetic quietly wrong. Flat arrays keep the layout explicit and match what gets `mload`ed.
- **Public inputs must be reduced mod the scalar field.** Without this check ecMul reduces them silently, so two distinct public-input vectors could verify against the same proof.
- **`view`, not `pure`** — `staticcall` reads the environment. (`contracts/lightclient/YulLightClient.sol` currently declares `pure` while doing exactly this, and does not compile.)

## Acceptance criteria

| Criterion | Status |
|---|---|
| Stage proof points and public inputs directly in memory | ✅ single 768-byte buffer, one FMP bump |
| `staticcall` to `0x08` and evaluate the boolean in Yul | ✅ result read from scratch space, compared in Yul |
| Reduces gas overhead for verification | ✅ 232,132 gas with one public input, against a 181,000 precompile floor |
| Correctly verifies valid proofs and rejects invalid ones | ✅ 7 tests, including two distinct ways of breaking the equation |

**Gas:** 232,132 for a verification with one public input. The pairing precompile alone costs 45,000 + 4 × 34,000 = 181,000, plus ecMul (6,000), ecAdd (150) and the 21,000 transaction base — so the wrapper itself adds very little on top of the unavoidable floor.

## Test fixtures

The fixtures are built from BN254 generators so that the pairing product is 1 **by construction**: with `A = alpha` and `B = beta` the first two terms cancel, and with `vk_x` and `C` both at infinity the remaining two are 1. That exercises the complete precompile path — negation, staging, the `0x08` call, and the ecMul/ecAdd accumulation — without needing a trusted setup to produce circuit proofs. Invalid cases perturb `A` and `C` independently.

If you would rather have fixtures from a real circuit, I am happy to add snarkjs-generated vectors in a follow-up; that means taking on a new dev dependency, so I did not do it unprompted.

## ⚠️ This PR cannot be verified by CI in its current state

`npx hardhat compile` fails on `main` before it ever reaches this contract. I hit **five** pre-existing failures, none related to this change:

| File | Problem |
|---|---|
| `contracts/bridge/BridgeGateway.sol:103` | a second file's `pragma` + imports are pasted into the middle of a function body |
| `contracts/verifiers/YulEd25519Verifier.sol:98` | `} else {` inside assembly — Yul has no `else` |
| `test/relayer/MockGasTarget.sol:15,31` | `let _ := i` — `_` is reserved in Yul |
| `contracts/bridge/YulBatchUnlocker.sol:34` | non-literal constant referenced in inline assembly |
| `contracts/lightclient/YulLightClient.sol:97` | `pure` function performing a `staticcall` |

This matches CI, which is failing on all eight recent runs on `main`.

To validate this work I compiled and ran the tests against an isolated Hardhat config containing only this contract. **All 7 tests pass.** The harness was removed before committing — only the two intended files are in this diff.

One further note: the existing tests under `test/crypto/` use the Hardhat 2 import style (`import { ethers } from "hardhat"`), which throws `does not provide an export named 'ethers'` under the Hardhat 3 in `package.json`. This PR's test uses the Hardhat 3 `network.connect()` API so it actually runs. It emits a deprecation warning suggesting `network.getOrCreate()`; I kept `connect()` as it is the documented test-time API, and I did not want to churn on an API I could not verify against the rest of the suite.

I have deliberately not fixed any of the above — happy to open a separate PR or issues for them if useful, but they are well outside the scope of #848.
