### PR TITLE
feat: add Soroban contract address resolver for Stellar networks

### DIFF
--- a/src/config/networks/index.ts
+++ b/src/config/networks/index.ts
@@ -1,0 +1,9 @@
+export {
+  StellarNetwork,
+  STELLAR_NETWORK_PASSPHRASES,
+  DEFAULT_NETWORK_CONFIGS,
+  SUPPORTED_NETWORKS,
+  isSupportedNetwork,
+  getNetworkConfig,
+} from './stellar-networks';
+export type { StellarNetworkConfig } from './stellar-networks';

--- a/src/config/networks/stellar-networks.ts
+++ b/src/config/networks/stellar-networks.ts
@@ -1,0 +1,141 @@
+/**
+ * File: src/config/networks/stellar-networks.ts
+ *
+ * Stellar/Soroban network identifiers, configuration types, and per-network
+ * defaults. These values are used by SorobanContractResolver to determine
+ * which contract address to return for a given network.
+ */
+
+/**
+ * Canonical identifiers for supported Stellar networks.
+ */
+export enum StellarNetwork {
+  /** Stellar public (main) network */
+  MAINNET = 'mainnet',
+  /** Stellar testnet — free XLM, resets periodically */
+  TESTNET = 'testnet',
+  /** Futurenet — preview of upcoming protocol changes */
+  FUTURENET = 'futurenet',
+  /** Local development / standalone node */
+  DEVELOPMENT = 'development',
+}
+
+/**
+ * Configuration for a specific Stellar network.
+ */
+export interface StellarNetworkConfig {
+  /** Canonical identifier for the network */
+  network: StellarNetwork;
+  /** Human-readable label */
+  label: string;
+  /** Network passphrase used for transaction signing */
+  networkPassphrase: string;
+  /** Default Horizon REST API URL */
+  horizonUrl: string;
+  /** Default Soroban RPC URL */
+  sorobanRpcUrl: string;
+  /** Whether this is a production (non-test) environment */
+  isProduction: boolean;
+}
+
+/**
+ * Well-known network passphrases as defined by the Stellar protocol.
+ */
+export const STELLAR_NETWORK_PASSPHRASES: Record<StellarNetwork, string> = {
+  [StellarNetwork.MAINNET]: 'Public Global Stellar Network ; September 2015',
+  [StellarNetwork.TESTNET]: 'Test SDF Network ; September 2015',
+  [StellarNetwork.FUTURENET]: 'Test SDF Future Network ; October 2022',
+  [StellarNetwork.DEVELOPMENT]: 'Standalone Network ; February 2017',
+};
+
+/**
+ * Default configurations for each supported Stellar network.
+ *
+ * These can be overridden at runtime via environment variables:
+ *   STELLAR_MAINNET_HORIZON_URL
+ *   STELLAR_MAINNET_SOROBAN_RPC_URL
+ *   STELLAR_TESTNET_HORIZON_URL
+ *   STELLAR_TESTNET_SOROBAN_RPC_URL
+ *   STELLAR_FUTURENET_HORIZON_URL
+ *   STELLAR_FUTURENET_SOROBAN_RPC_URL
+ *   STELLAR_DEVELOPMENT_HORIZON_URL
+ *   STELLAR_DEVELOPMENT_SOROBAN_RPC_URL
+ */
+export const DEFAULT_NETWORK_CONFIGS: Record<StellarNetwork, StellarNetworkConfig> = {
+  [StellarNetwork.MAINNET]: {
+    network: StellarNetwork.MAINNET,
+    label: 'Stellar Mainnet',
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASES[StellarNetwork.MAINNET],
+    horizonUrl:
+      process.env.STELLAR_MAINNET_HORIZON_URL ?? 'https://horizon.stellar.org',
+    sorobanRpcUrl:
+      process.env.STELLAR_MAINNET_SOROBAN_RPC_URL ??
+      'https://soroban-rpc.stellar.org',
+    isProduction: true,
+  },
+
+  [StellarNetwork.TESTNET]: {
+    network: StellarNetwork.TESTNET,
+    label: 'Stellar Testnet',
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASES[StellarNetwork.TESTNET],
+    horizonUrl:
+      process.env.STELLAR_TESTNET_HORIZON_URL ??
+      'https://horizon-testnet.stellar.org',
+    sorobanRpcUrl:
+      process.env.STELLAR_TESTNET_SOROBAN_RPC_URL ??
+      'https://soroban-testnet.stellar.org',
+    isProduction: false,
+  },
+
+  [StellarNetwork.FUTURENET]: {
+    network: StellarNetwork.FUTURENET,
+    label: 'Stellar Futurenet',
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASES[StellarNetwork.FUTURENET],
+    horizonUrl:
+      process.env.STELLAR_FUTURENET_HORIZON_URL ??
+      'https://horizon-futurenet.stellar.org',
+    sorobanRpcUrl:
+      process.env.STELLAR_FUTURENET_SOROBAN_RPC_URL ??
+      'https://rpc-futurenet.stellar.org',
+    isProduction: false,
+  },
+
+  [StellarNetwork.DEVELOPMENT]: {
+    network: StellarNetwork.DEVELOPMENT,
+    label: 'Local Development',
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASES[StellarNetwork.DEVELOPMENT],
+    horizonUrl:
+      process.env.STELLAR_DEVELOPMENT_HORIZON_URL ?? 'http://localhost:8000',
+    sorobanRpcUrl:
+      process.env.STELLAR_DEVELOPMENT_SOROBAN_RPC_URL ??
+      'http://localhost:8000/soroban/rpc',
+    isProduction: false,
+  },
+};
+
+/**
+ * Set of all supported network identifiers for fast membership checks.
+ */
+export const SUPPORTED_NETWORKS = new Set<string>(Object.values(StellarNetwork));
+
+/**
+ * Returns true when the provided string is a valid StellarNetwork value.
+ */
+export function isSupportedNetwork(value: string): value is StellarNetwork {
+  return SUPPORTED_NETWORKS.has(value);
+}
+
+/**
+ * Returns the StellarNetworkConfig for a given network identifier.
+ * Throws UnsupportedNetworkError when the network is not recognized.
+ */
+export function getNetworkConfig(network: StellarNetwork): StellarNetworkConfig {
+  const config = DEFAULT_NETWORK_CONFIGS[network];
+  if (!config) {
+    throw new Error(
+      `[getNetworkConfig] Unsupported network: "${network}". ` +
+        `Supported: ${[...SUPPORTED_NETWORKS].join(', ')}`,
+    );
+  }
+  return config;
+}

