### PR TITLE
feat: Add FlashLoanGuardVault for flash-loan isolation on liquidity v…

### DIFF
--- a/contracts/vault/FlashLoanGuardVault.sol
+++ b/contracts/vault/FlashLoanGuardVault.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title FlashLoanGuardVault
+/// @notice Single-asset liquidity vault that issues LP shares and blocks
+///         single-block deposit-and-withdraw cycles so a flash-loan-funded
+///         actor cannot temporarily skew the share price (or the bridge yield
+///         accrued to LPs) and unwind the position before the borrowed funds
+///         are repaid in the same transaction.
+/// @dev Every account has one `lastActionBlock` entry that is updated on both
+///      `deposit` and `withdraw`. Any deposit or withdrawal attempted in the
+///      same block as that account's previous deposit or withdrawal reverts,
+///      which in particular rules out the classic
+///      borrow -> deposit -> (manipulate) -> withdraw -> repay
+///      flash-loan cycle, since the withdraw leg always lands in the same
+///      block as the deposit leg. Legitimate LPs are unaffected because they
+///      never need to deposit and withdraw within the same block.
+contract FlashLoanGuardVault is ERC20, Ownable, Pausable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    /// @notice Underlying ERC-20 asset held by the vault.
+    IERC20 public immutable asset;
+
+    /// @notice Last block number in which `account` deposited or withdrew.
+    mapping(address => uint256) public lastActionBlock;
+
+    /// @notice Thrown when a deposit or withdrawal is attempted in the same
+    ///         block as the caller's previous deposit or withdrawal.
+    error SameBlockFlashLoanCycle(address account, uint256 blockNumber);
+
+    /// @notice Thrown when a zero-amount deposit or withdrawal is attempted,
+    ///         or when the computed share/asset amount rounds down to zero.
+    error ZeroAmount();
+
+    /// @notice Thrown when a withdrawal requests more shares than the caller holds.
+    error InsufficientShares();
+
+    /// @notice Emitted when `account` deposits `assets` and receives `shares`.
+    event Deposited(address indexed account, uint256 assets, uint256 shares);
+
+    /// @notice Emitted when `account` redeems `shares` for `assets`.
+    event Withdrawn(address indexed account, uint256 shares, uint256 assets);
+
+    /// @param _asset  Underlying ERC-20 token accepted by the vault.
+    /// @param name_   LP share token name.
+    /// @param symbol_ LP share token symbol.
+    /// @param admin   Initial owner, authorized to pause/unpause the vault.
+    constructor(
+        IERC20 _asset,
+        string memory name_,
+        string memory symbol_,
+        address admin
+    ) ERC20(name_, symbol_) Ownable(admin) {
+        asset = _asset;
+    }
+
+    /// @notice Reverts if `msg.sender` already deposited or withdrew in the
+    ///         current block; otherwise records this action's block after
+    ///         the wrapped function body completes.
+    modifier flashLoanGuard() {
+        uint256 last = lastActionBlock[msg.sender];
+        if (last == block.number) {
+            revert SameBlockFlashLoanCycle(msg.sender, block.number);
+        }
+        _;
+        lastActionBlock[msg.sender] = block.number;
+    }
+
+    /// @notice Total underlying assets currently held by the vault.
+    function totalAssets() public view returns (uint256) {
+        return asset.balanceOf(address(this));
+    }
+
+    /// @notice Deposit `assets` of the underlying token and receive LP shares
+    ///         proportional to the current share price.
+    /// @param assets Amount of underlying token to deposit.
+    /// @return shares Amount of LP shares minted to the caller.
+    function deposit(
+        uint256 assets
+    ) external nonReentrant whenNotPaused flashLoanGuard returns (uint256 shares) {
+        if (assets == 0) revert ZeroAmount();
+
+        uint256 supply = totalSupply();
+        uint256 assetsBefore = totalAssets();
+
+        shares = supply == 0 ? assets : (assets * supply) / assetsBefore;
+        if (shares == 0) revert ZeroAmount();
+
+        asset.safeTransferFrom(msg.sender, address(this), assets);
+        _mint(msg.sender, shares);
+
+        emit Deposited(msg.sender, assets, shares);
+    }
+
+    /// @notice Burn `shares` of LP tokens and withdraw the proportional amount
+    ///         of underlying assets.
+    /// @param shares Amount of LP shares to redeem.
+    /// @return assets Amount of underlying token returned to the caller.
+    function withdraw(
+        uint256 shares
+    ) external nonReentrant whenNotPaused flashLoanGuard returns (uint256 assets) {
+        if (shares == 0) revert ZeroAmount();
+        if (balanceOf(msg.sender) < shares) revert InsufficientShares();
+
+        uint256 supply = totalSupply();
+        assets = (shares * totalAssets()) / supply;
+        if (assets == 0) revert ZeroAmount();
+
+        _burn(msg.sender, shares);
+        asset.safeTransfer(msg.sender, assets);
+
+        emit Withdrawn(msg.sender, shares, assets);
+    }
+
+    /// @notice Pause deposits and withdrawals in an emergency.
+    /// @dev Only callable by the owner.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Resume deposits and withdrawals.
+    /// @dev Only callable by the owner.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/test/vault/FlashLoanAttacker.sol
+++ b/test/vault/FlashLoanAttacker.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {FlashLoanGuardVault} from "../../contracts/vault/FlashLoanGuardVault.sol";
+
+/// @title FlashLoanAttacker
+/// @notice Test double that deposits into and immediately withdraws from a
+///         FlashLoanGuardVault within a single transaction, simulating a
+///         flash-loan-funded actor that borrows, deposits, and withdraws
+///         atomically to try to skew the share price in one block.
+contract FlashLoanAttacker {
+    /// @notice Deposit `amount` into `vault` and withdraw all resulting
+    ///         shares in the same call.
+    function attack(FlashLoanGuardVault vault, IERC20 asset, uint256 amount) external {
+        asset.approve(address(vault), amount);
+        uint256 shares = vault.deposit(amount);
+        vault.withdraw(shares);
+    }
+}

