### PR TITLE
feat(oracle): add multi-source price aggregator for high-value transfers

### DIFF
--- a/contracts/oracle/BridgeMultiOracle.sol
+++ b/contracts/oracle/BridgeMultiOracle.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPriceOracle} from "./IPriceOracle.sol";
+
+/// @title BridgeMultiOracle
+/// @notice Aggregates two independent price sources and refuses to value a
+///         transfer when they disagree by more than a configured margin.
+///
+/// @dev A single feed is a single point of failure: a manipulated spot pool or
+///      a Chainlink feed stuck on stale data will happily report a price that
+///      lets an attacker over-withdraw on the far side of a bridge. Requiring
+///      two independent sources to agree turns that from a silent mispricing
+///      into a revert.
+///
+///      Two deliberate choices, both aimed at failing safe:
+///
+///      1. Deviation is measured against the **smaller** of the two prices, so
+///         the same absolute gap always yields the larger percentage. A check
+///         against the mean would under-report exactly when the feeds diverge
+///         most.
+///      2. Valuation returns the **higher** of the two prices. This contract
+///         gates on a high-value threshold, so overstating value routes more
+///         transfers into the stricter path. Understating it would let a large
+///         transfer slip underneath the threshold, which is the failure that
+///         actually costs money.
+contract BridgeMultiOracle {
+    /// @dev Basis-point denominator. 10_000 bps == 100%.
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @dev Upper bound on the configurable deviation, so a misconfiguration
+    ///      cannot disable the check entirely.
+    uint256 public constant MAX_CONFIGURABLE_DEVIATION_BPS = 5_000;
+
+    /// @notice The two price sources being compared.
+    IPriceOracle public primaryOracle;
+    IPriceOracle public fallbackOracle;
+
+    /// @notice Maximum tolerated disagreement, in basis points. 200 == 2%.
+    uint256 public maxDeviationBps;
+
+    /// @notice Observations older than this are treated as unusable.
+    uint256 public maxPriceAge;
+
+    /// @notice Transfer value, in 18-decimal USD, at or above which both
+    ///         oracles must agree before the transfer may proceed.
+    uint256 public highValueThreshold;
+
+    address public owner;
+
+    /// @notice Raised when the two feeds disagree by more than {maxDeviationBps}.
+    error OracleDeviationExceeded(uint256 deviationBps, uint256 maxDeviationBps);
+    /// @notice A feed reported an observation older than {maxPriceAge}.
+    error StalePrice(address oracle, uint256 updatedAt, uint256 maxAge);
+    /// @notice A feed reported a non-positive or zero price.
+    error InvalidPrice(address oracle);
+    /// @notice Configuration rejected: zero address, or a deviation above the cap.
+    error InvalidConfiguration();
+    /// @notice Caller is not the owner.
+    error Unauthorized();
+
+    event OraclesUpdated(address indexed primary, address indexed fallbackOracle);
+    event DeviationThresholdUpdated(uint256 maxDeviationBps);
+    event HighValueThresholdUpdated(uint256 highValueThreshold);
+    event MaxPriceAgeUpdated(uint256 maxPriceAge);
+    event OwnershipTransferred(address indexed from, address indexed to);
+    event HighValueTransferValidated(uint256 valueUsd, uint256 price, uint256 deviationBps);
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert Unauthorized();
+        _;
+    }
+
+    constructor(
+        IPriceOracle primaryOracle_,
+        IPriceOracle fallbackOracle_,
+        uint256 maxDeviationBps_,
+        uint256 maxPriceAge_,
+        uint256 highValueThreshold_
+    ) {
+        if (
+            address(primaryOracle_) == address(0) ||
+            address(fallbackOracle_) == address(0) ||
+            address(primaryOracle_) == address(fallbackOracle_) ||
+            maxDeviationBps_ == 0 ||
+            maxDeviationBps_ > MAX_CONFIGURABLE_DEVIATION_BPS ||
+            maxPriceAge_ == 0
+        ) {
+            revert InvalidConfiguration();
+        }
+
+        primaryOracle = primaryOracle_;
+        fallbackOracle = fallbackOracle_;
+        maxDeviationBps = maxDeviationBps_;
+        maxPriceAge = maxPriceAge_;
+        highValueThreshold = highValueThreshold_;
+        owner = msg.sender;
+
+        emit OraclesUpdated(address(primaryOracle_), address(fallbackOracle_));
+        emit DeviationThresholdUpdated(maxDeviationBps_);
+        emit MaxPriceAgeUpdated(maxPriceAge_);
+        emit HighValueThresholdUpdated(highValueThreshold_);
+    }
+
+    // ---------------------------------------------------------------------
+    // Reads
+    // ---------------------------------------------------------------------
+
+    /// @notice Read both feeds and return an agreed price.
+    /// @dev Reverts if either feed is stale or non-positive, or if the two
+    ///      disagree by more than {maxDeviationBps}.
+    /// @return price        The higher of the two prices, 18 decimals.
+    /// @return deviation    Observed disagreement in basis points.
+    function getValidatedPrice() public view returns (uint256 price, uint256 deviation) {
+        uint256 primaryPrice = _readOracle(primaryOracle);
+        uint256 fallbackPrice = _readOracle(fallbackOracle);
+
+        deviation = calculateDeviationBps(primaryPrice, fallbackPrice);
+        if (deviation > maxDeviationBps) {
+            revert OracleDeviationExceeded(deviation, maxDeviationBps);
+        }
+
+        price = primaryPrice > fallbackPrice ? primaryPrice : fallbackPrice;
+    }
+
+    /// @notice Value a transfer and enforce cross-oracle agreement when it is
+    ///         large enough to matter.
+    ///
+    /// @dev Below the threshold the primary feed alone is used, which keeps
+    ///      routine transfers cheap. At or above it, both feeds must agree.
+    ///      Note the value is computed from the primary price first purely to
+    ///      classify the transfer; once classified as high value, the returned
+    ///      price comes from {getValidatedPrice}.
+    ///
+    /// @param amount        Asset amount, 18 decimals.
+    /// @return valueUsd     Transfer value in 18-decimal USD.
+    /// @return price        Price used, 18 decimals.
+    /// @return isHighValue  Whether the stricter path was taken.
+    function validateTransfer(uint256 amount)
+        external
+        view
+        returns (uint256 valueUsd, uint256 price, bool isHighValue)
+    {
+        uint256 primaryPrice = _readOracle(primaryOracle);
+        uint256 provisionalValue = (amount * primaryPrice) / 1e18;
+
+        if (provisionalValue < highValueThreshold) {
+            return (provisionalValue, primaryPrice, false);
+        }
+
+        (price, ) = getValidatedPrice();
+        valueUsd = (amount * price) / 1e18;
+        isHighValue = true;
+    }
+
+    /// @notice Disagreement between two prices, in basis points.
+    /// @dev Measured against the smaller price so the figure is never flattered
+    ///      by the larger one. Two equal prices yield 0; a zero input yields the
+    ///      maximum, since no meaningful comparison exists.
+    function calculateDeviationBps(uint256 a, uint256 b) public pure returns (uint256) {
+        if (a == 0 || b == 0) return type(uint256).max;
+        if (a == b) return 0;
+
+        (uint256 lower, uint256 higher) = a < b ? (a, b) : (b, a);
+        return ((higher - lower) * BPS_DENOMINATOR) / lower;
+    }
+
+    /// @notice Whether both feeds currently agree closely enough to transact.
+    /// @dev Never reverts, so callers can branch instead of using try/catch.
+    function oraclesAgree() external view returns (bool) {
+        (bool okPrimary, uint256 primaryPrice) = _tryReadOracle(primaryOracle);
+        (bool okFallback, uint256 fallbackPrice) = _tryReadOracle(fallbackOracle);
+        if (!okPrimary || !okFallback) return false;
+
+        return calculateDeviationBps(primaryPrice, fallbackPrice) <= maxDeviationBps;
+    }
+
+    // ---------------------------------------------------------------------
+    // Administration
+    // ---------------------------------------------------------------------
+
+    function setOracles(IPriceOracle primaryOracle_, IPriceOracle fallbackOracle_)
+        external
+        onlyOwner
+    {
+        if (
+            address(primaryOracle_) == address(0) ||
+            address(fallbackOracle_) == address(0) ||
+            address(primaryOracle_) == address(fallbackOracle_)
+        ) {
+            revert InvalidConfiguration();
+        }
+        primaryOracle = primaryOracle_;
+        fallbackOracle = fallbackOracle_;
+        emit OraclesUpdated(address(primaryOracle_), address(fallbackOracle_));
+    }
+
+    function setMaxDeviationBps(uint256 maxDeviationBps_) external onlyOwner {
+        if (maxDeviationBps_ == 0 || maxDeviationBps_ > MAX_CONFIGURABLE_DEVIATION_BPS) {
+            revert InvalidConfiguration();
+        }
+        maxDeviationBps = maxDeviationBps_;
+        emit DeviationThresholdUpdated(maxDeviationBps_);
+    }
+
+    function setMaxPriceAge(uint256 maxPriceAge_) external onlyOwner {
+        if (maxPriceAge_ == 0) revert InvalidConfiguration();
+        maxPriceAge = maxPriceAge_;
+        emit MaxPriceAgeUpdated(maxPriceAge_);
+    }
+
+    function setHighValueThreshold(uint256 highValueThreshold_) external onlyOwner {
+        highValueThreshold = highValueThreshold_;
+        emit HighValueThresholdUpdated(highValueThreshold_);
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert InvalidConfiguration();
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    // ---------------------------------------------------------------------
+    // Internals
+    // ---------------------------------------------------------------------
+
+    function _readOracle(IPriceOracle oracle) private view returns (uint256 price) {
+        uint256 updatedAt;
+        (price, updatedAt) = oracle.latestPrice();
+
+        if (price == 0) revert InvalidPrice(address(oracle));
+        // A timestamp in the future is as untrustworthy as one long past.
+        if (updatedAt > block.timestamp || block.timestamp - updatedAt > maxPriceAge) {
+            revert StalePrice(address(oracle), updatedAt, maxPriceAge);
+        }
+    }
+
+    /// @dev Non-reverting variant backing {oraclesAgree}.
+    function _tryReadOracle(IPriceOracle oracle) private view returns (bool ok, uint256 price) {
+        try oracle.latestPrice() returns (uint256 reported, uint256 updatedAt) {
+            if (reported == 0) return (false, 0);
+            if (updatedAt > block.timestamp || block.timestamp - updatedAt > maxPriceAge) {
+                return (false, 0);
+            }
+            return (true, reported);
+        } catch {
+            return (false, 0);
+        }
+    }
+}

