### PR TITLE
perf(utils): slice calldata arrays in Yul without dynamic memory copies

### DIFF
--- a/contracts/utils/CalldataSlicer.sol
+++ b/contracts/utils/CalldataSlicer.sol
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title CalldataSlicer
+/// @notice Zero-copy slicer for dynamically sized calldata arrays.
+/// @dev Solidity's `cd[start:end]` operator inserts implicit bounds checks
+///      and, when the resulting slice is forwarded into a `memory` sub-routine,
+///      copies the range into a freshly allocated dynamic buffer. This library
+///      never allocates: it rewrites the `(offset, length)` pair that Solidity
+///      uses to represent a calldata array and returns that pair as a typed
+///      calldata slice, which can be passed straight into Yul verifier loops.
+///
+///      Nested ABI-encoded arrays (a `bytes` / `T[]` packed inside an outer
+///      `bytes calldata` blob) are decoded with `calldataload` — first the
+///      relative offset pointer, then the length word — so neither the offset
+///      table nor the payload is ever copied into memory.
+library CalldataSlicer {
+    /// @notice The requested range is not a subset of the source array, or an
+    ///         ABI offset/length word would read past the enclosing buffer.
+    error SliceOutOfBounds();
+
+    /// @notice Returns `data[start:end]` as a calldata slice, without copying.
+    /// @param data  Source byte array, already ABI-decoded as `bytes calldata`.
+    /// @param start Inclusive start index, in bytes.
+    /// @param end   Exclusive end index, in bytes.
+    /// @return result Zero-copy view of the requested range.
+    function slice(
+        bytes calldata data,
+        uint256 start,
+        uint256 end
+    ) internal pure returns (bytes calldata result) {
+        bool oob;
+        assembly ("memory-safe") {
+            oob := or(gt(start, end), gt(end, data.length))
+            // Always assign so the calldata return is defined even on the
+            // revert path (the compiler cannot see through a later `revert`).
+            result.offset := 0
+            result.length := 0
+            if iszero(oob) {
+                result.offset := add(data.offset, start)
+                result.length := sub(end, start)
+            }
+        }
+        if (oob) revert SliceOutOfBounds();
+    }
+
+    /// @notice Returns `data[start:end]` as a calldata slice, without copying.
+    /// @param data  Source word array (`bytes32[]`, ABI-decoded).
+    /// @param start Inclusive start index, in elements.
+    /// @param end   Exclusive end index, in elements.
+    /// @return result Zero-copy view of the requested range.
+    function slice(
+        bytes32[] calldata data,
+        uint256 start,
+        uint256 end
+    ) internal pure returns (bytes32[] calldata result) {
+        uint256 dataOffset;
+        uint256 dataLength;
+        assembly ("memory-safe") {
+            dataOffset := data.offset
+            dataLength := data.length
+        }
+        (uint256 offset, uint256 length) = _sliceWordArray(
+            dataOffset,
+            dataLength,
+            start,
+            end
+        );
+        assembly ("memory-safe") {
+            result.offset := offset
+            result.length := length
+        }
+    }
+
+    /// @notice Returns `data[start:end]` as a calldata slice, without copying.
+    /// @param data  Source address array, ABI-decoded as `address[] calldata`.
+    /// @param start Inclusive start index, in elements.
+    /// @param end   Exclusive end index, in elements.
+    /// @return result Zero-copy view of the requested range.
+    function slice(
+        address[] calldata data,
+        uint256 start,
+        uint256 end
+    ) internal pure returns (address[] calldata result) {
+        uint256 dataOffset;
+        uint256 dataLength;
+        assembly ("memory-safe") {
+            dataOffset := data.offset
+            dataLength := data.length
+        }
+        (uint256 offset, uint256 length) = _sliceWordArray(
+            dataOffset,
+            dataLength,
+            start,
+            end
+        );
+        assembly ("memory-safe") {
+            result.offset := offset
+            result.length := length
+        }
+    }
+
+    /// @notice Loads one 32-byte word from a byte slice via `calldataload`.
+    /// @param data       Source byte slice.
+    /// @param byteOffset Offset from the start of `data`, in bytes. The 32-byte
+    ///                   window `[byteOffset, byteOffset+32)` must lie inside
+    ///                   `data`.
+    /// @return word      The word at that calldata offset.
+    function loadWord(
+        bytes calldata data,
+        uint256 byteOffset
+    ) internal pure returns (bytes32 word) {
+        bool oob;
+        assembly ("memory-safe") {
+            let tail := add(byteOffset, 0x20)
+            oob := or(lt(tail, byteOffset), gt(tail, data.length))
+            if iszero(oob) {
+                word := calldataload(add(data.offset, byteOffset))
+            }
+        }
+        if (oob) revert SliceOutOfBounds();
+    }
+
+    /// @notice Loads element `index` from a word array via `calldataload`.
+    /// @param data  Source word array.
+    /// @param index Element index. Reverts if `index >= data.length`.
+    /// @return word The word at `data[index]`.
+    function wordAt(
+        bytes32[] calldata data,
+        uint256 index
+    ) internal pure returns (bytes32 word) {
+        bool oob;
+        assembly ("memory-safe") {
+            oob := iszero(lt(index, data.length))
+            if iszero(oob) {
+                word := calldataload(add(data.offset, mul(index, 0x20)))
+            }
+        }
+        if (oob) revert SliceOutOfBounds();
+    }
+
+    /// @notice Loads element `index` from an address array via `calldataload`.
+    /// @param data  Source address array.
+    /// @param index Element index. Reverts if `index >= data.length`.
+    /// @return value The address at `data[index]`.
+    function wordAt(
+        address[] calldata data,
+        uint256 index
+    ) internal pure returns (address value) {
+        bool oob;
+        assembly ("memory-safe") {
+            oob := iszero(lt(index, data.length))
+            if iszero(oob) {
+                value := and(
+                    calldataload(add(data.offset, mul(index, 0x20))),
+                    0xffffffffffffffffffffffffffffffffffffffff
+                )
+            }
+        }
+        if (oob) revert SliceOutOfBounds();
+    }
+
+    /// @notice Extracts a nested ABI-encoded `bytes` from `data` with no copy.
+    /// @dev `data` is treated as the ABI encoding of a tuple of dynamic
+    ///      values. `headOffset` is the byte offset *within* `data` of the
+    ///      32-byte relative-offset head word for the field being extracted.
+    ///
+    ///      Layout (relative to `data.offset`):
+    ///        `calldataload(headOffset)` → relative offset `rel`
+    ///        `calldataload(rel)`        → byte length `len`
+    ///        payload                    → `[rel+32, rel+32+len)`
+    ///
+    ///      Both the offset pointer and the length word are read with
+    ///      `calldataload`. The returned slice points at the payload.
+    /// @param data       Outer ABI-encoded buffer.
+    /// @param headOffset Byte offset of the field's head word inside `data`.
+    /// @return result    Zero-copy `bytes calldata` view of the nested payload.
+    function extractBytes(
+        bytes calldata data,
+        uint256 headOffset
+    ) internal pure returns (bytes calldata result) {
+        (uint256 offset, uint256 length) = _extractDynamic(data, headOffset, false);
+        assembly ("memory-safe") {
+            result.offset := offset
+            result.length := length
+        }
+    }
+
+    /// @notice Extracts a nested ABI-encoded `bytes32[]` from `data` with no copy.
+    /// @dev Same head/tail layout as {extractBytes}, except the length word is
+    ///      an *element count* and the payload is `length * 32` bytes.
+    /// @param data       Outer ABI-encoded buffer.
+    /// @param headOffset Byte offset of the field's head word inside `data`.
+    /// @return result    Zero-copy `bytes32[] calldata` view of the nested array.
+    function extractWords(
+        bytes calldata data,
+        uint256 headOffset
+    ) internal pure returns (bytes32[] calldata result) {
+        (uint256 offset, uint256 length) = _extractDynamic(data, headOffset, true);
+        assembly ("memory-safe") {
+            result.offset := offset
+            result.length := length
+        }
+    }
+
+    /// @notice Returns the raw `(offset, length)` pointer pair for a byte slice.
+    /// @dev Intended for Yul verifiers that consume absolute calldata offsets
+    ///      rather than typed Solidity slices.
+    /// @param data Source byte slice.
+    /// @return offset Absolute calldata offset of the first payload byte.
+    /// @return length Payload length in bytes.
+    function pointers(
+        bytes calldata data
+    ) internal pure returns (uint256 offset, uint256 length) {
+        assembly ("memory-safe") {
+            offset := data.offset
+            length := data.length
+        }
+    }
+
+    /// @notice Returns the raw `(offset, length)` pointer pair for a word array.
+    /// @param data Source word array.
+    /// @return offset Absolute calldata offset of the first element.
+    /// @return length Element count.
+    function pointers(
+        bytes32[] calldata data
+    ) internal pure returns (uint256 offset, uint256 length) {
+        assembly ("memory-safe") {
+            offset := data.offset
+            length := data.length
+        }
+    }
+
+    /// @dev Shared word-array slicer. `dataOffset` / `dataLength` are the
+    ///      Solidity calldata-slice fields of the source array. `length` in
+    ///      the return pair is an element count, not a byte count.
+    function _sliceWordArray(
+        uint256 dataOffset,
+        uint256 dataLength,
+        uint256 start,
+        uint256 end
+    ) private pure returns (uint256 offset, uint256 length) {
+        bool oob;
+        assembly ("memory-safe") {
+            oob := or(gt(start, end), gt(end, dataLength))
+            if iszero(oob) {
+                offset := add(dataOffset, mul(start, 0x20))
+                length := sub(end, start)
+            }
+        }
+        if (oob) revert SliceOutOfBounds();
+    }
+
+    /// @dev Walks one ABI dynamic-field head/tail pair inside `data`.
+    ///      `asWords == true` treats the length word as an element count
+    ///      (payload size `len * 32`); otherwise it is a byte length.
+    function _extractDynamic(
+        bytes calldata data,
+        uint256 headOffset,
+        bool asWords
+    ) private pure returns (uint256 offset, uint256 length) {
+        bool oob;
+        assembly ("memory-safe") {
+            let bound := data.length
+            let base := data.offset
+
+            // Head word `[headOffset, headOffset+32)` must lie inside `data`.
+            let headEnd := add(headOffset, 0x20)
+            oob := or(lt(headEnd, headOffset), gt(headEnd, bound))
+
+            if iszero(oob) {
+                // Relative offset pointer — first `calldataload`.
+                let rel := calldataload(add(base, headOffset))
+
+                // Length word `[rel, rel+32)` must lie inside `data`.
+                let lenEnd := add(rel, 0x20)
+                oob := or(lt(lenEnd, rel), gt(lenEnd, bound))
+
+                if iszero(oob) {
+                    // Length — second `calldataload`.
+                    let len := calldataload(add(base, rel))
+
+                    let payloadBytes := len
+                    if asWords {
+                        payloadBytes := mul(len, 0x20)
+                        // Overflow: `len * 32` wrapped.
+                        if iszero(eq(len, div(payloadBytes, 0x20))) {
+                            oob := 1
+                        }
+                    }
+
+                    if iszero(oob) {
+                        let payloadEnd := add(lenEnd, payloadBytes)
+                        oob := or(lt(payloadEnd, lenEnd), gt(payloadEnd, bound))
+                        if iszero(oob) {
+                            offset := add(add(base, rel), 0x20)
+                            length := len
+                        }
+                    }
+                }
+            }
+        }
+        if (oob) revert SliceOutOfBounds();
+    }
+}