--- a/src/resolvers/contracts/index.ts
+++ b/src/resolvers/contracts/index.ts
@@ -1,0 +1,1 @@
+export * from './soroban';

--- a/src/resolvers/contracts/soroban/index.ts
+++ b/src/resolvers/contracts/soroban/index.ts
@@ -1,0 +1,16 @@
+export {
+  SorobanContractResolver,
+  sorobanContractResolver,
+} from './soroban-contract-resolver.service';
+export type { } from './soroban-contract-resolver.service';
+
+export {
+  UnsupportedNetworkError,
+  ContractNotFoundError,
+  DuplicateContractError,
+} from './soroban-contract-resolver.types';
+export type {
+  ContractEntry,
+  ResolveOptions,
+  ResolveResult,
+} from './soroban-contract-resolver.types';

--- a/src/resolvers/contracts/soroban/soroban-contract-resolver.service.ts
+++ b/src/resolvers/contracts/soroban/soroban-contract-resolver.service.ts
@@ -1,0 +1,305 @@
+/**
+ * File: src/resolvers/contracts/soroban/soroban-contract-resolver.service.ts
+ *
+ * Resolves the correct Soroban contract address for a requested Stellar
+ * network.  The resolver integrates with a simple in-process contract
+ * registry and supports environment-variable overrides for each
+ * contract/network pair, allowing zero-downtime address changes via
+ * deployment configuration rather than code changes.
+ *
+ * @example
+ * const resolver = new SorobanContractResolver();
+ *
+ * resolver.register({
+ *   contractName: 'bridge_vault',
+ *   network: StellarNetwork.TESTNET,
+ *   address: 'CATEST...',
+ *   envOverrideKey: 'BRIDGE_VAULT_TESTNET_ADDRESS',
+ * });
+ *
+ * const result = resolver.resolve('bridge_vault', StellarNetwork.TESTNET);
+ * console.log(result.address); // env override if set, otherwise 'CATEST...'
+ */
+
+import {
+  StellarNetwork,
+  isSupportedNetwork,
+} from '../../../config/networks/stellar-networks';
+import {
+  ContractEntry,
+  ResolveOptions,
+  ResolveResult,
+  UnsupportedNetworkError,
+  ContractNotFoundError,
+  DuplicateContractError,
+} from './soroban-contract-resolver.types';
+
+/** Internal map key format: "<normalised-name>@<network>" */
+function registryKey(contractName: string, network: StellarNetwork): string {
+  return `${contractName.toLowerCase().trim()}@${network}`;
+}
+
+export class SorobanContractResolver {
+  private readonly registry = new Map<string, ContractEntry>();
+
+  // ─── Registration ───────────────────────────────────────────────────────
+
+  /**
+   * Add a single contract entry to the registry.
+   *
+   * @throws {UnsupportedNetworkError} if `entry.network` is not a valid
+   *   StellarNetwork value.
+   * @throws {DuplicateContractError} if a registration for the same
+   *   contractName/network pair already exists.
+   */
+  register(entry: ContractEntry): void {
+    this.assertNetworkSupported(entry.network);
+
+    const key = registryKey(entry.contractName, entry.network);
+    if (this.registry.has(key)) {
+      throw new DuplicateContractError(entry.contractName, entry.network);
+    }
+
+    this.registry.set(key, {
+      ...entry,
+      contractName: entry.contractName.toLowerCase().trim(),
+    });
+  }
+
+  /**
+   * Register multiple entries in a single call.
+   * All entries are validated before any are written; on failure the
+   * registry is left unchanged.
+   *
+   * @throws {UnsupportedNetworkError} for any entry with an invalid network.
+   * @throws {DuplicateContractError} if any entry would overwrite an
+   *   existing registration.
+   */
+  registerBatch(entries: ContractEntry[]): void {
+    // Validate all first so the registry is never partially written
+    for (const entry of entries) {
+      this.assertNetworkSupported(entry.network);
+      const key = registryKey(entry.contractName, entry.network);
+      if (this.registry.has(key)) {
+        throw new DuplicateContractError(entry.contractName, entry.network);
+      }
+    }
+    for (const entry of entries) {
+      this.register(entry);
+    }
+  }
+
+  /**
+   * Update the address (and optionally other fields) for an existing
+   * registry entry.  This is intentionally separate from register() so
+   * address changes require an explicit decision.
+   *
+   * @throws {ContractNotFoundError} if the entry does not exist yet.
+   */
+  update(
+    contractName: string,
+    network: StellarNetwork,
+    changes: Partial<Pick<ContractEntry, 'address' | 'envOverrideKey' | 'description' | 'metadata'>>,
+  ): ContractEntry {
+    this.assertNetworkSupported(network);
+    const key = registryKey(contractName, network);
+    const existing = this.registry.get(key);
+    if (!existing) {
+      throw new ContractNotFoundError(contractName, network);
+    }
+    const updated: ContractEntry = { ...existing, ...changes };
+    this.registry.set(key, updated);
+    return updated;
+  }
+
+  /**
+   * Remove an entry from the registry.
+   * Returns true when the entry existed and was removed, false otherwise.
+   */
+  deregister(contractName: string, network: StellarNetwork): boolean {
+    this.assertNetworkSupported(network);
+    return this.registry.delete(registryKey(contractName, network));
+  }
+
+  // ─── Resolution ─────────────────────────────────────────────────────────
+
+  /**
+   * Resolve the contract address for a given name and network.
+   *
+   * Resolution order:
+   *   1. If `entry.envOverrideKey` is set **and** options.ignoreEnvOverride
+   *      is false, check `process.env[envOverrideKey]`.  If non-empty, use
+   *      that address and set resolvedFromEnv = true.
+   *   2. Otherwise return the static address stored in the registry entry.
+   *
+   * @throws {UnsupportedNetworkError} when `network` is not a recognised
+   *   StellarNetwork value.
+   * @throws {ContractNotFoundError} when no entry matches the name/network
+   *   pair.
+   */
+  resolve(
+    contractName: string,
+    network: StellarNetwork,
+    options: ResolveOptions = {},
+  ): ResolveResult {
+    this.assertNetworkSupported(network);
+
+    const key = registryKey(contractName, network);
+    const entry = this.registry.get(key);
+    if (!entry) {
+      throw new ContractNotFoundError(contractName, network);
+    }
+
+    let address = entry.address;
+    let resolvedFromEnv = false;
+
+    if (!options.ignoreEnvOverride && entry.envOverrideKey) {
+      const envValue = process.env[entry.envOverrideKey];
+      if (envValue && envValue.trim().length > 0) {
+        address = envValue.trim();
+        resolvedFromEnv = true;
+      }
+    }
+
+    return {
+      contractName: entry.contractName,
+      network,
+      address,
+      resolvedFromEnv,
+      entry,
+    };
+  }
+
+  /**
+   * Resolve all registered contracts for a given network.
+   * Contracts with env overrides applied will have resolvedFromEnv = true.
+   *
+   * @throws {UnsupportedNetworkError} when `network` is invalid.
+   */
+  resolveAll(network: StellarNetwork, options: ResolveOptions = {}): ResolveResult[] {
+    this.assertNetworkSupported(network);
+
+    const results: ResolveResult[] = [];
+    for (const entry of this.registry.values()) {
+      if (entry.network === network) {
+        results.push(this.resolve(entry.contractName, network, options));
+      }
+    }
+    return results;
+  }
+
+  // ─── Introspection ───────────────────────────────────────────────────────
+
+  /**
+   * Return the raw registry entry for a contract/network pair without
+   * applying env overrides.
+   */
+  getEntry(contractName: string, network: StellarNetwork): ContractEntry | undefined {
+    if (!isSupportedNetwork(network)) return undefined;
+    return this.registry.get(registryKey(contractName, network));
+  }
+
+  /**
+   * Return all registered entries, optionally filtered by network.
+   */
+  listEntries(network?: StellarNetwork): ContractEntry[] {
+    const all = Array.from(this.registry.values());
+    return network ? all.filter((e) => e.network === network) : all;
+  }
+
+  /**
+   * Returns true when a registration exists for the given name/network.
+   */
+  has(contractName: string, network: StellarNetwork): boolean {
+    if (!isSupportedNetwork(network)) return false;
+    return this.registry.has(registryKey(contractName, network));
+  }
+
+  /**
+   * Clear all entries (useful in tests).
+   */
+  clear(): void {
+    this.registry.clear();
+  }
+
+  // ─── Private helpers ─────────────────────────────────────────────────────
+
+  private assertNetworkSupported(network: string): asserts network is StellarNetwork {
+    if (!isSupportedNetwork(network)) {
+      throw new UnsupportedNetworkError(network);
+    }
+  }
+}
+
+/**
+ * Default singleton resolver pre-seeded with well-known BridgeWise Soroban
+ * contract addresses.
+ *
+ * Addresses can be overridden at deploy time via the documented environment
+ * variables without touching this file.
+ */
+export const sorobanContractResolver = new SorobanContractResolver();
+
+sorobanContractResolver.registerBatch([
+  // ── Bridge Vault ──────────────────────────────────────────────────────
+  {
+    contractName: 'bridge_vault',
+    network: StellarNetwork.MAINNET,
+    address: 'CABRIDGE_VAULT_MAINNET_PLACEHOLDER_ADDRESS00000000000000000',
+    envOverrideKey: 'SOROBAN_BRIDGE_VAULT_MAINNET_ADDRESS',
+    description: 'Primary bridge vault on Stellar Mainnet',
+  },
+  {
+    contractName: 'bridge_vault',
+    network: StellarNetwork.TESTNET,
+    address: 'CABRIDGE_VAULT_TESTNET_PLACEHOLDER_ADDRESS00000000000000000',
+    envOverrideKey: 'SOROBAN_BRIDGE_VAULT_TESTNET_ADDRESS',
+    description: 'Bridge vault on Stellar Testnet',
+  },
+  {
+    contractName: 'bridge_vault',
+    network: StellarNetwork.FUTURENET,
+    address: 'CABRIDGE_VAULT_FUTURENET_PLACEHOLDER_ADDRESS0000000000000000',
+    envOverrideKey: 'SOROBAN_BRIDGE_VAULT_FUTURENET_ADDRESS',
+    description: 'Bridge vault on Stellar Futurenet',
+  },
+  {
+    contractName: 'bridge_vault',
+    network: StellarNetwork.DEVELOPMENT,
+    address: 'CABRIDGE_VAULT_DEVELOPMENT_PLACEHOLDER_ADDRESS000000000000000',
+    envOverrideKey: 'SOROBAN_BRIDGE_VAULT_DEVELOPMENT_ADDRESS',
+    description: 'Bridge vault on local development node',
+  },
+
+  // ── Atomic Swap ───────────────────────────────────────────────────────
+  {
+    contractName: 'atomic_swap',
+    network: StellarNetwork.MAINNET,
+    address: 'CAATOMIC_SWAP_MAINNET_PLACEHOLDER_ADDRESS000000000000000000',
+    envOverrideKey: 'SOROBAN_ATOMIC_SWAP_MAINNET_ADDRESS',
+    description: 'Atomic swap contract on Stellar Mainnet',
+  },
+  {
+    contractName: 'atomic_swap',
+    network: StellarNetwork.TESTNET,
+    address: 'CAATOMIC_SWAP_TESTNET_PLACEHOLDER_ADDRESS000000000000000000',
+    envOverrideKey: 'SOROBAN_ATOMIC_SWAP_TESTNET_ADDRESS',
+    description: 'Atomic swap contract on Stellar Testnet',
+  },
+  {
+    contractName: 'atomic_swap',
+    network: StellarNetwork.FUTURENET,
+    address: 'CAATOMIC_SWAP_FUTURENET_PLACEHOLDER_ADDRESS00000000000000000',
+    envOverrideKey: 'SOROBAN_ATOMIC_SWAP_FUTURENET_ADDRESS',
+    description: 'Atomic swap contract on Stellar Futurenet',
+  },
+  {
+    contractName: 'atomic_swap',
+    network: StellarNetwork.DEVELOPMENT,
+    address: 'CAATOMIC_SWAP_DEVELOPMENT_PLACEHOLDER_ADDRESS0000000000000000',
+    envOverrideKey: 'SOROBAN_ATOMIC_SWAP_DEVELOPMENT_ADDRESS',
+    description: 'Atomic swap contract on local development node',
+  },
+]);
+
+export default sorobanContractResolver;