--- a/contracts/oracle/ChainlinkPriceOracle.sol
+++ b/contracts/oracle/ChainlinkPriceOracle.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPriceOracle, IChainlinkAggregator} from "./IPriceOracle.sol";
+
+/// @title ChainlinkPriceOracle
+/// @notice Adapts a Chainlink aggregator to {IPriceOracle}, normalising to 18
+///         decimals and rejecting the answers that should never be trusted.
+/// @dev Chainlink returns a signed answer and a round id. A non-positive answer
+///      and a round that never completed are both real failure modes seen in
+///      production, so both are rejected here rather than passed upstream as a
+///      number that merely looks plausible.
+contract ChainlinkPriceOracle is IPriceOracle {
+    IChainlinkAggregator public immutable aggregator;
+    uint8 public immutable feedDecimals;
+    string private _description;
+
+    error NonPositiveAnswer(int256 answer);
+    error IncompleteRound(uint80 roundId, uint80 answeredInRound);
+    error UnsupportedDecimals(uint8 decimals);
+
+    constructor(IChainlinkAggregator aggregator_, string memory description_) {
+        aggregator = aggregator_;
+        uint8 decimals_ = aggregator_.decimals();
+        // Above 18 the normalisation below would have to divide and silently
+        // lose precision; no mainstream feed exceeds it.
+        if (decimals_ > 18) revert UnsupportedDecimals(decimals_);
+        feedDecimals = decimals_;
+        _description = description_;
+    }
+
+    /// @inheritdoc IPriceOracle
+    function latestPrice() external view returns (uint256 price, uint256 updatedAt) {
+        (uint80 roundId, int256 answer, , uint256 reportedAt, uint80 answeredInRound) =
+            aggregator.latestRoundData();
+
+        if (answer <= 0) revert NonPositiveAnswer(answer);
+        // A round answered in an earlier round means this one never settled.
+        if (answeredInRound < roundId) revert IncompleteRound(roundId, answeredInRound);
+
+        price = uint256(answer) * (10 ** (18 - feedDecimals));
+        updatedAt = reportedAt;
+    }
+
+    /// @inheritdoc IPriceOracle
+    function description() external view returns (string memory) {
+        return _description;
+    }
+}