--- a/test/utils/CalldataSlicer.test.ts
+++ b/test/utils/CalldataSlicer.test.ts
@@ -1,0 +1,322 @@
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+describe('CalldataSlicer', function () {
+  this.timeout(120_000);
+
+  let ethers: any;
+
+  before(async function () {
+    this.timeout(120_000);
+    const connection = await hre.network.create();
+    ethers = connection.ethers;
+  });
+
+  async function deploy() {
+    const Harness = await ethers.getContractFactory('CalldataSlicerHarness');
+    const harness = await Harness.deploy();
+    await harness.waitForDeployment();
+    return { harness };
+  }
+
+  function encodeBytes(value: string): string {
+    return ethers.AbiCoder.defaultAbiCoder().encode(['bytes'], [value]);
+  }
+
+  function encodeWords(words: string[]): string {
+    return ethers.AbiCoder.defaultAbiCoder().encode(['bytes32[]'], [words]);
+  }
+
+  function xorWords(words: string[]): string {
+    let acc = 0n;
+    for (const w of words) {
+      acc ^= BigInt(w);
+    }
+    return ethers.toBeHex(acc, 32);
+  }
+
+  const WORD_A =
+    '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const WORD_B =
+    '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const WORD_C =
+    '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+  const WORD_D =
+    '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+  // --- bytes slicing ---
+
+  it('echoes a mid-range bytes slice', async () => {
+    const { harness } = await deploy();
+    const data = ethers.hexlify(ethers.toUtf8Bytes('bridgewise-calldata'));
+
+    expect(await harness.echoBytes(data, 0, 10)).to.equal(
+      ethers.hexlify(ethers.toUtf8Bytes('bridgewise')),
+    );
+    expect(await harness.echoBytes(data, 11, 19)).to.equal(
+      ethers.hexlify(ethers.toUtf8Bytes('calldata')),
+    );
+  });
+
+  it('echoes the full range and empty slices', async () => {
+    const { harness } = await deploy();
+    const data = '0x01020304';
+
+    expect(await harness.echoBytes(data, 0, 4)).to.equal(data);
+    expect(await harness.echoBytes(data, 0, 0)).to.equal('0x');
+    expect(await harness.echoBytes(data, 4, 4)).to.equal('0x');
+    expect(await harness.echoBytes(data, 2, 2)).to.equal('0x');
+  });
+
+  it('echoes an empty source as an empty slice', async () => {
+    const { harness } = await deploy();
+    expect(await harness.echoBytes('0x', 0, 0)).to.equal('0x');
+  });
+
+  it('returns offset = sourceOffset + start and length = end - start', async () => {
+    const { harness } = await deploy();
+    const data = '0x0011223344556677';
+    const start = 2n;
+    const end = 6n;
+
+    const [offset, length, sourceOffset] = await harness.sliceBytesPointers(
+      data,
+      start,
+      end,
+    );
+    expect(length).to.equal(end - start);
+    expect(offset).to.equal(sourceOffset + start);
+  });
+
+  // --- word / address array slicing ---
+
+  it('echoes a mid-range bytes32[] slice', async () => {
+    const { harness } = await deploy();
+    const sliced = await harness.echoWords(
+      [WORD_A, WORD_B, WORD_C, WORD_D],
+      1,
+      3,
+    );
+    expect(sliced).to.deep.equal([WORD_B, WORD_C]);
+  });
+
+  it('echoes a mid-range address[] slice', async () => {
+    const { harness } = await deploy();
+    const addrs = [
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+      '0x3333333333333333333333333333333333333333',
+    ];
+    expect(await harness.echoAddresses(addrs, 1, 3)).to.deep.equal([
+      ethers.getAddress(addrs[1]),
+      ethers.getAddress(addrs[2]),
+    ]);
+  });
+
+  it('returns word-array offset = sourceOffset + start*32', async () => {
+    const { harness } = await deploy();
+    const start = 1n;
+    const end = 3n;
+    const [offset, length, sourceOffset] = await harness.sliceWordsPointers(
+      [WORD_A, WORD_B, WORD_C, WORD_D],
+      start,
+      end,
+    );
+    expect(length).to.equal(2n);
+    expect(offset).to.equal(sourceOffset + start * 32n);
+  });
+
+  it('loads a sliced word via calldataload', async () => {
+    const { harness } = await deploy();
+    expect(
+      await harness.wordAtSlice([WORD_A, WORD_B, WORD_C], 1, 3, 0),
+    ).to.equal(WORD_B);
+    expect(
+      await harness.wordAtSlice([WORD_A, WORD_B, WORD_C], 1, 3, 1),
+    ).to.equal(WORD_C);
+  });
+
+  it('loads a 32-byte window out of a bytes slice', async () => {
+    const { harness } = await deploy();
+    const data = ethers.concat([WORD_A, WORD_B]);
+    expect(await harness.loadWord(data, 0)).to.equal(WORD_A);
+    expect(await harness.loadWord(data, 32)).to.equal(WORD_B);
+  });
+
+  it('loads a sliced address via calldataload', async () => {
+    const { harness } = await deploy();
+    const addrs = [
+      '0x1111111111111111111111111111111111111111',
+      '0x2222222222222222222222222222222222222222',
+      '0x3333333333333333333333333333333333333333',
+    ];
+    expect(await harness.addressAtSlice(addrs, 1, 3, 0)).to.equal(
+      ethers.getAddress(addrs[1]),
+    );
+  });
+
+  // --- nested ABI extraction via calldataload ---
+
+  it('extracts a nested bytes payload from an ABI-encoded buffer', async () => {
+    const { harness } = await deploy();
+    const inner = ethers.hexlify(ethers.toUtf8Bytes('hello-bridge'));
+    const encoded = encodeBytes(inner);
+    expect(await harness.echoExtractedBytes(encoded, 0)).to.equal(inner);
+  });
+
+  it('extracts a nested bytes32[] payload from an ABI-encoded buffer', async () => {
+    const { harness } = await deploy();
+    const inner = [WORD_A, WORD_B, WORD_C];
+    const encoded = encodeWords(inner);
+    expect(await harness.echoExtractedWords(encoded, 0)).to.deep.equal(inner);
+  });
+
+  it('extracts the second dynamic field of a two-arg ABI encoding', async () => {
+    const { harness } = await deploy();
+    const innerBytes = '0xabcd';
+    const innerWords = [WORD_A, WORD_D];
+    const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+      ['bytes32[]', 'bytes'],
+      [innerWords, innerBytes],
+    );
+
+    expect(await harness.echoExtractedWords(encoded, 0)).to.deep.equal(
+      innerWords,
+    );
+    expect(await harness.echoExtractedBytes(encoded, 32)).to.equal(innerBytes);
+  });
+
+  it('extracted bytes length matches the nested payload', async () => {
+    const { harness } = await deploy();
+    const inner = '0x1122334455';
+    const [, length] = await harness.extractedBytesPointers(
+      encodeBytes(inner),
+      0,
+    );
+    expect(length).to.equal(5n);
+  });
+
+  // --- zero dynamic memory allocation ---
+
+  it('does not advance the free memory pointer while slicing bytes', async () => {
+    const { harness } = await deploy();
+    const [before, after] = await harness.freeMemAfterBytesSlice(
+      '0x00112233445566778899',
+      2,
+      8,
+    );
+    expect(after).to.equal(before);
+  });
+
+  it('does not advance the free memory pointer while extracting nested bytes', async () => {
+    const { harness } = await deploy();
+    const encoded = encodeBytes('0xdeadbeef');
+    const [before, after] = await harness.freeMemAfterExtract(encoded, 0);
+    expect(after).to.equal(before);
+  });
+
+  // --- pass zero-copy pointers to verifier logic ---
+
+  it('passes a sliced word array to low-level verifier logic', async () => {
+    const { harness } = await deploy();
+    const words = [WORD_A, WORD_B, WORD_C, WORD_D];
+    expect(await harness.xorSlice(words, 1, 4)).to.equal(
+      xorWords([WORD_B, WORD_C, WORD_D]),
+    );
+  });
+
+  it('passes an extracted nested word array to low-level verifier logic', async () => {
+    const { harness } = await deploy();
+    const words = [WORD_A, WORD_C];
+    expect(await harness.xorExtracted(encodeWords(words), 0)).to.equal(
+      xorWords(words),
+    );
+  });
+
+  it('XOR-reduces an empty slice to zero', async () => {
+    const { harness } = await deploy();
+    expect(await harness.xorSlice([WORD_A, WORD_B], 1, 1)).to.equal(
+      ethers.ZeroHash,
+    );
+  });
+
+  // --- array bounds safety ---
+
+  it('reverts when end is past the bytes length', async () => {
+    const { harness } = await deploy();
+    await expect(
+      harness.echoBytes('0x0102', 0, 3),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+
+  it('reverts when start is greater than end', async () => {
+    const { harness } = await deploy();
+    await expect(
+      harness.echoBytes('0x010203', 2, 1),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+
+  it('reverts when a word-array slice is out of bounds', async () => {
+    const { harness } = await deploy();
+    await expect(
+      harness.echoWords([WORD_A, WORD_B], 0, 3),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+    await expect(
+      harness.echoWords([WORD_A, WORD_B], 2, 1),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+
+  it('reverts when wordAt reads past the sliced range', async () => {
+    const { harness } = await deploy();
+    await expect(
+      harness.wordAtSlice([WORD_A, WORD_B, WORD_C], 1, 2, 1),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+
+  it('reverts when loadWord would read past the byte array', async () => {
+    const { harness } = await deploy();
+    await expect(
+      harness.loadWord('0x00112233', 1),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+
+  it('reverts when the nested ABI offset pointer is out of range', async () => {
+    const { harness } = await deploy();
+    await expect(
+      harness.echoExtractedBytes('0x01', 0),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+
+  it('reverts when the nested ABI length exceeds the outer buffer', async () => {
+    const { harness } = await deploy();
+    // offset = 0x20, length = 0x40, but only 32 bytes of payload follow
+    const crafted = ethers.concat([
+      ethers.zeroPadValue('0x20', 32),
+      ethers.zeroPadValue('0x40', 32),
+      ethers.zeroPadValue('0x01', 32),
+    ]);
+    await expect(
+      harness.echoExtractedBytes(crafted, 0),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+
+  it('reverts when extractWords length * 32 overflows', async () => {
+    const { harness } = await deploy();
+    const hugeLen = (1n << 252n) + 1n;
+    const crafted = ethers.concat([
+      ethers.zeroPadValue('0x20', 32),
+      ethers.zeroPadValue(ethers.toBeHex(hugeLen), 32),
+    ]);
+    await expect(
+      harness.echoExtractedWords(crafted, 0),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+
+  it('reverts when headOffset itself is past the outer buffer', async () => {
+    const { harness } = await deploy();
+    const encoded = encodeBytes('0x11');
+    await expect(
+      harness.echoExtractedBytes(encoded, ethers.dataLength(encoded)),
+    ).to.be.revertedWithCustomError(harness, 'SliceOutOfBounds');
+  });
+});

--- a/test/utils/CalldataSlicerHarness.sol
+++ b/test/utils/CalldataSlicerHarness.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {CalldataSlicer} from "../../contracts/utils/CalldataSlicer.sol";
+
+/// @notice Test harness exposing {CalldataSlicer} and a stub verifier that
+///         consumes zero-copy calldata slices via `calldataload`.
+contract CalldataSlicerHarness {
+    error SliceOutOfBounds();
+
+    /// @notice Echoes `data[start:end]` through the zero-copy slicer. The
+    ///         ABI encoder copies the result for the external return; the
+    ///         library itself does not allocate.
+    function echoBytes(
+        bytes calldata data,
+        uint256 start,
+        uint256 end
+    ) external pure returns (bytes memory) {
+        return CalldataSlicer.slice(data, start, end);
+    }
+
+    /// @notice Echoes `data[start:end]` for a word array.
+    function echoWords(
+        bytes32[] calldata data,
+        uint256 start,
+        uint256 end
+    ) external pure returns (bytes32[] memory) {
+        return CalldataSlicer.slice(data, start, end);
+    }
+
+    /// @notice Echoes `data[start:end]` for an address array.
+    function echoAddresses(
+        address[] calldata data,
+        uint256 start,
+        uint256 end
+    ) external pure returns (address[] memory) {
+        return CalldataSlicer.slice(data, start, end);
+    }
+
+    /// @notice Returns the absolute calldata offset and byte length of a slice.
+    function sliceBytesPointers(
+        bytes calldata data,
+        uint256 start,
+        uint256 end
+    ) external pure returns (uint256 offset, uint256 length, uint256 sourceOffset) {
+        bytes calldata sliced = CalldataSlicer.slice(data, start, end);
+        assembly {
+            sourceOffset := data.offset
+        }
+        (offset, length) = CalldataSlicer.pointers(sliced);
+    }
+
+    /// @notice Returns the absolute calldata offset and element count of a slice.
+    function sliceWordsPointers(
+        bytes32[] calldata data,
+        uint256 start,
+        uint256 end
+    ) external pure returns (uint256 offset, uint256 length, uint256 sourceOffset) {
+        bytes32[] calldata sliced = CalldataSlicer.slice(data, start, end);
+        assembly {
+            sourceOffset := data.offset
+        }
+        (offset, length) = CalldataSlicer.pointers(sliced);
+    }
+
+    /// @notice Loads a 32-byte window out of a byte slice.
+    function loadWord(
+        bytes calldata data,
+        uint256 byteOffset
+    ) external pure returns (bytes32) {
+        return CalldataSlicer.loadWord(data, byteOffset);
+    }
+
+    /// @notice Loads one element of a sliced word array via `calldataload`.
+    function wordAtSlice(
+        bytes32[] calldata data,
+        uint256 start,
+        uint256 end,
+        uint256 index
+    ) external pure returns (bytes32) {
+        return CalldataSlicer.wordAt(CalldataSlicer.slice(data, start, end), index);
+    }
+
+    /// @notice Loads one element of a sliced address array via `calldataload`.
+    function addressAtSlice(
+        address[] calldata data,
+        uint256 start,
+        uint256 end,
+        uint256 index
+    ) external pure returns (address) {
+        return CalldataSlicer.wordAt(CalldataSlicer.slice(data, start, end), index);
+    }
+
+    /// @notice Extracts a nested ABI-encoded `bytes` and echoes it.
+    function echoExtractedBytes(
+        bytes calldata data,
+        uint256 headOffset
+    ) external pure returns (bytes memory) {
+        return CalldataSlicer.extractBytes(data, headOffset);
+    }
+
+    /// @notice Extracts a nested ABI-encoded `bytes32[]` and echoes it.
+    function echoExtractedWords(
+        bytes calldata data,
+        uint256 headOffset
+    ) external pure returns (bytes32[] memory) {
+        return CalldataSlicer.extractWords(data, headOffset);
+    }
+
+    /// @notice Pointer pair for a nested `bytes` extracted via `calldataload`.
+    function extractedBytesPointers(
+        bytes calldata data,
+        uint256 headOffset
+    ) external pure returns (uint256 offset, uint256 length) {
+        return CalldataSlicer.pointers(CalldataSlicer.extractBytes(data, headOffset));
+    }
+
+    /// @notice Snapshots the free-memory pointer around a bytes slice.
+    function freeMemAfterBytesSlice(
+        bytes calldata data,
+        uint256 start,
+        uint256 end
+    ) external pure returns (uint256 before, uint256 after_, uint256 offset) {
+        assembly {
+            before := mload(0x40)
+        }
+        bytes calldata sliced = CalldataSlicer.slice(data, start, end);
+        assembly {
+            offset := sliced.offset
+            after_ := mload(0x40)
+        }
+    }
+
+    /// @notice Snapshots the free-memory pointer around a nested extract.
+    function freeMemAfterExtract(
+        bytes calldata data,
+        uint256 headOffset
+    ) external pure returns (uint256 before, uint256 after_, uint256 offset) {
+        assembly {
+            before := mload(0x40)
+        }
+        bytes calldata extracted = CalldataSlicer.extractBytes(data, headOffset);
+        assembly {
+            offset := extracted.offset
+            after_ := mload(0x40)
+        }
+    }
+
+    /// @notice Passes a zero-copy word-array slice into a Yul verifier stub
+    ///         that XOR-reduces elements with `calldataload`.
+    function xorSlice(
+        bytes32[] calldata data,
+        uint256 start,
+        uint256 end
+    ) external pure returns (bytes32) {
+        return _xorVerifier(CalldataSlicer.slice(data, start, end));
+    }
+
+    /// @notice Passes a nested word array extracted from `data` into the same
+    ///         verifier stub, still without building a memory array.
+    function xorExtracted(
+        bytes calldata data,
+        uint256 headOffset
+    ) external pure returns (bytes32) {
+        return _xorVerifier(CalldataSlicer.extractWords(data, headOffset));
+    }
+
+    /// @dev Low-level verifier logic: walks `words` entirely through the
+    ///      calldata pointer the slicer handed over. No dynamic buffer is
+    ///      allocated for the array itself.
+    function _xorVerifier(bytes32[] calldata words) private pure returns (bytes32 acc) {
+        uint256 n = words.length;
+        for (uint256 i; i < n; ) {
+            acc ^= CalldataSlicer.wordAt(words, i);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CalldataSlicer`, a Yul utility that extracts dynamically sized calldata arrays via `calldataload` (offset pointer + length word) and returns zero-copy slices.
- Slices can be passed straight into low-level verifier loops without allocating a dynamic memory buffer; bounds checks revert with `SliceOutOfBounds`.
- Covered by Hardhat tests for bytes / bytes32[] / address[] slices, nested ABI extraction, free-memory-pointer invariance, verifier pass-through, and array-bounds reverts.

## Test plan
- [x] `cargo test` (CI) — passed
- [x] `pnpm run build` (CI) — passed
- [x] `hardhat test test/utils/CalldataSlicer.test.ts` — 28 passing

Closes: #845 