--- a/src/resolvers/contracts/soroban/soroban-contract-resolver.types.ts
+++ b/src/resolvers/contracts/soroban/soroban-contract-resolver.types.ts
@@ -1,0 +1,121 @@
+/**
+ * File: src/resolvers/contracts/soroban/soroban-contract-resolver.types.ts
+ *
+ * Type definitions for the Soroban contract address resolver.
+ */
+
+import { StellarNetwork } from '../../../config/networks/stellar-networks';
+
+/**
+ * A single entry in the contract registry describing one contract
+ * deployment for a specific network.
+ */
+export interface ContractEntry {
+  /**
+   * Logical name / identifier for this contract (e.g. "bridge_vault",
+   * "atomic_swap").  Case-insensitive during lookups.
+   */
+  contractName: string;
+
+  /** The Stellar network where this contract is deployed. */
+  network: StellarNetwork;
+
+  /**
+   * The on-chain Soroban contract address (C… StrKey).
+   * May be overridden at runtime via an environment variable whose name is
+   * stored in envOverrideKey.
+   */
+  address: string;
+
+  /**
+   * Optional name of an environment variable whose value, if present,
+   * supersedes `address` at resolution time.
+   *
+   * Example: `"BRIDGE_VAULT_MAINNET_ADDRESS"`
+   */
+  envOverrideKey?: string;
+
+  /** Human-readable description of the contract's purpose. */
+  description?: string;
+
+  /** Arbitrary metadata attached to this contract entry. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options accepted by SorobanContractResolver.resolve().
+ */
+export interface ResolveOptions {
+  /**
+   * When true, bypass the environment-variable override and return the
+   * static `address` stored in the registry entry.
+   * Default: false.
+   */
+  ignoreEnvOverride?: boolean;
+}
+
+/**
+ * Result returned by SorobanContractResolver.resolve().
+ */
+export interface ResolveResult {
+  /** Logical name of the contract that was resolved. */
+  contractName: string;
+
+  /** Stellar network on which the address is valid. */
+  network: StellarNetwork;
+
+  /**
+   * The resolved contract address.
+   * This will be the env-override value when one is set, otherwise the
+   * static address from the registry.
+   */
+  address: string;
+
+  /** True when the address came from an environment variable override. */
+  resolvedFromEnv: boolean;
+
+  /** Full registry entry for this contract/network pair. */
+  entry: ContractEntry;
+}
+
+/**
+ * Error thrown when a caller requests an address for a network that is
+ * not in the set of supported StellarNetwork values.
+ */
+export class UnsupportedNetworkError extends Error {
+  constructor(network: string) {
+    super(
+      `[SorobanContractResolver] Unsupported network: "${network}". ` +
+        `Supported networks: ${Object.values(StellarNetwork).join(', ')}`,
+    );
+    this.name = 'UnsupportedNetworkError';
+  }
+}
+
+/**
+ * Error thrown when no contract entry matches the requested name/network
+ * combination.
+ */
+export class ContractNotFoundError extends Error {
+  constructor(contractName: string, network: StellarNetwork) {
+    super(
+      `[SorobanContractResolver] No contract registered for ` +
+        `"${contractName}" on network "${network}".`,
+    );
+    this.name = 'ContractNotFoundError';
+  }
+}
+
+/**
+ * Error thrown when a duplicate contract entry is registered for the same
+ * name/network pair.
+ */
+export class DuplicateContractError extends Error {
+  constructor(contractName: string, network: StellarNetwork) {
+    super(
+      `[SorobanContractResolver] A contract entry for ` +
+        `"${contractName}" on network "${network}" is already registered.`,
+    );
+    this.name = 'DuplicateContractError';
+  }
+}

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,0 +1,1 @@
+export * from './contracts';

--- a/tests/resolvers/contracts/soroban-contract-resolver.spec.ts
+++ b/tests/resolvers/contracts/soroban-contract-resolver.spec.ts
@@ -1,0 +1,495 @@
+/**
+ * File: tests/resolvers/contracts/soroban-contract-resolver.spec.ts
+ *
+ * Unit tests for SorobanContractResolver.
+ *
+ * Coverage:
+ *   ✓ Contract resolver implemented and instantiable
+ *   ✓ Network-specific addresses returned correctly
+ *   ✓ Unsupported networks are rejected (UnsupportedNetworkError)
+ *   ✓ Environment-variable overrides are applied when set
+ *   ✓ Env overrides can be bypassed with ignoreEnvOverride
+ *   ✓ Missing contract raises ContractNotFoundError
+ *   ✓ Duplicate registration raises DuplicateContractError
+ *   ✓ Batch registration and rollback on conflict
+ *   ✓ Update, deregister, has, listEntries, resolveAll
+ *   ✓ Singleton sorobanContractResolver is pre-seeded
+ */
+
+import { SorobanContractResolver, sorobanContractResolver } from '../../../src/resolvers/contracts/soroban/soroban-contract-resolver.service';
+import {
+  ContractNotFoundError,
+  DuplicateContractError,
+  UnsupportedNetworkError,
+} from '../../../src/resolvers/contracts/soroban/soroban-contract-resolver.types';
+import { StellarNetwork } from '../../../src/config/networks/stellar-networks';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const TESTNET_ADDR = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVLIHE';
+const MAINNET_ADDR = 'CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBULIHE';
+const ENV_ADDR = 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCULIHE';
+
+function freshResolver(): SorobanContractResolver {
+  return new SorobanContractResolver();
+}
+
+// ─── Describe: instantiation ──────────────────────────────────────────────────
+
+describe('SorobanContractResolver', () => {
+  describe('instantiation', () => {
+    it('creates a fresh empty resolver', () => {
+      const resolver = freshResolver();
+      expect(resolver.listEntries()).toHaveLength(0);
+    });
+  });
+
+  // ─── Describe: register ────────────────────────────────────────────────────
+
+  describe('register()', () => {
+    it('stores an entry and makes it retrievable via has()', () => {
+      const resolver = freshResolver();
+      resolver.register({
+        contractName: 'my_contract',
+        network: StellarNetwork.TESTNET,
+        address: TESTNET_ADDR,
+      });
+      expect(resolver.has('my_contract', StellarNetwork.TESTNET)).toBe(true);
+    });
+
+    it('normalises contract names to lowercase', () => {
+      const resolver = freshResolver();
+      resolver.register({
+        contractName: 'My_Contract',
+        network: StellarNetwork.TESTNET,
+        address: TESTNET_ADDR,
+      });
+      expect(resolver.has('my_contract', StellarNetwork.TESTNET)).toBe(true);
+      expect(resolver.getEntry('MY_CONTRACT', StellarNetwork.TESTNET)).toBeDefined();
+    });
+
+    it('throws UnsupportedNetworkError for an unknown network string', () => {
+      const resolver = freshResolver();
+      expect(() =>
+        resolver.register({
+          contractName: 'x',
+          network: 'zanzibar' as StellarNetwork,
+          address: TESTNET_ADDR,
+        }),
+      ).toThrow(UnsupportedNetworkError);
+    });
+
+    it('throws DuplicateContractError on second registration for same name+network', () => {
+      const resolver = freshResolver();
+      resolver.register({
+        contractName: 'vault',
+        network: StellarNetwork.TESTNET,
+        address: TESTNET_ADDR,
+      });
+      expect(() =>
+        resolver.register({
+          contractName: 'vault',
+          network: StellarNetwork.TESTNET,
+          address: MAINNET_ADDR,
+        }),
+      ).toThrow(DuplicateContractError);
+    });
+
+    it('allows the same name on different networks', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+      resolver.register({ contractName: 'vault', network: StellarNetwork.MAINNET, address: MAINNET_ADDR });
+      expect(resolver.has('vault', StellarNetwork.TESTNET)).toBe(true);
+      expect(resolver.has('vault', StellarNetwork.MAINNET)).toBe(true);
+    });
+  });
+
+  // ─── Describe: registerBatch ──────────────────────────────────────────────
+
+  describe('registerBatch()', () => {
+    it('registers multiple entries at once', () => {
+      const resolver = freshResolver();
+      resolver.registerBatch([
+        { contractName: 'a', network: StellarNetwork.TESTNET, address: TESTNET_ADDR },
+        { contractName: 'b', network: StellarNetwork.MAINNET, address: MAINNET_ADDR },
+      ]);
+      expect(resolver.has('a', StellarNetwork.TESTNET)).toBe(true);
+      expect(resolver.has('b', StellarNetwork.MAINNET)).toBe(true);
+    });
+
+    it('leaves the registry unchanged when any entry would be a duplicate', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'a', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+
+      expect(() =>
+        resolver.registerBatch([
+          { contractName: 'new_one', network: StellarNetwork.TESTNET, address: TESTNET_ADDR },
+          { contractName: 'a', network: StellarNetwork.TESTNET, address: MAINNET_ADDR }, // duplicate
+        ]),
+      ).toThrow(DuplicateContractError);
+
+      // 'new_one' must NOT have been persisted despite being valid
+      expect(resolver.has('new_one', StellarNetwork.TESTNET)).toBe(false);
+    });
+  });
+
+  // ─── Describe: resolve – network-specific addresses ───────────────────────
+
+  describe('resolve() – network-specific addresses', () => {
+    it('returns the testnet address for StellarNetwork.TESTNET', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+      resolver.register({ contractName: 'vault', network: StellarNetwork.MAINNET, address: MAINNET_ADDR });
+
+      const result = resolver.resolve('vault', StellarNetwork.TESTNET);
+      expect(result.address).toBe(TESTNET_ADDR);
+      expect(result.network).toBe(StellarNetwork.TESTNET);
+      expect(result.resolvedFromEnv).toBe(false);
+    });
+
+    it('returns the mainnet address for StellarNetwork.MAINNET', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+      resolver.register({ contractName: 'vault', network: StellarNetwork.MAINNET, address: MAINNET_ADDR });
+
+      const result = resolver.resolve('vault', StellarNetwork.MAINNET);
+      expect(result.address).toBe(MAINNET_ADDR);
+      expect(result.network).toBe(StellarNetwork.MAINNET);
+    });
+
+    it('returns the futurenet address for StellarNetwork.FUTURENET', () => {
+      const resolver = freshResolver();
+      const futurenetAddr = 'CDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
+      resolver.register({ contractName: 'vault', network: StellarNetwork.FUTURENET, address: futurenetAddr });
+
+      const result = resolver.resolve('vault', StellarNetwork.FUTURENET);
+      expect(result.address).toBe(futurenetAddr);
+      expect(result.network).toBe(StellarNetwork.FUTURENET);
+    });
+
+    it('returns the development address for StellarNetwork.DEVELOPMENT', () => {
+      const resolver = freshResolver();
+      const devAddr = 'CEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+      resolver.register({ contractName: 'vault', network: StellarNetwork.DEVELOPMENT, address: devAddr });
+
+      const result = resolver.resolve('vault', StellarNetwork.DEVELOPMENT);
+      expect(result.address).toBe(devAddr);
+    });
+
+    it('includes the full ContractEntry in the result', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR, description: 'test vault' });
+
+      const result = resolver.resolve('vault', StellarNetwork.TESTNET);
+      expect(result.entry.description).toBe('test vault');
+      expect(result.contractName).toBe('vault');
+    });
+
+    it('is case-insensitive on contractName lookup', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'Bridge_Vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+
+      const result = resolver.resolve('BRIDGE_VAULT', StellarNetwork.TESTNET);
+      expect(result.address).toBe(TESTNET_ADDR);
+    });
+  });
+
+  // ─── Describe: resolve – unsupported network rejection ────────────────────
+
+  describe('resolve() – unsupported network rejection', () => {
+    it('throws UnsupportedNetworkError for an invalid network string', () => {
+      const resolver = freshResolver();
+      expect(() =>
+        resolver.resolve('vault', 'ethereum' as StellarNetwork),
+      ).toThrow(UnsupportedNetworkError);
+    });
+
+    it('error message names the offending network', () => {
+      const resolver = freshResolver();
+      try {
+        resolver.resolve('vault', 'not_a_network' as StellarNetwork);
+        fail('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(UnsupportedNetworkError);
+        expect((err as Error).message).toContain('not_a_network');
+      }
+    });
+
+    it('throws UnsupportedNetworkError from register() for unsupported networks', () => {
+      const resolver = freshResolver();
+      expect(() =>
+        resolver.register({ contractName: 'x', network: 'rinkeby' as StellarNetwork, address: 'CA...' }),
+      ).toThrow(UnsupportedNetworkError);
+    });
+  });
+
+  // ─── Describe: resolve – missing contract ─────────────────────────────────
+
+  describe('resolve() – ContractNotFoundError', () => {
+    it('throws when no entry exists for the name+network', () => {
+      const resolver = freshResolver();
+      expect(() =>
+        resolver.resolve('nonexistent', StellarNetwork.TESTNET),
+      ).toThrow(ContractNotFoundError);
+    });
+
+    it('throws when entry exists on a different network', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+
+      expect(() =>
+        resolver.resolve('vault', StellarNetwork.MAINNET),
+      ).toThrow(ContractNotFoundError);
+    });
+
+    it('error message includes contract name and network', () => {
+      const resolver = freshResolver();
+      try {
+        resolver.resolve('my_contract', StellarNetwork.TESTNET);
+      } catch (err) {
+        expect((err as Error).message).toContain('my_contract');
+        expect((err as Error).message).toContain(StellarNetwork.TESTNET);
+      }
+    });
+  });
+
+  // ─── Describe: environment-variable overrides ─────────────────────────────
+
+  describe('resolve() – environment-variable overrides', () => {
+    const ENV_KEY = 'TEST_CONTRACT_ADDRESS_OVERRIDE';
+
+    afterEach(() => {
+      delete process.env[ENV_KEY];
+    });
+
+    it('uses the env override address when the env var is set', () => {
+      process.env[ENV_KEY] = ENV_ADDR;
+      const resolver = freshResolver();
+      resolver.register({
+        contractName: 'vault',
+        network: StellarNetwork.TESTNET,
+        address: TESTNET_ADDR,
+        envOverrideKey: ENV_KEY,
+      });
+
+      const result = resolver.resolve('vault', StellarNetwork.TESTNET);
+      expect(result.address).toBe(ENV_ADDR);
+      expect(result.resolvedFromEnv).toBe(true);
+    });
+
+    it('falls back to static address when env var is not set', () => {
+      delete process.env[ENV_KEY]; // ensure unset
+      const resolver = freshResolver();
+      resolver.register({
+        contractName: 'vault',
+        network: StellarNetwork.TESTNET,
+        address: TESTNET_ADDR,
+        envOverrideKey: ENV_KEY,
+      });
+
+      const result = resolver.resolve('vault', StellarNetwork.TESTNET);
+      expect(result.address).toBe(TESTNET_ADDR);
+      expect(result.resolvedFromEnv).toBe(false);
+    });
+
+    it('ignores the env override when ignoreEnvOverride is true', () => {
+      process.env[ENV_KEY] = ENV_ADDR;
+      const resolver = freshResolver();
+      resolver.register({
+        contractName: 'vault',
+        network: StellarNetwork.TESTNET,
+        address: TESTNET_ADDR,
+        envOverrideKey: ENV_KEY,
+      });
+
+      const result = resolver.resolve('vault', StellarNetwork.TESTNET, { ignoreEnvOverride: true });
+      expect(result.address).toBe(TESTNET_ADDR);
+      expect(result.resolvedFromEnv).toBe(false);
+    });
+
+    it('ignores whitespace-only env var values', () => {
+      process.env[ENV_KEY] = '   ';
+      const resolver = freshResolver();
+      resolver.register({
+        contractName: 'vault',
+        network: StellarNetwork.TESTNET,
+        address: TESTNET_ADDR,
+        envOverrideKey: ENV_KEY,
+      });
+
+      const result = resolver.resolve('vault', StellarNetwork.TESTNET);
+      expect(result.address).toBe(TESTNET_ADDR);
+      expect(result.resolvedFromEnv).toBe(false);
+    });
+
+    it('trims whitespace from env var value', () => {
+      process.env[ENV_KEY] = `  ${ENV_ADDR}  `;
+      const resolver = freshResolver();
+      resolver.register({
+        contractName: 'vault',
+        network: StellarNetwork.TESTNET,
+        address: TESTNET_ADDR,
+        envOverrideKey: ENV_KEY,
+      });
+
+      const result = resolver.resolve('vault', StellarNetwork.TESTNET);
+      expect(result.address).toBe(ENV_ADDR);
+      expect(result.resolvedFromEnv).toBe(true);
+    });
+  });
+
+  // ─── Describe: update() ───────────────────────────────────────────────────
+
+  describe('update()', () => {
+    it('updates the address of an existing entry', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+
+      const updated = resolver.update('vault', StellarNetwork.TESTNET, { address: MAINNET_ADDR });
+      expect(updated.address).toBe(MAINNET_ADDR);
+
+      const resolved = resolver.resolve('vault', StellarNetwork.TESTNET);
+      expect(resolved.address).toBe(MAINNET_ADDR);
+    });
+
+    it('throws ContractNotFoundError for non-existent entry', () => {
+      const resolver = freshResolver();
+      expect(() =>
+        resolver.update('nonexistent', StellarNetwork.TESTNET, { address: TESTNET_ADDR }),
+      ).toThrow(ContractNotFoundError);
+    });
+  });
+
+  // ─── Describe: deregister() ───────────────────────────────────────────────
+
+  describe('deregister()', () => {
+    it('removes an existing entry and returns true', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+
+      expect(resolver.deregister('vault', StellarNetwork.TESTNET)).toBe(true);
+      expect(resolver.has('vault', StellarNetwork.TESTNET)).toBe(false);
+    });
+
+    it('returns false when entry did not exist', () => {
+      const resolver = freshResolver();
+      expect(resolver.deregister('ghost', StellarNetwork.TESTNET)).toBe(false);
+    });
+  });
+
+  // ─── Describe: resolveAll() ───────────────────────────────────────────────
+
+  describe('resolveAll()', () => {
+    it('returns all entries for a given network', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+      resolver.register({ contractName: 'swap', network: StellarNetwork.TESTNET, address: MAINNET_ADDR });
+      resolver.register({ contractName: 'vault', network: StellarNetwork.MAINNET, address: MAINNET_ADDR });
+
+      const results = resolver.resolveAll(StellarNetwork.TESTNET);
+      expect(results).toHaveLength(2);
+      const names = results.map((r) => r.contractName);
+      expect(names).toContain('vault');
+      expect(names).toContain('swap');
+    });
+
+    it('returns an empty array when no contracts are registered for the network', () => {
+      const resolver = freshResolver();
+      expect(resolver.resolveAll(StellarNetwork.TESTNET)).toHaveLength(0);
+    });
+
+    it('throws UnsupportedNetworkError for invalid network', () => {
+      const resolver = freshResolver();
+      expect(() =>
+        resolver.resolveAll('badnet' as StellarNetwork),
+      ).toThrow(UnsupportedNetworkError);
+    });
+  });
+
+  // ─── Describe: listEntries() ──────────────────────────────────────────────
+
+  describe('listEntries()', () => {
+    it('lists all entries when no filter is given', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'a', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+      resolver.register({ contractName: 'b', network: StellarNetwork.MAINNET, address: MAINNET_ADDR });
+
+      expect(resolver.listEntries()).toHaveLength(2);
+    });
+
+    it('filters by network when a filter is provided', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'a', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+      resolver.register({ contractName: 'b', network: StellarNetwork.MAINNET, address: MAINNET_ADDR });
+
+      const testnet = resolver.listEntries(StellarNetwork.TESTNET);
+      expect(testnet).toHaveLength(1);
+      expect(testnet[0].contractName).toBe('a');
+    });
+  });
+
+  // ─── Describe: clear() ───────────────────────────────────────────────────
+
+  describe('clear()', () => {
+    it('removes all registered entries', () => {
+      const resolver = freshResolver();
+      resolver.register({ contractName: 'vault', network: StellarNetwork.TESTNET, address: TESTNET_ADDR });
+      resolver.clear();
+      expect(resolver.listEntries()).toHaveLength(0);
+    });
+  });
+
+  // ─── Describe: singleton sorobanContractResolver ─────────────────────────
+
+  describe('sorobanContractResolver (singleton)', () => {
+    it('is an instance of SorobanContractResolver', () => {
+      expect(sorobanContractResolver).toBeInstanceOf(SorobanContractResolver);
+    });
+
+    it('is pre-seeded with bridge_vault entries for all networks', () => {
+      for (const network of Object.values(StellarNetwork)) {
+        expect(sorobanContractResolver.has('bridge_vault', network)).toBe(true);
+      }
+    });
+
+    it('is pre-seeded with atomic_swap entries for all networks', () => {
+      for (const network of Object.values(StellarNetwork)) {
+        expect(sorobanContractResolver.has('atomic_swap', network)).toBe(true);
+      }
+    });
+
+    it('resolves bridge_vault on testnet to a non-empty address', () => {
+      const result = sorobanContractResolver.resolve('bridge_vault', StellarNetwork.TESTNET);
+      expect(result.address).toBeTruthy();
+      expect(result.network).toBe(StellarNetwork.TESTNET);
+    });
+
+    it('testnet and mainnet bridge_vault addresses are different', () => {
+      const testnet = sorobanContractResolver.resolve('bridge_vault', StellarNetwork.TESTNET);
+      const mainnet = sorobanContractResolver.resolve('bridge_vault', StellarNetwork.MAINNET);
+      expect(testnet.address).not.toBe(mainnet.address);
+    });
+  });
+
+  // ─── Describe: error type names ───────────────────────────────────────────
+
+  describe('error type names', () => {
+    it('UnsupportedNetworkError has correct name', () => {
+      const err = new UnsupportedNetworkError('badnet');
+      expect(err.name).toBe('UnsupportedNetworkError');
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('ContractNotFoundError has correct name', () => {
+      const err = new ContractNotFoundError('vault', StellarNetwork.TESTNET);
+      expect(err.name).toBe('ContractNotFoundError');
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('DuplicateContractError has correct name', () => {
+      const err = new DuplicateContractError('vault', StellarNetwork.TESTNET);
+      expect(err.name).toBe('DuplicateContractError');
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+});


### PR DESCRIPTION
feat: Soroban contract address resolver for Stellar networks
  
  Summary
  
  Implements a network-aware contract address resolver for Soroban contracts deployed across
  Stellar environments. Solves the problem of the same integration using different contract
  deployments on testnet, mainnet, futurenet, and local development — previously there was no
  single place to look up the correct address for a given network.
  
  Changes
  
  src/config/networks/
  
  - StellarNetwork enum (mainnet | testnet | futurenet | development)
  - StellarNetworkConfig interface with per-network Horizon URL, Soroban RPC URL, and network
  passphrase
  - Default configs driven by environment variables (STELLAR_<NETWORK>_HORIZON_URL,
  STELLAR_<NETWORK>_SOROBAN_RPC_URL) so URLs can be changed at deploy time without code changes
  
  src/resolvers/contracts/soroban/
  
  - SorobanContractResolver — core resolver class with register, registerBatch, resolve,
  resolveAll, update, deregister, has, listEntries, and clear
  - Environment-variable override support per contract entry (envOverrideKey) — when set, the
  resolved address comes from the env var rather than the static registry value;
  ResolveResult.resolvedFromEnv signals which path was taken
  - Typed errors: UnsupportedNetworkError, ContractNotFoundError, DuplicateContractError
  - Pre-seeded singleton sorobanContractResolver with bridge_vault and atomic_swap entries
  across all four networks, ready to use out of the box
  
  tests/resolvers/contracts/
  
  - 43 unit tests covering all acceptance criteria: resolver instantiation, per-network address
  resolution, unsupported network rejection, missing contract errors, env override
  apply/bypass/whitespace handling, batch registration atomicity, update, deregister, and
  singleton seeding
  
  Test results
  
  Tests: 43 passed, 43 total
  Test Suites: 1 passed, 1 total
  
  How to use
  
  import { sorobanContractResolver } from 'src/resolvers/contracts/soroban';
  import { StellarNetwork } from 'src/config/networks';
  
  // Resolve a pre-registered contract
  const result = sorobanContractResolver.resolve('bridge_vault', StellarNetwork.TESTNET);
  console.log(result.address);        // static address or env override
  console.log(result.resolvedFromEnv); // true when SOROBAN_BRIDGE_VAULT_TESTNET_ADDRESS is set
  
  // Register a custom contract
  sorobanContractResolver.register({
    contractName: 'my_contract',
    network: StellarNetwork.MAINNET,
    address: 'CA...',
    envOverrideKey: 'MY_CONTRACT_MAINNET_ADDRESS',
  });
  
  Notes
  
  - Unsupported network strings throw UnsupportedNetworkError — callers are never silently given
  a wrong address
  - registerBatch is atomic: if any entry is invalid or duplicate, the registry is left
  unchanged
  - The singleton is intentionally pre-seeded with placeholder addresses; real addresses should
  be injected via the documented environment variables in production

closes #912 