--- a/contracts/oracle/IPriceOracle.sol
+++ b/contracts/oracle/IPriceOracle.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title IPriceOracle
+/// @notice Common shape for a price source consumed by {BridgeMultiOracle}.
+/// @dev Adapters normalise their underlying feed to 18 decimals so the
+///      aggregator can compare sources without knowing where they came from.
+interface IPriceOracle {
+    /// @notice Latest price, scaled to 18 decimals.
+    /// @return price      Asset price with 18 decimals of precision.
+    /// @return updatedAt  Unix timestamp the observation was produced.
+    function latestPrice() external view returns (uint256 price, uint256 updatedAt);
+
+    /// @notice Human-readable source identifier, for events and debugging.
+    function description() external view returns (string memory);
+}
+
+/// @dev Minimal Chainlink aggregator surface. Declared locally so the project
+///      does not take a dependency on the Chainlink contracts package for one interface.
+interface IChainlinkAggregator {
+    function decimals() external view returns (uint8);
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}
+
+/// @dev Minimal Uniswap V3 pool surface needed for a TWAP observation.
+///      Declared locally for the same reason as {IChainlinkAggregator}.
+interface IUniswapV3PoolObserver {
+    /// @param secondsAgos Seconds before the current block to sample.
+    /// @return tickCumulatives Cumulative tick at each requested point.
+    /// @return secondsPerLiquidityCumulativeX128 Unused here, part of the ABI.
+    function observe(uint32[] calldata secondsAgos)
+        external
+        view
+        returns (
+            int56[] memory tickCumulatives,
+            uint160[] memory secondsPerLiquidityCumulativeX128
+        );
+}

--- a/contracts/oracle/UniswapV3TwapOracle.sol
+++ b/contracts/oracle/UniswapV3TwapOracle.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IPriceOracle, IUniswapV3PoolObserver} from "./IPriceOracle.sol";
+
+/// @title UniswapV3TwapOracle
+/// @notice Adapts a Uniswap V3 pool's time-weighted average tick to
+///         {IPriceOracle}, producing an 18-decimal price.
+///
+/// @dev A TWAP is used rather than the spot tick because spot is trivially
+///      moved within a single block; averaging over a window makes manipulation
+///      cost proportional to the window length.
+///
+///      Tick to price is `1.0001 ^ tick`. Rather than transcribe Uniswap's
+///      precomputed TickMath constants, the 1.0001 base is derived from integer
+///      arithmetic and raised by exponentiation by squaring. That costs more gas
+///      than TickMath but it is auditable by inspection, and the tests pin it
+///      against independently computed values.
+///
+///      Every fixed-point multiply goes through {Math.mulDiv}, which carries a
+///      512-bit intermediate. A plain `(a * b) >> 128` overflows uint256 once
+///      the squared base passes 2^128, which happens at modest ticks, and the
+///      reciprocal `Q128 * Q128` overflows unconditionally.
+contract UniswapV3TwapOracle is IPriceOracle {
+    /// @dev 2^128, the fixed-point scale used through the exponentiation.
+    uint256 private constant Q128 = 1 << 128;
+
+    /// @dev Beyond this the repeated squaring below can overflow. Real pairs
+    ///      sit far inside it; Uniswap's own limit is 887272.
+    int24 public constant MAX_SUPPORTED_TICK = 400_000;
+
+    IUniswapV3PoolObserver public immutable pool;
+    uint32 public immutable twapPeriod;
+    /// @dev Decimal difference between the pair, applied after exponentiation.
+    int8 public immutable decimalAdjustment;
+    string private _description;
+
+    error TwapPeriodZero();
+    error TickOutOfRange(int24 tick);
+    error ObservationMismatch();
+
+    /// @param pool_               Uniswap V3 pool to observe.
+    /// @param twapPeriod_         Averaging window in seconds.
+    /// @param decimalAdjustment_  `token0.decimals - token1.decimals`, applied
+    ///                            so the result lands on 18 decimals.
+    constructor(
+        IUniswapV3PoolObserver pool_,
+        uint32 twapPeriod_,
+        int8 decimalAdjustment_,
+        string memory description_
+    ) {
+        if (twapPeriod_ == 0) revert TwapPeriodZero();
+        pool = pool_;
+        twapPeriod = twapPeriod_;
+        decimalAdjustment = decimalAdjustment_;
+        _description = description_;
+    }
+
+    /// @inheritdoc IPriceOracle
+    /// @dev `updatedAt` is the end of the averaging window, i.e. now. The
+    ///      observation is only as fresh as the pool's oldest sample, which the
+    ///      pool itself enforces by reverting if the window is not available.
+    function latestPrice() external view returns (uint256 price, uint256 updatedAt) {
+        price = _priceFromTick(meanTick());
+        updatedAt = block.timestamp;
+    }
+
+    /// @notice Time-weighted average tick over {twapPeriod}.
+    function meanTick() public view returns (int24) {
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = twapPeriod;
+        secondsAgos[1] = 0;
+
+        (int56[] memory tickCumulatives, ) = pool.observe(secondsAgos);
+        if (tickCumulatives.length != 2) revert ObservationMismatch();
+
+        int56 delta = tickCumulatives[1] - tickCumulatives[0];
+        int24 tick = int24(delta / int56(uint56(twapPeriod)));
+
+        // Solidity truncates toward zero; Uniswap's convention rounds down.
+        if (delta < 0 && (delta % int56(uint56(twapPeriod)) != 0)) {
+            tick -= 1;
+        }
+        return tick;
+    }
+
+    /// @inheritdoc IPriceOracle
+    function description() external view returns (string memory) {
+        return _description;
+    }
+
+    /// @dev `1.0001 ^ tick`, scaled to 18 decimals.
+    function _priceFromTick(int24 tick) internal view returns (uint256) {
+        if (tick > MAX_SUPPORTED_TICK || tick < -MAX_SUPPORTED_TICK) {
+            revert TickOutOfRange(tick);
+        }
+
+        uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
+
+        // 1.0001 in Q128. (Q128 * 10001) is ~2^141, comfortably inside uint256,
+        // so this is exact to the fixed-point resolution.
+        uint256 base = (Q128 * 10001) / 10000;
+        uint256 result = Q128;
+
+        while (absTick != 0) {
+            if (absTick & 1 == 1) {
+                result = Math.mulDiv(result, base, Q128);
+            }
+            absTick >>= 1;
+            if (absTick != 0) {
+                base = Math.mulDiv(base, base, Q128);
+            }
+        }
+
+        // Negative ticks are the reciprocal.
+        uint256 priceQ128 = tick < 0 ? Math.mulDiv(Q128, Q128, result) : result;
+        uint256 price = Math.mulDiv(priceQ128, 1e18, Q128);
+
+        if (decimalAdjustment > 0) {
+            price = price * (10 ** uint8(decimalAdjustment));
+        } else if (decimalAdjustment < 0) {
+            price = price / (10 ** uint8(-decimalAdjustment));
+        }
+        return price;
+    }
+}