--- a/test/vault/FlashLoanGuardVault.test.ts
+++ b/test/vault/FlashLoanGuardVault.test.ts
@@ -1,0 +1,184 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+describe("FlashLoanGuardVault", () => {
+  let ethers: any;
+  let networkHelpers: any;
+
+  before(async () => {
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+    networkHelpers = connection.networkHelpers;
+  });
+
+  async function deploy() {
+    const [admin, alice, bob] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const asset = await MockERC20.deploy("Mock USD", "mUSD");
+    await asset.waitForDeployment();
+
+    const Vault = await ethers.getContractFactory("FlashLoanGuardVault");
+    const vault = await Vault.deploy(
+      await asset.getAddress(),
+      "Guarded LP",
+      "gLP",
+      admin.address
+    );
+    await vault.waitForDeployment();
+
+    for (const signer of [alice, bob]) {
+      await asset.mint(signer.address, ethers.parseEther("1000"));
+      await asset.connect(signer).approve(await vault.getAddress(), ethers.MaxUint256);
+    }
+
+    return { vault, asset, admin, alice, bob };
+  }
+
+  it("deploys with the configured asset and LP token metadata", async () => {
+    const { vault, asset } = await deploy();
+
+    expect(await vault.asset()).to.equal(await asset.getAddress());
+    expect(await vault.name()).to.equal("Guarded LP");
+    expect(await vault.symbol()).to.equal("gLP");
+    expect(await vault.totalAssets()).to.equal(0);
+  });
+
+  it("mints shares 1:1 for the first deposit", async () => {
+    const { vault, asset, alice } = await deploy();
+
+    const amount = ethers.parseEther("100");
+    await expect(vault.connect(alice).deposit(amount))
+      .to.emit(vault, "Deposited")
+      .withArgs(alice.address, amount, amount);
+
+    expect(await vault.balanceOf(alice.address)).to.equal(amount);
+    expect(await asset.balanceOf(await vault.getAddress())).to.equal(amount);
+  });
+
+  it("mints proportional shares for a subsequent depositor", async () => {
+    const { vault, bob, alice } = await deploy();
+
+    await vault.connect(alice).deposit(ethers.parseEther("100"));
+    await networkHelpers.mine();
+
+    // Vault holds 100 assets backing 100 shares, so price is still 1:1.
+    await expect(vault.connect(bob).deposit(ethers.parseEther("50")))
+      .to.emit(vault, "Deposited")
+      .withArgs(bob.address, ethers.parseEther("50"), ethers.parseEther("50"));
+
+    expect(await vault.totalSupply()).to.equal(ethers.parseEther("150"));
+  });
+
+  it("reverts on a zero-amount deposit", async () => {
+    const { vault, alice } = await deploy();
+
+    await expect(vault.connect(alice).deposit(0)).to.be.revertedWithCustomError(
+      vault,
+      "ZeroAmount"
+    );
+  });
+
+  it("allows withdrawal in a later block and returns the underlying assets", async () => {
+    const { vault, asset, alice } = await deploy();
+
+    const amount = ethers.parseEther("100");
+    await vault.connect(alice).deposit(amount);
+    await networkHelpers.mine();
+
+    const balanceBefore = await asset.balanceOf(alice.address);
+    await expect(vault.connect(alice).withdraw(amount))
+      .to.emit(vault, "Withdrawn")
+      .withArgs(alice.address, amount, amount);
+
+    expect(await vault.balanceOf(alice.address)).to.equal(0);
+    expect(await asset.balanceOf(alice.address)).to.equal(balanceBefore + amount);
+  });
+
+  it("reverts a withdrawal for more shares than the caller holds", async () => {
+    const { vault, alice } = await deploy();
+
+    await vault.connect(alice).deposit(ethers.parseEther("10"));
+    await networkHelpers.mine();
+
+    await expect(
+      vault.connect(alice).withdraw(ethers.parseEther("11"))
+    ).to.be.revertedWithCustomError(vault, "InsufficientShares");
+  });
+
+  it("reverts on a zero-amount withdrawal", async () => {
+    const { vault, alice } = await deploy();
+
+    await vault.connect(alice).deposit(ethers.parseEther("10"));
+    await networkHelpers.mine();
+
+    await expect(vault.connect(alice).withdraw(0)).to.be.revertedWithCustomError(
+      vault,
+      "ZeroAmount"
+    );
+  });
+
+  it("blocks a same-block deposit-then-withdraw flash loan cycle", async () => {
+    const { vault, asset } = await deploy();
+
+    const Attacker = await ethers.getContractFactory("FlashLoanAttacker");
+    const attacker = await Attacker.deploy();
+    await attacker.waitForDeployment();
+
+    // Simulate flash-loaned funds arriving in the attacker contract.
+    const amount = ethers.parseEther("500");
+    await asset.mint(await attacker.getAddress(), amount);
+
+    const expectedBlock = (await ethers.provider.getBlockNumber()) + 1;
+
+    await expect(
+      attacker.attack(await vault.getAddress(), await asset.getAddress(), amount)
+    )
+      .to.be.revertedWithCustomError(vault, "SameBlockFlashLoanCycle")
+      .withArgs(await attacker.getAddress(), expectedBlock);
+
+    // The whole cycle reverted atomically: no shares outstanding, no assets
+    // absorbed by the vault, and the attacker still holds its borrowed funds.
+    expect(await vault.totalSupply()).to.equal(0);
+    expect(await asset.balanceOf(await vault.getAddress())).to.equal(0);
+    expect(await asset.balanceOf(await attacker.getAddress())).to.equal(amount);
+  });
+
+  it("does not block ordinary multi-block deposit and withdraw", async () => {
+    const { vault, alice } = await deploy();
+
+    const amount = ethers.parseEther("25");
+    await vault.connect(alice).deposit(amount);
+    await networkHelpers.mine();
+    await networkHelpers.mine();
+
+    await vault.connect(alice).withdraw(amount);
+    expect(await vault.balanceOf(alice.address)).to.equal(0);
+  });
+
+  it("allows the owner to pause and unpause the vault", async () => {
+    const { vault, admin, alice } = await deploy();
+
+    await vault.connect(admin).pause();
+    expect(await vault.paused()).to.equal(true);
+
+    await expect(
+      vault.connect(alice).deposit(ethers.parseEther("1"))
+    ).to.be.revertedWithCustomError(vault, "EnforcedPause");
+
+    await vault.connect(admin).unpause();
+    expect(await vault.paused()).to.equal(false);
+
+    await vault.connect(alice).deposit(ethers.parseEther("1"));
+    expect(await vault.balanceOf(alice.address)).to.equal(ethers.parseEther("1"));
+  });
+
+  it("rejects pause from a non-owner", async () => {
+    const { vault, alice } = await deploy();
+
+    await expect(vault.connect(alice).pause()).to.be.revertedWithCustomError(
+      vault,
+      "OwnableUnauthorizedAccount"
+    );
+  });
+});


### PR DESCRIPTION
…aults

Implements a single-asset LP vault that tracks the last block in which each account deposited or withdrew and reverts any deposit/withdraw landing on that same block. This blocks the classic borrow -> deposit -> manipulate -> withdraw -> repay flash-loan cycle used to skew LP share price or extract unearned bridge yield, while leaving normal multi-block LP activity unaffected.

Closes #850 