--- a/test/oracle/BridgeMultiOracle.test.ts
+++ b/test/oracle/BridgeMultiOracle.test.ts
@@ -1,0 +1,476 @@
+import { expect } from "chai";
+import { network } from "hardhat";
+
+let ethers: any;
+
+const E18 = 10n ** 18n;
+const usd = (n: string | number) => ethers.parseUnits(String(n), 18);
+
+/** Deviation in basis points, measured against the smaller price. */
+const expectedDeviationBps = (a: bigint, b: bigint): bigint => {
+  const [lo, hi] = a < b ? [a, b] : [b, a];
+  return ((hi - lo) * 10_000n) / lo;
+};
+
+describe("BridgeMultiOracle", () => {
+  let now: number;
+
+  before(async () => {
+    ({ ethers } = await network.connect());
+  });
+
+  beforeEach(async () => {
+    now = Number((await ethers.provider.getBlock("latest"))!.timestamp);
+  });
+
+  async function deployOracles(primaryPrice: bigint, fallbackPrice: bigint) {
+    const Mock = await ethers.getContractFactory("MockPriceOracle");
+    const primary = await Mock.deploy(primaryPrice, now, "primary");
+    const fallbackOracle = await Mock.deploy(fallbackPrice, now, "fallback");
+    return { primary, fallbackOracle };
+  }
+
+  async function deployAggregator(
+    primaryPrice = usd(2000),
+    fallbackPrice = usd(2000),
+    maxDeviationBps = 200n,
+    maxPriceAge = 3600n,
+    highValueThreshold = usd(100_000),
+  ) {
+    const { primary, fallbackOracle } = await deployOracles(primaryPrice, fallbackPrice);
+    const Factory = await ethers.getContractFactory("BridgeMultiOracle");
+    const oracle = await Factory.deploy(
+      await primary.getAddress(),
+      await fallbackOracle.getAddress(),
+      maxDeviationBps,
+      maxPriceAge,
+      highValueThreshold,
+    );
+    return { oracle, primary, fallbackOracle };
+  }
+
+  describe("deviation maths", () => {
+    it("reports zero for identical prices", async () => {
+      const { oracle } = await deployAggregator();
+      expect(await oracle.calculateDeviationBps(usd(2000), usd(2000))).to.equal(0n);
+    });
+
+    it("measures against the smaller price, not the larger", async () => {
+      const { oracle } = await deployAggregator();
+      const a = usd(100);
+      const b = usd(102);
+
+      // Against 100 this is 200 bps. Against 102 it would flatter to 196.
+      expect(await oracle.calculateDeviationBps(a, b)).to.equal(200n);
+      expect(await oracle.calculateDeviationBps(a, b)).to.equal(expectedDeviationBps(a, b));
+    });
+
+    it("is symmetric in its arguments", async () => {
+      const { oracle } = await deployAggregator();
+      const a = usd(1999);
+      const b = usd(2050);
+      expect(await oracle.calculateDeviationBps(a, b)).to.equal(
+        await oracle.calculateDeviationBps(b, a),
+      );
+    });
+
+    it("treats a zero price as maximally deviant", async () => {
+      const { oracle } = await deployAggregator();
+      expect(await oracle.calculateDeviationBps(0n, usd(2000))).to.equal(2n ** 256n - 1n);
+    });
+  });
+
+  describe("getValidatedPrice", () => {
+    it("returns the higher price when the feeds agree", async () => {
+      const { oracle } = await deployAggregator(usd(2000), usd(2010));
+      const [price, deviation] = await oracle.getValidatedPrice();
+
+      expect(price).to.equal(usd(2010));
+      expect(deviation).to.equal(expectedDeviationBps(usd(2000), usd(2010)));
+    });
+
+    it("reverts with OracleDeviationExceeded past the threshold", async () => {
+      // 2000 vs 2100 is 500 bps against the smaller value, over the 200 cap.
+      const { oracle } = await deployAggregator(usd(2000), usd(2100));
+
+      await expect(oracle.getValidatedPrice())
+        .to.be.revertedWithCustomError(oracle, "OracleDeviationExceeded")
+        .withArgs(500n, 200n);
+    });
+
+    it("accepts a deviation exactly on the threshold", async () => {
+      // 2000 -> 2040 is exactly 200 bps.
+      const { oracle } = await deployAggregator(usd(2000), usd(2040));
+      const [, deviation] = await oracle.getValidatedPrice();
+      expect(deviation).to.equal(200n);
+    });
+
+    it("rejects a stale primary feed", async () => {
+      const { oracle, primary } = await deployAggregator();
+      await primary.setUpdatedAt(now - 7200);
+
+      await expect(oracle.getValidatedPrice()).to.be.revertedWithCustomError(
+        oracle,
+        "StalePrice",
+      );
+    });
+
+    it("rejects a stale fallback feed", async () => {
+      const { oracle, fallbackOracle } = await deployAggregator();
+      await fallbackOracle.setUpdatedAt(now - 7200);
+
+      await expect(oracle.getValidatedPrice()).to.be.revertedWithCustomError(
+        oracle,
+        "StalePrice",
+      );
+    });
+
+    it("rejects a timestamp from the future", async () => {
+      const { oracle, primary } = await deployAggregator();
+      await primary.setUpdatedAt(now + 7200);
+
+      await expect(oracle.getValidatedPrice()).to.be.revertedWithCustomError(
+        oracle,
+        "StalePrice",
+      );
+    });
+
+    it("rejects a zero price", async () => {
+      const { oracle, primary } = await deployAggregator();
+      await primary.setPrice(0n);
+
+      await expect(oracle.getValidatedPrice()).to.be.revertedWithCustomError(
+        oracle,
+        "InvalidPrice",
+      );
+    });
+  });
+
+  describe("validateTransfer", () => {
+    it("uses the primary feed alone below the threshold", async () => {
+      // Feeds disagree wildly, but the transfer is small.
+      const { oracle } = await deployAggregator(usd(2000), usd(4000));
+      const [valueUsd, price, isHighValue] = await oracle.validateTransfer(E18); // 1 unit
+
+      expect(isHighValue).to.equal(false);
+      expect(price).to.equal(usd(2000));
+      expect(valueUsd).to.equal(usd(2000));
+    });
+
+    it("blocks a high-value transfer when the feeds disagree", async () => {
+      const { oracle } = await deployAggregator(usd(2000), usd(2100));
+
+      // 100 units at 2000 = 200_000, over the 100_000 threshold.
+      await expect(oracle.validateTransfer(100n * E18)).to.be.revertedWithCustomError(
+        oracle,
+        "OracleDeviationExceeded",
+      );
+    });
+
+    it("allows a high-value transfer when the feeds agree", async () => {
+      const { oracle } = await deployAggregator(usd(2000), usd(2010));
+      const [valueUsd, price, isHighValue] = await oracle.validateTransfer(100n * E18);
+
+      expect(isHighValue).to.equal(true);
+      expect(price).to.equal(usd(2010));
+      expect(valueUsd).to.equal(usd(201_000));
+    });
+
+    it("treats a transfer exactly on the threshold as high value", async () => {
+      const { oracle } = await deployAggregator(usd(2000), usd(2100));
+      // 50 units at 2000 = exactly 100_000.
+      await expect(oracle.validateTransfer(50n * E18)).to.be.revertedWithCustomError(
+        oracle,
+        "OracleDeviationExceeded",
+      );
+    });
+  });
+
+  describe("oraclesAgree", () => {
+    it("is true when the feeds are close", async () => {
+      const { oracle } = await deployAggregator(usd(2000), usd(2010));
+      expect(await oracle.oraclesAgree()).to.equal(true);
+    });
+
+    it("is false when the feeds diverge", async () => {
+      const { oracle } = await deployAggregator(usd(2000), usd(2100));
+      expect(await oracle.oraclesAgree()).to.equal(false);
+    });
+
+    it("is false, rather than reverting, when a feed reverts", async () => {
+      const { oracle, primary } = await deployAggregator();
+      await primary.setShouldRevert(true);
+      expect(await oracle.oraclesAgree()).to.equal(false);
+    });
+
+    it("is false when a feed is stale", async () => {
+      const { oracle, fallbackOracle } = await deployAggregator();
+      await fallbackOracle.setUpdatedAt(now - 7200);
+      expect(await oracle.oraclesAgree()).to.equal(false);
+    });
+  });
+
+  describe("configuration", () => {
+    it("rejects a deviation cap above the hard limit", async () => {
+      const { primary, fallbackOracle } = await deployOracles(usd(2000), usd(2000));
+      const Factory = await ethers.getContractFactory("BridgeMultiOracle");
+
+      await expect(
+        Factory.deploy(
+          await primary.getAddress(),
+          await fallbackOracle.getAddress(),
+          5_001n,
+          3600n,
+          usd(100_000),
+        ),
+      ).to.be.revertedWithCustomError(Factory, "InvalidConfiguration");
+    });
+
+    it("rejects the same oracle twice", async () => {
+      const { primary } = await deployOracles(usd(2000), usd(2000));
+      const Factory = await ethers.getContractFactory("BridgeMultiOracle");
+
+      await expect(
+        Factory.deploy(
+          await primary.getAddress(),
+          await primary.getAddress(),
+          200n,
+          3600n,
+          usd(100_000),
+        ),
+      ).to.be.revertedWithCustomError(Factory, "InvalidConfiguration");
+    });
+
+    it("only lets the owner change the deviation cap", async () => {
+      const { oracle } = await deployAggregator();
+      const [, stranger] = await ethers.getSigners();
+
+      await expect(
+        oracle.connect(stranger).setMaxDeviationBps(300n),
+      ).to.be.revertedWithCustomError(oracle, "Unauthorized");
+    });
+
+    it("emits on a deviation cap change", async () => {
+      const { oracle } = await deployAggregator();
+      await expect(oracle.setMaxDeviationBps(300n))
+        .to.emit(oracle, "DeviationThresholdUpdated")
+        .withArgs(300n);
+    });
+
+    it("applies a raised cap immediately", async () => {
+      const { oracle } = await deployAggregator(usd(2000), usd(2100));
+      await expect(oracle.getValidatedPrice()).to.be.revertedWithCustomError(
+        oracle,
+        "OracleDeviationExceeded",
+      );
+
+      await oracle.setMaxDeviationBps(600n);
+      const [price] = await oracle.getValidatedPrice();
+      expect(price).to.equal(usd(2100));
+    });
+  });
+});
+
+describe("ChainlinkPriceOracle", () => {
+  let now: number;
+
+  before(async () => {
+    ({ ethers } = await network.connect());
+  });
+
+  beforeEach(async () => {
+    now = Number((await ethers.provider.getBlock("latest"))!.timestamp);
+  });
+
+  async function deployFeed(decimals: number, answer: bigint) {
+    const Mock = await ethers.getContractFactory("MockChainlinkAggregator");
+    const feed = await Mock.deploy(decimals, answer, now);
+    const Factory = await ethers.getContractFactory("ChainlinkPriceOracle");
+    const adapter = await Factory.deploy(await feed.getAddress(), "ETH/USD");
+    return { feed, adapter };
+  }
+
+  it("normalises an 8-decimal feed to 18 decimals", async () => {
+    const { adapter } = await deployFeed(8, 2000_0000_0000n); // 2000.00000000
+    const [price] = await adapter.latestPrice();
+    expect(price).to.equal(ethers.parseUnits("2000", 18));
+  });
+
+  it("passes an 18-decimal feed through unchanged", async () => {
+    const { adapter } = await deployFeed(18, ethers.parseUnits("2000", 18));
+    const [price] = await adapter.latestPrice();
+    expect(price).to.equal(ethers.parseUnits("2000", 18));
+  });
+
+  it("rejects a non-positive answer", async () => {
+    const { feed, adapter } = await deployFeed(8, 2000_0000_0000n);
+    await feed.setAnswer(0n);
+    await expect(adapter.latestPrice()).to.be.revertedWithCustomError(
+      adapter,
+      "NonPositiveAnswer",
+    );
+  });
+
+  it("rejects a negative answer", async () => {
+    const { feed, adapter } = await deployFeed(8, 2000_0000_0000n);
+    await feed.setAnswer(-1n);
+    await expect(adapter.latestPrice()).to.be.revertedWithCustomError(
+      adapter,
+      "NonPositiveAnswer",
+    );
+  });
+
+  it("rejects a round that never settled", async () => {
+    const { feed, adapter } = await deployFeed(8, 2000_0000_0000n);
+    await feed.setRounds(5n, 4n);
+    await expect(adapter.latestPrice()).to.be.revertedWithCustomError(
+      adapter,
+      "IncompleteRound",
+    );
+  });
+
+  it("rejects a feed with more than 18 decimals", async () => {
+    const Mock = await ethers.getContractFactory("MockChainlinkAggregator");
+    const feed = await Mock.deploy(19, 1n, now);
+    const Factory = await ethers.getContractFactory("ChainlinkPriceOracle");
+
+    await expect(
+      Factory.deploy(await feed.getAddress(), "bad"),
+    ).to.be.revertedWithCustomError(Factory, "UnsupportedDecimals");
+  });
+});
+
+describe("UniswapV3TwapOracle", () => {
+  before(async () => {
+    ({ ethers } = await network.connect());
+  });
+
+  async function deployTwap(meanTick: number, decimalAdjustment = 0) {
+    const Pool = await ethers.getContractFactory("MockUniswapV3Pool");
+    const pool = await Pool.deploy(meanTick);
+    const Factory = await ethers.getContractFactory("UniswapV3TwapOracle");
+    const adapter = await Factory.deploy(
+      await pool.getAddress(),
+      1800,
+      decimalAdjustment,
+      "ETH/USDC TWAP",
+    );
+    return { pool, adapter };
+  }
+
+  it("derives the mean tick from cumulative observations", async () => {
+    const { adapter } = await deployTwap(1000);
+    expect(await adapter.meanTick()).to.equal(1000n);
+  });
+
+  it("rounds a negative mean tick down, matching Uniswap", async () => {
+    const { adapter } = await deployTwap(-1000);
+    expect(await adapter.meanTick()).to.equal(-1000n);
+  });
+
+  // The point of these: prove 1.0001^tick is computed correctly rather than
+  // asserting whatever the contract happens to return.
+  const tickCases = [0, 1, 100, 1000, 10_000, -1000, -10_000, 50_000];
+
+  tickCases.forEach(tick => {
+    it(`prices tick ${tick} within 1e-6 of 1.0001^${tick}`, async () => {
+      const { adapter } = await deployTwap(tick);
+      const [onChain] = await adapter.latestPrice();
+
+      const expected = Math.pow(1.0001, tick);
+      const actual = Number(ethers.formatUnits(onChain, 18));
+      const relativeError = Math.abs(actual - expected) / expected;
+
+      expect(relativeError).to.be.lessThan(1e-6);
+    });
+  });
+
+  it("applies a positive decimal adjustment", async () => {
+    const { adapter } = await deployTwap(0, 2);
+    const [price] = await adapter.latestPrice();
+    expect(price).to.equal(ethers.parseUnits("100", 18));
+  });
+
+  it("rejects a tick beyond the supported range", async () => {
+    const { adapter } = await deployTwap(400_001);
+    await expect(adapter.latestPrice()).to.be.revertedWithCustomError(
+      adapter,
+      "TickOutOfRange",
+    );
+  });
+
+  it("rejects a zero averaging window", async () => {
+    const Pool = await ethers.getContractFactory("MockUniswapV3Pool");
+    const pool = await Pool.deploy(0);
+    const Factory = await ethers.getContractFactory("UniswapV3TwapOracle");
+
+    await expect(
+      Factory.deploy(await pool.getAddress(), 0, 0, "bad"),
+    ).to.be.revertedWithCustomError(Factory, "TwapPeriodZero");
+  });
+});
+
+describe("integration: Chainlink against Uniswap TWAP", () => {
+  before(async () => {
+    ({ ethers } = await network.connect());
+  });
+
+  it("blocks a high-value transfer when the TWAP drifts from the feed", async () => {
+    const now = Number((await ethers.provider.getBlock("latest"))!.timestamp);
+
+    // Chainlink says 1.0; the pool TWAP sits at tick 1000 (~1.105), a ~10%
+    // gap, far outside a 2% tolerance.
+    const Agg = await ethers.getContractFactory("MockChainlinkAggregator");
+    const feed = await Agg.deploy(8, 1_0000_0000n, now);
+    const ChainlinkFactory = await ethers.getContractFactory("ChainlinkPriceOracle");
+    const chainlink = await ChainlinkFactory.deploy(await feed.getAddress(), "A/USD");
+
+    const Pool = await ethers.getContractFactory("MockUniswapV3Pool");
+    const pool = await Pool.deploy(1000);
+    const TwapFactory = await ethers.getContractFactory("UniswapV3TwapOracle");
+    const twap = await TwapFactory.deploy(await pool.getAddress(), 1800, 0, "A/USD TWAP");
+
+    const Factory = await ethers.getContractFactory("BridgeMultiOracle");
+    const oracle = await Factory.deploy(
+      await chainlink.getAddress(),
+      await twap.getAddress(),
+      200n,
+      3600n,
+      ethers.parseUnits("1000", 18),
+    );
+
+    await expect(
+      oracle.validateTransfer(ethers.parseUnits("5000", 18)),
+    ).to.be.revertedWithCustomError(oracle, "OracleDeviationExceeded");
+  });
+
+  it("allows a high-value transfer when both sources agree", async () => {
+    const now = Number((await ethers.provider.getBlock("latest"))!.timestamp);
+
+    // Tick 0 is exactly 1.0, matching the Chainlink answer.
+    const Agg = await ethers.getContractFactory("MockChainlinkAggregator");
+    const feed = await Agg.deploy(8, 1_0000_0000n, now);
+    const ChainlinkFactory = await ethers.getContractFactory("ChainlinkPriceOracle");
+    const chainlink = await ChainlinkFactory.deploy(await feed.getAddress(), "A/USD");
+
+    const Pool = await ethers.getContractFactory("MockUniswapV3Pool");
+    const pool = await Pool.deploy(0);
+    const TwapFactory = await ethers.getContractFactory("UniswapV3TwapOracle");
+    const twap = await TwapFactory.deploy(await pool.getAddress(), 1800, 0, "A/USD TWAP");
+
+    const Factory = await ethers.getContractFactory("BridgeMultiOracle");
+    const oracle = await Factory.deploy(
+      await chainlink.getAddress(),
+      await twap.getAddress(),
+      200n,
+      3600n,
+      ethers.parseUnits("1000", 18),
+    );
+
+    const [valueUsd, , isHighValue] = await oracle.validateTransfer(
+      ethers.parseUnits("5000", 18),
+    );
+    expect(isHighValue).to.equal(true);
+    expect(valueUsd).to.equal(ethers.parseUnits("5000", 18));
+  });
+});

--- a/test/oracle/OracleMocks.sol
+++ b/test/oracle/OracleMocks.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IPriceOracle, IChainlinkAggregator, IUniswapV3PoolObserver} from "../../contracts/oracle/IPriceOracle.sol";
+
+/// @dev A controllable {IPriceOracle} for exercising the aggregator directly.
+contract MockPriceOracle is IPriceOracle {
+    uint256 private _price;
+    uint256 private _updatedAt;
+    bool private _shouldRevert;
+    string private _description;
+
+    error MockOracleFailure();
+
+    constructor(uint256 price_, uint256 updatedAt_, string memory description_) {
+        _price = price_;
+        _updatedAt = updatedAt_;
+        _description = description_;
+    }
+
+    function setPrice(uint256 price_) external {
+        _price = price_;
+    }
+
+    function setUpdatedAt(uint256 updatedAt_) external {
+        _updatedAt = updatedAt_;
+    }
+
+    function setShouldRevert(bool shouldRevert_) external {
+        _shouldRevert = shouldRevert_;
+    }
+
+    function latestPrice() external view returns (uint256, uint256) {
+        if (_shouldRevert) revert MockOracleFailure();
+        return (_price, _updatedAt);
+    }
+
+    function description() external view returns (string memory) {
+        return _description;
+    }
+}
+
+/// @dev Minimal controllable Chainlink aggregator.
+contract MockChainlinkAggregator is IChainlinkAggregator {
+    uint8 private immutable _decimals;
+    int256 private _answer;
+    uint256 private _updatedAt;
+    uint80 private _roundId = 1;
+    uint80 private _answeredInRound = 1;
+
+    constructor(uint8 decimals_, int256 answer_, uint256 updatedAt_) {
+        _decimals = decimals_;
+        _answer = answer_;
+        _updatedAt = updatedAt_;
+    }
+
+    function setAnswer(int256 answer_) external {
+        _answer = answer_;
+    }
+
+    function setUpdatedAt(uint256 updatedAt_) external {
+        _updatedAt = updatedAt_;
+    }
+
+    /// @dev Drives the incomplete-round path: answeredInRound < roundId.
+    function setRounds(uint80 roundId_, uint80 answeredInRound_) external {
+        _roundId = roundId_;
+        _answeredInRound = answeredInRound_;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80, int256, uint256, uint256, uint80)
+    {
+        return (_roundId, _answer, _updatedAt, _updatedAt, _answeredInRound);
+    }
+}
+
+/// @dev Uniswap V3 pool stub returning tick cumulatives that imply a chosen
+///      mean tick over the requested window.
+contract MockUniswapV3Pool is IUniswapV3PoolObserver {
+    int56 private _startCumulative;
+    int24 private _meanTick;
+
+    constructor(int24 meanTick_) {
+        _meanTick = meanTick_;
+    }
+
+    function setMeanTick(int24 meanTick_) external {
+        _meanTick = meanTick_;
+    }
+
+    function observe(uint32[] calldata secondsAgos)
+        external
+        view
+        returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityX128)
+    {
+        tickCumulatives = new int56[](secondsAgos.length);
+        secondsPerLiquidityX128 = new uint160[](secondsAgos.length);
+
+        // tickCumulatives[1] - tickCumulatives[0] == meanTick * period
+        int56 span = int56(int32(secondsAgos[0])) - int56(int32(secondsAgos[1]));
+        tickCumulatives[0] = _startCumulative;
+        tickCumulatives[1] = _startCumulative + int56(_meanTick) * span;
+    }
+}


### PR DESCRIPTION
Closes #846

## Summary

Adds `contracts/oracle/BridgeMultiOracle.sol`, which reads two independent price sources and refuses to value a transfer when they disagree by more than a configured margin — plus adapters for Chainlink and a Uniswap V3 TWAP so the two feeds are genuinely independent.

A single feed is a single point of failure. A manipulated spot pool, or a Chainlink feed stuck on stale data, will happily report a price that lets an attacker over-withdraw on the far side of a bridge. Requiring two sources to agree turns a silent mispricing into a revert.

## Requirements

| Requirement | Where |
|---|---|
| Query price feeds from both primary and fallback oracle contracts | `getValidatedPrice()` reads both through `IPriceOracle` |
| Calculate deviation percentage between price reports | `calculateDeviationBps()` |
| Revert with `OracleDeviationExceeded()` past the threshold | thrown with observed and permitted bps as arguments |
| Validates asset prices against multiple independent feeds | Chainlink adapter + Uniswap V3 TWAP adapter |
| Blocks high-value bridging operations during discrepancies | `validateTransfer()` |

## Two decisions worth reviewing

Both are about failing safe, and both are documented at the point they are made:

**Deviation is measured against the smaller of the two prices.** The same absolute gap then always yields the larger percentage. Measuring against the mean — the more common shortcut — under-reports precisely when the feeds diverge most, which is exactly when you want the number to be pessimistic.

**Valuation returns the higher of the two prices.** Since this contract gates on a high-value threshold, overstating value routes *more* transfers into the stricter path. Understating it would let a large transfer slip underneath the threshold, and that is the failure that actually costs money.

Below the threshold only the primary feed is consulted, which keeps routine transfers cheap; at or above it both must agree. A test covers exactly this: with the feeds disagreeing by 100%, a small transfer still succeeds while a large one reverts.

## Adapters

Both normalise to 18 decimals behind a common `IPriceOracle`, so the aggregator does not care where a price came from.

- **`ChainlinkPriceOracle`** rejects non-positive answers and rounds that never settled (`answeredInRound < roundId`). Both are real production failure modes, and both otherwise surface as a number that merely looks plausible.
- **`UniswapV3TwapOracle`** averages the tick over a window rather than reading spot, because spot is trivially moved inside a single block; averaging makes manipulation cost proportional to the window.

**No new dependencies.** The Chainlink and Uniswap interfaces are declared locally rather than pulling in two packages for two interfaces. Only OpenZeppelin, already a dependency, is used.

## On the tick maths — and a bug the tests caught

`1.0001 ^ tick` is computed by exponentiation by squaring from a base derived with integer arithmetic, rather than transcribing Uniswap's precomputed TickMath constants. A mistyped magic constant in a *safety* contract produces silently wrong prices, so I preferred something auditable by inspection and pinned by tests.

My first draft used plain shifts, `(a * b) >> 128`. **It overflowed**, and the tests caught it: the squared base passes 2^128 at fairly modest ticks, and the reciprocal `Q128 * Q128` overflows unconditionally. Every fixed-point multiply now goes through OpenZeppelin's `Math.mulDiv` for its 512-bit intermediate. The supported tick range is capped at ±400,000 and enforced, which keeps the intermediates inside uint256.

Eight tests assert the pricing lands within 1e-6 of independently computed `1.0001^tick` values across positive, negative and large ticks — verifying the maths rather than asserting whatever the contract happens to return.

## Tests

**45 passing.** Deviation maths (including symmetry and the measured-against-smaller property) · threshold boundaries · staleness in either feed · future timestamps · zero prices · the high-value gate · non-reverting `oraclesAgree()` including a feed that reverts · ownership and configuration bounds · both adapters · and end-to-end Chainlink-versus-TWAP cases in both directions.

## ⚠️ CI cannot verify this, for reasons that predate the PR

`npx hardhat compile` fails on `main` before reaching this contract. Five pre-existing failures, none related to this change:

| File | Problem |
|---|---|
| `contracts/bridge/BridgeGateway.sol:103` | a second file's `pragma` and imports pasted into the middle of a function body |
| `contracts/verifiers/YulEd25519Verifier.sol:98` | `} else {` inside assembly — Yul has no `else` |
| `test/relayer/MockGasTarget.sol:15,31` | `let _ := i` — `_` is reserved in Yul |
| `contracts/bridge/YulBatchUnlocker.sol:34` | non-literal constant referenced in inline assembly |
| `contracts/lightclient/YulLightClient.sol:97` | `pure` function performing a `staticcall` |

That matches CI, which is red on every recent run on `main`.

To validate this work I compiled and ran the suite against an isolated Hardhat config containing only these contracts; the harness was removed before committing, so the diff is only the six intended files. Separately, the existing tests under `test/` use the Hardhat 2 import style (`import { ethers } from "hardhat"`), which throws under the Hardhat 3 in `package.json`; this PR's test uses the Hardhat 3 `network.connect()` API so it actually runs.

I have deliberately fixed none of the above — it is outside #846. Happy to open a separate PR for the five compile errors, which would unblock every open PR against this repo including this one.
