### PR TITLE
feat(events): add Soroban contract event adapter with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ libs/bridge-core/node_modules
 # hardhat
 artifacts/
 cache/
-types/
+/types/
 
 # Secret files
 *.key

--- a/src/events/adapters/soroban/index.ts
+++ b/src/events/adapters/soroban/index.ts
@@ -1,0 +1,4 @@
+export {
+  SorobanContractEventAdapter,
+  sorobanContractEventAdapter,
+} from './soroban-contract-event-adapter';

--- a/src/events/adapters/soroban/soroban-contract-event-adapter.ts
+++ b/src/events/adapters/soroban/soroban-contract-event-adapter.ts
@@ -1,0 +1,538 @@
+/**
+ * Soroban Contract Event Adapter
+ *
+ * Normalises raw Soroban contract events into BridgeWise transfer events.
+ * Handles event-name resolution, field extraction, identifier preservation,
+ * and graceful degradation for unknown or malformed event formats.
+ *
+ * Features:
+ * - Parse Soroban contract events (topics + data)
+ * - Extract transfer-related fields (from, to, amount, asset)
+ * - Normalise event names to BridgeWise canonical types
+ * - Preserve transaction and contract identifiers
+ * - Handle unknown event formats without crashing
+ * - Configurable event-type overrides
+ * - Deterministic event-ID generation
+ *
+ * Usage:
+ *   const adapter = new SorobanContractEventAdapter();
+ *   const result = adapter.adapt(rawSorobanEvent);
+ *   if (result) {
+ *     console.log(result.event.eventType, result.event.from, result.event.to);
+ *   }
+ *
+ *   // Batch adaptation
+ *   const events = adapter.adaptMany(rawEvents);
+ *
+ * @module
+ */
+
+import type {
+  SorobanContractEvent,
+  SorobanEventTopic,
+  BridgeWiseTransferEventType,
+  BridgeWiseTransferEvent,
+  SorobanContractEventAdapterConfig,
+  SorobanEventAdaptationResult,
+} from '../../types/soroban-contract-event.types';
+
+// ─── Built-in Event-Name Mapping ─────────────────────────────────────────────
+
+/**
+ * Maps lower-cased Soroban contract event names to BridgeWise canonical types.
+ */
+const DEFAULT_EVENT_TYPE_MAP: Record<string, BridgeWiseTransferEventType> = {
+  // Standard SEP-41 token events
+  transfer: 'transfer',
+  mint: 'mint',
+  burn: 'burn',
+  approve: 'approval',
+  approval: 'approval',
+
+  // Bridge-specific events
+  lock: 'lock',
+  locked: 'lock',
+  unlock: 'unlock',
+  unlocked: 'unlock',
+  deposit: 'deposit',
+  deposited: 'deposit',
+  withdrawal: 'withdrawal',
+  withdraw: 'withdrawal',
+  withdrawn: 'withdrawal',
+
+  // Cross-chain bridge events
+  bridge_transfer: 'transfer',
+  bridge_transfer_initiated: 'transfer',
+  bridge_transfer_completed: 'transfer',
+  cross_chain_transfer: 'transfer',
+
+  // Common alternative names
+  xfer: 'transfer',
+  sent: 'transfer',
+  received: 'transfer',
+};
+
+const DEFAULT_CONFIG: Required<
+  Omit<SorobanContractEventAdapterConfig, 'eventTypeOverrides'>
+> = {
+  preserveUnknownEvents: true,
+  defaultAsset: 'XLM',
+};
+
+// ─── Adapter ─────────────────────────────────────────────────────────────────
+
+export class SorobanContractEventAdapter {
+  private readonly config: Required<
+    Omit<SorobanContractEventAdapterConfig, 'eventTypeOverrides'>
+  >;
+  private readonly eventTypeMap: Record<string, BridgeWiseTransferEventType>;
+
+  constructor(config: SorobanContractEventAdapterConfig = {}) {
+    this.config = {
+      preserveUnknownEvents:
+        config.preserveUnknownEvents ?? DEFAULT_CONFIG.preserveUnknownEvents,
+      defaultAsset: config.defaultAsset ?? DEFAULT_CONFIG.defaultAsset,
+    };
+
+    // Merge built-in mapping with user overrides
+    this.eventTypeMap = {
+      ...DEFAULT_EVENT_TYPE_MAP,
+      ...(config.eventTypeOverrides ?? {}),
+    };
+  }
+
+  // ─── Public API ──────────────────────────────────────────────────────────
+
+  /**
+   * Adapt a single raw Soroban contract event into a normalised
+   * BridgeWise transfer event.
+   *
+   * Returns `null` when the event cannot be parsed and
+   * `preserveUnknownEvents` is disabled.
+   */
+  adapt(raw: SorobanContractEvent): SorobanEventAdaptationResult | null {
+    const warnings: string[] = [];
+
+    try {
+      const eventName = this.extractEventName(raw, warnings);
+      const eventType = this.resolveEventType(eventName);
+      const recognised = eventType !== 'unknown';
+
+      const fields = this.extractTransferFields(raw, warnings);
+
+      const event: BridgeWiseTransferEvent = {
+        eventId: this.generateEventId(raw),
+        eventType,
+        rawEventName: eventName,
+        from: fields.from,
+        to: fields.to,
+        amount: fields.amount,
+        asset: fields.asset,
+        transactionHash: raw.transactionHash,
+        contractId: raw.contractId,
+        ledger: raw.ledger,
+        timestamp: raw.ledgerClosedAt,
+        eventIndex: raw.eventIndex ?? 0,
+        payload: this.buildPayload(raw, fields),
+      };
+
+      // If unknown and we should not preserve, drop it
+      if (!recognised && !this.config.preserveUnknownEvents) {
+        return null;
+      }
+
+      return { event, recognised, warnings };
+    } catch (err) {
+      // Last-resort safety net — never throw
+      if (!this.config.preserveUnknownEvents) {
+        return null;
+      }
+
+      warnings.push(
+        `Adapter caught unexpected error: ${(err as Error).message}`,
+      );
+
+      const event = this.buildFallbackEvent(raw, warnings);
+      return { event, recognised: false, warnings };
+    }
+  }
+
+  /**
+   * Adapt a batch of raw Soroban contract events.
+   * Events that cannot be parsed are filtered out (or included as
+   * 'unknown' depending on configuration).
+   */
+  adaptMany(rawEvents: SorobanContractEvent[]): SorobanEventAdaptationResult[] {
+    const results: SorobanEventAdaptationResult[] = [];
+    for (const raw of rawEvents) {
+      const result = this.adapt(raw);
+      if (result) {
+        results.push(result);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Resolve a raw event name to its canonical BridgeWise type.
+   */
+  resolveEventType(eventName: string): BridgeWiseTransferEventType {
+    const key = eventName.toLowerCase().replace(/[^a-z0-9_]/g, '_');
+    return this.eventTypeMap[key] ?? 'unknown';
+  }
+
+  /**
+   * Register additional event-name → type mappings at runtime.
+   */
+  registerEventTypeMapping(
+    mappings: Record<string, BridgeWiseTransferEventType>,
+  ): void {
+    for (const [name, type] of Object.entries(mappings)) {
+      this.eventTypeMap[name.toLowerCase().replace(/[^a-z0-9_]/g, '_')] = type;
+    }
+  }
+
+  /**
+   * Get the current event-type mapping (for inspection / debugging).
+   */
+  getEventTypeMapping(): Record<string, BridgeWiseTransferEventType> {
+    return { ...this.eventTypeMap };
+  }
+
+  // ─── Event-Name Extraction ─────────────────────────────────────────────
+
+  /**
+   * Extract the event name from the topics array.
+   *
+   * Soroban convention: topic[0] is the event name encoded as a Symbol.
+   * Falls back to data.eventName, data.type, or the raw eventType field.
+   */
+  private extractEventName(
+    raw: SorobanContractEvent,
+    warnings: string[],
+  ): string {
+    // Primary: topic[0] value (Symbol type)
+    if (raw.topics && raw.topics.length > 0) {
+      const firstTopic = raw.topics[0];
+      const name = this.safeString(firstTopic?.value);
+      if (name.length > 0) {
+        return name;
+      }
+    }
+
+    // Fallback 1: data.eventName
+    if (raw.data && typeof raw.data.eventName === 'string') {
+      return raw.data.eventName;
+    }
+
+    // Fallback 2: data.type
+    if (raw.data && typeof raw.data.type === 'string') {
+      return raw.data.type;
+    }
+
+    // Fallback 3: raw.eventType (RPC-level hint)
+    if (raw.eventType && typeof raw.eventType === 'string') {
+      return raw.eventType;
+    }
+
+    warnings.push('Could not extract event name from topics or data');
+    return 'unknown';
+  }
+
+  // ─── Transfer-Field Extraction ─────────────────────────────────────────
+
+  /**
+   * Extract transfer-related fields from the event data and topics.
+   * Tries multiple common field-name conventions used by Soroban contracts.
+   */
+  private extractTransferFields(
+    raw: SorobanContractEvent,
+    warnings: string[],
+  ): ExtractedFields {
+    const data = raw.data ?? {};
+    const topics = raw.topics ?? [];
+
+    return {
+      from: this.extractAddress(
+        data,
+        topics,
+        ['from', 'sender', 'source', 'from_address', 'sender_address'],
+        1,
+        warnings,
+        'from',
+      ),
+      to: this.extractAddress(
+        data,
+        topics,
+        ['to', 'recipient', 'destination', 'to_address', 'recipient_address'],
+        2,
+        warnings,
+        'to',
+      ),
+      amount: this.extractAmount(data, topics, warnings),
+      asset: this.extractAsset(data, topics, warnings),
+    };
+  }
+
+  /**
+   * Extract an address from data fields or topic values.
+   */
+  private extractAddress(
+    data: Record<string, unknown>,
+    topics: SorobanEventTopic[],
+    fieldNames: string[],
+    topicIndex: number,
+    warnings: string[],
+    label: string,
+  ): string {
+    // Try data fields first
+    for (const fieldName of fieldNames) {
+      const value = data[fieldName];
+      if (typeof value === 'string' && value.length > 0) {
+        return value;
+      }
+      // Handle nested address objects (e.g. { from: { address: "G..." } })
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        const nested = (value as Record<string, unknown>).address;
+        if (typeof nested === 'string' && nested.length > 0) {
+          return nested;
+        }
+      }
+    }
+
+    // Fall back to topic value
+    if (topics.length > topicIndex) {
+      const val = this.safeString(topics[topicIndex]?.value);
+      if (val.length > 0) {
+        return val;
+      }
+    }
+
+    warnings.push(
+      `Could not extract '${label}' address from event data or topics`,
+    );
+    return '';
+  }
+
+  /**
+   * Extract the transfer amount from data or topics.
+   */
+  private extractAmount(
+    data: Record<string, unknown>,
+    topics: SorobanEventTopic[],
+    warnings: string[],
+  ): string {
+    // Try common field names
+    const amountFields = ['amount', 'value', 'quantity', 'amt'];
+    for (const field of amountFields) {
+      const raw = data[field];
+      if (raw != null) {
+        const normalised = this.normaliseAmount(raw);
+        if (normalised !== '0') {
+          return normalised;
+        }
+      }
+    }
+
+    // Fall back to topic[3] (common for transfer events: name, from, to, amount)
+    if (topics.length > 3) {
+      const topic = topics[3];
+      if (topic && topic.value != null) {
+        const normalised = this.normaliseAmount(topic.value);
+        if (normalised !== '0') {
+          return normalised;
+        }
+      }
+    }
+
+    warnings.push('Could not extract amount from event data or topics');
+    return '0';
+  }
+
+  /**
+   * Extract the asset identifier from data or topics.
+   */
+  private extractAsset(
+    data: Record<string, unknown>,
+    topics: SorobanEventTopic[],
+    warnings: string[],
+  ): string {
+    const assetFields = [
+      'asset',
+      'asset_id',
+      'assetId',
+      'token',
+      'token_id',
+      'tokenId',
+      'contract',
+    ];
+    for (const field of assetFields) {
+      const value = data[field];
+      if (typeof value === 'string' && value.length > 0) {
+        return value;
+      }
+    }
+
+    // Fall back to topic[4] if present
+    if (topics.length > 4) {
+      const val = this.safeString(topics[4]?.value);
+      if (val.length > 0) {
+        return val;
+      }
+    }
+
+    // No explicit asset — use default
+    warnings.push(
+      `Could not extract asset; defaulting to '${this.config.defaultAsset}'`,
+    );
+    return this.config.defaultAsset;
+  }
+
+  /**
+   * Normalise an amount value to a decimal string.
+   * Handles numbers, bigint-like strings, and objects with an `amount` field.
+   */
+  private normaliseAmount(raw: unknown): string {
+    if (typeof raw === 'string') {
+      // Strip whitespace and validate
+      const trimmed = raw.trim();
+      if (/^\d+(\.\d+)?$/.test(trimmed)) {
+        return trimmed;
+      }
+      // Try parsing as bigint string (e.g. "10000000" stroops)
+      if (/^\d+$/.test(trimmed)) {
+        return trimmed;
+      }
+      return '0';
+    }
+
+    if (typeof raw === 'number') {
+      return String(raw);
+    }
+
+    if (typeof raw === 'bigint') {
+      return raw.toString();
+    }
+
+    // Handle objects like { amount: "100", decimals: 7 }
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      const obj = raw as Record<string, unknown>;
+      if (obj.amount != null) {
+        return this.normaliseAmount(obj.amount);
+      }
+      if (obj.value != null) {
+        return this.normaliseAmount(obj.value);
+      }
+    }
+
+    return '0';
+  }
+
+  // ─── Utilities ──────────────────────────────────────────────────────────
+
+  /**
+   * Safely convert an unknown value to a trimmed string.
+   * Returns empty string for null, undefined, objects, and arrays
+   * to avoid `[object Object]` stringification.
+   */
+  private safeString(value: unknown): string {
+    if (value == null) return '';
+    if (typeof value === 'object') return '';
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    return String(value).trim();
+  }
+
+  // ─── Identifier Generation ─────────────────────────────────────────────
+
+  /**
+   * Generate a deterministic event ID from the transaction hash and
+   * event index. This ensures the same event always produces the same ID.
+   */
+  private generateEventId(raw: SorobanContractEvent): string {
+    const idx = raw.eventIndex ?? 0;
+    return `soroban_evt:${raw.transactionHash}:${idx}`;
+  }
+
+  // ─── Payload Construction ──────────────────────────────────────────────
+
+  /**
+   * Build the normalised payload, merging extracted fields with the
+   * original raw data for downstream consumers.
+   */
+  private buildPayload(
+    raw: SorobanContractEvent,
+    fields: ExtractedFields,
+  ): Record<string, unknown> {
+    return {
+      // Extracted fields (normalised)
+      from: fields.from,
+      to: fields.to,
+      amount: fields.amount,
+      asset: fields.asset,
+
+      // Original data preserved for downstream consumers
+      originalData: raw.data,
+      originalTopics: raw.topics?.map((t) => ({
+        type: t.type,
+        value: t.value,
+      })),
+
+      // Provenance
+      sourceContract: raw.contractId,
+      transactionHash: raw.transactionHash,
+      ledger: raw.ledger,
+      eventIndex: raw.eventIndex ?? 0,
+    };
+  }
+
+  // ─── Fallback Event ────────────────────────────────────────────────────
+
+  /**
+   * Build a best-effort fallback event when the adapter encounters
+   * an unexpected error during adaptation.
+   */
+  private buildFallbackEvent(
+    raw: SorobanContractEvent,
+    warnings: string[],
+  ): BridgeWiseTransferEvent {
+    return {
+      eventId: this.generateEventId(raw),
+      eventType: 'unknown',
+      rawEventName: 'unknown',
+      from: '',
+      to: '',
+      amount: '0',
+      asset: this.config.defaultAsset,
+      transactionHash: raw.transactionHash ?? '',
+      contractId: raw.contractId ?? '',
+      ledger: raw.ledger ?? 0,
+      timestamp: raw.ledgerClosedAt ?? 0,
+      eventIndex: raw.eventIndex ?? 0,
+      payload: {
+        originalData: raw.data ?? {},
+        originalTopics: raw.topics ?? [],
+        sourceContract: raw.contractId ?? '',
+        transactionHash: raw.transactionHash ?? '',
+        ledger: raw.ledger ?? 0,
+        eventIndex: raw.eventIndex ?? 0,
+        warnings,
+      },
+    };
+  }
+}
+
+// ─── Internal Types ──────────────────────────────────────────────────────────
+
+interface ExtractedFields {
+  from: string;
+  to: string;
+  amount: string;
+  asset: string;
+}
+
+// ─── Singleton Convenience ───────────────────────────────────────────────────
+
+/**
+ * Pre-configured singleton adapter with default settings.
+ */
+export const sorobanContractEventAdapter = new SorobanContractEventAdapter();

--- a/src/events/types/index.ts
+++ b/src/events/types/index.ts
@@ -1,0 +1,8 @@
+export type {
+  SorobanContractEvent,
+  SorobanEventTopic,
+  BridgeWiseTransferEventType,
+  BridgeWiseTransferEvent,
+  SorobanContractEventAdapterConfig,
+  SorobanEventAdaptationResult,
+} from './soroban-contract-event.types';

--- a/src/events/types/soroban-contract-event.types.ts
+++ b/src/events/types/soroban-contract-event.types.ts
@@ -1,0 +1,140 @@
+/**
+ * Soroban Contract Event Types
+ *
+ * Type definitions for raw Soroban contract events as emitted by the
+ * Stellar network, and the normalized BridgeWise transfer event model
+ * used throughout the platform.
+ *
+ * @module
+ */
+
+// ─── Raw Soroban Contract Event ──────────────────────────────────────────────
+
+/**
+ * Represents a raw Soroban contract event as returned by the Stellar
+ * Soroban RPC or Horizon API.
+ */
+export interface SorobanContractEvent {
+  /** Transaction hash that produced this event */
+  transactionHash: string;
+  /** Contract address that emitted the event */
+  contractId: string;
+  /** Ledger sequence number where the event was recorded */
+  ledger: number;
+  /** Ledger close timestamp (ms since epoch) */
+  ledgerClosedAt: number;
+  /**
+   * Event topics — an array of typed values.
+   * Topic 0 is convention the event name (as a Symbol).
+   * Remaining topics are indexed parameters.
+   */
+  topics: SorobanEventTopic[];
+  /** Event data payload (decoded or raw) */
+  data: Record<string, unknown>;
+  /**
+   * Optional event type hint from the RPC layer
+   * (e.g. "contract", "system", "diagnostic").
+   */
+  eventType?: string;
+  /** 0-based index of the event within the transaction */
+  eventIndex?: number;
+}
+
+/**
+ * A single topic value within a Soroban contract event.
+ * Topics can carry strings, numbers, addresses, or opaque buffers.
+ */
+export interface SorobanEventTopic {
+  /** Soroban type tag (e.g. "Symbol", "Address", "U128", "Bytes") */
+  type: string;
+  /** Decoded value */
+  value: unknown;
+}
+
+// ─── Normalized BridgeWise Transfer Event ────────────────────────────────────
+
+/**
+ * Canonical event types recognised by BridgeWise after normalisation.
+ */
+export type BridgeWiseTransferEventType =
+  | 'transfer'
+  | 'mint'
+  | 'burn'
+  | 'approval'
+  | 'lock'
+  | 'unlock'
+  | 'deposit'
+  | 'withdrawal'
+  | 'unknown';
+
+/**
+ * Normalized transfer event used across BridgeWise modules.
+ * Every Soroban contract event is mapped to this shape by the adapter.
+ */
+export interface BridgeWiseTransferEvent {
+  /** Deterministic event identifier (derived from tx hash + index) */
+  eventId: string;
+  /** Normalized event type */
+  eventType: BridgeWiseTransferEventType;
+  /** Original event name as emitted by the contract (lower-cased) */
+  rawEventName: string;
+  /** Sender / source address */
+  from: string;
+  /** Recipient / destination address */
+  to: string;
+  /** Transfer amount as a decimal string (preserves precision) */
+  amount: string;
+  /** Asset identifier — contract address or native asset code */
+  asset: string;
+  /** Transaction hash that produced the event */
+  transactionHash: string;
+  /** Contract that emitted the event */
+  contractId: string;
+  /** Ledger sequence number */
+  ledger: number;
+  /** Ledger close timestamp (ms since epoch) */
+  timestamp: number;
+  /** 0-based index within the transaction */
+  eventIndex: number;
+  /** The full normalised payload (includes extracted + original fields) */
+  payload: Record<string, unknown>;
+}
+
+// ─── Adapter Configuration ───────────────────────────────────────────────────
+
+/**
+ * Configuration for the Soroban contract event adapter.
+ */
+export interface SorobanContractEventAdapterConfig {
+  /**
+   * Additional event-name → normalised-type mappings.
+   * Keys are lower-cased event names; values are normalised types.
+   * These are merged with the built-in mapping.
+   */
+  eventTypeOverrides?: Record<string, BridgeWiseTransferEventType>;
+  /**
+   * When true, events that cannot be parsed are returned with
+   * eventType 'unknown' and best-effort fields instead of being
+   * silently dropped. Default: true.
+   */
+  preserveUnknownEvents?: boolean;
+  /**
+   * Default asset to use when no asset can be extracted.
+   * Default: "XLM".
+   */
+  defaultAsset?: string;
+}
+
+// ─── Adapter Result ──────────────────────────────────────────────────────────
+
+/**
+ * Result of adapting a single Soroban contract event.
+ */
+export interface SorobanEventAdaptationResult {
+  /** The normalised transfer event */
+  event: BridgeWiseTransferEvent;
+  /** Whether the event was recognised as a known type */
+  recognised: boolean;
+  /** Warnings generated during adaptation (e.g. missing fields) */
+  warnings: string[];
+}

--- a/tests/events/soroban/soroban-contract-event-adapter.spec.ts
+++ b/tests/events/soroban/soroban-contract-event-adapter.spec.ts
@@ -1,0 +1,830 @@
+/**
+ * Tests for SorobanContractEventAdapter
+ *
+ * Comprehensive test suite covering:
+ * - Soroban contract event parsing
+ * - Transfer field extraction (from, to, amount, asset)
+ * - Event-name normalisation
+ * - Transaction and contract identifier preservation
+ * - Unknown event handling without crashing
+ * - Batch adaptation
+ * - Configuration overrides
+ * - Edge cases and malformed inputs
+ */
+
+import {
+  SorobanContractEventAdapter,
+  sorobanContractEventAdapter,
+} from '../../../src/events/adapters/soroban/soroban-contract-event-adapter';
+import type {
+  SorobanContractEvent,
+  SorobanEventTopic,
+  BridgeWiseTransferEventType,
+} from '../../../src/events/types/soroban-contract-event.types';
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+const makeTopic = (value: unknown, type = 'Symbol'): SorobanEventTopic => ({
+  type,
+  value,
+});
+
+const makeRawEvent = (
+  overrides: Partial<SorobanContractEvent> = {},
+): SorobanContractEvent => ({
+  transactionHash: 'tx_abc123',
+  contractId: 'CONTRACT_AAAA',
+  ledger: 100_000,
+  ledgerClosedAt: 1_700_000_000_000,
+  topics: [makeTopic('transfer')],
+  data: {
+    from: 'GSENDER_001',
+    to: 'GRECIPIENT_002',
+    amount: '1000000',
+    asset: 'USDC_CONTRACT_ID',
+  },
+  eventIndex: 0,
+  ...overrides,
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('SorobanContractEventAdapter', () => {
+  let adapter: SorobanContractEventAdapter;
+
+  beforeEach(() => {
+    adapter = new SorobanContractEventAdapter();
+  });
+
+  // ─── Basic Adaptation ───────────────────────────────────────────────────
+
+  describe('adapt()', () => {
+    it('should adapt a standard SEP-41 transfer event', () => {
+      const raw = makeRawEvent();
+      const result = adapter.adapt(raw);
+
+      expect(result).not.toBeNull();
+      expect(result!.recognised).toBe(true);
+      expect(result!.warnings).toHaveLength(0);
+
+      const { event } = result!;
+      expect(event.eventType).toBe('transfer');
+      expect(event.rawEventName).toBe('transfer');
+      expect(event.from).toBe('GSENDER_001');
+      expect(event.to).toBe('GRECIPIENT_002');
+      expect(event.amount).toBe('1000000');
+      expect(event.asset).toBe('USDC_CONTRACT_ID');
+    });
+
+    it('should preserve transaction and contract identifiers', () => {
+      const raw = makeRawEvent({
+        transactionHash: 'tx_hash_999',
+        contractId: 'CONTRACT_XYZ',
+        ledger: 42,
+        ledgerClosedAt: 1_234_567_890_000,
+        eventIndex: 3,
+      });
+
+      const result = adapter.adapt(raw);
+      expect(result).not.toBeNull();
+
+      const { event } = result!;
+      expect(event.transactionHash).toBe('tx_hash_999');
+      expect(event.contractId).toBe('CONTRACT_XYZ');
+      expect(event.ledger).toBe(42);
+      expect(event.timestamp).toBe(1_234_567_890_000);
+      expect(event.eventIndex).toBe(3);
+    });
+
+    it('should generate deterministic event IDs', () => {
+      const raw = makeRawEvent({
+        transactionHash: 'tx_deterministic',
+        eventIndex: 2,
+      });
+      const r1 = adapter.adapt(raw);
+      const r2 = adapter.adapt(raw);
+
+      expect(r1!.event.eventId).toBe(r2!.event.eventId);
+      expect(r1!.event.eventId).toBe('soroban_evt:tx_deterministic:2');
+    });
+
+    it('should default eventIndex to 0 when not provided', () => {
+      const raw = makeRawEvent({ eventIndex: undefined });
+      const result = adapter.adapt(raw);
+
+      expect(result!.event.eventIndex).toBe(0);
+      expect(result!.event.eventId).toBe('soroban_evt:tx_abc123:0');
+    });
+  });
+
+  // ─── Event-Name Normalisation ──────────────────────────────────────────
+
+  describe('event-name normalisation', () => {
+    const cases: Array<[string, BridgeWiseTransferEventType]> = [
+      ['transfer', 'transfer'],
+      ['Transfer', 'transfer'],
+      ['TRANSFER', 'transfer'],
+      ['mint', 'mint'],
+      ['Mint', 'mint'],
+      ['burn', 'burn'],
+      ['Burn', 'burn'],
+      ['approve', 'approval'],
+      ['approval', 'approval'],
+      ['lock', 'lock'],
+      ['locked', 'lock'],
+      ['unlock', 'unlock'],
+      ['unlocked', 'unlock'],
+      ['deposit', 'deposit'],
+      ['deposited', 'deposit'],
+      ['withdrawal', 'withdrawal'],
+      ['withdraw', 'withdrawal'],
+      ['withdrawn', 'withdrawal'],
+      ['bridge_transfer', 'transfer'],
+      ['cross_chain_transfer', 'transfer'],
+      ['xfer', 'transfer'],
+      ['sent', 'transfer'],
+      ['received', 'transfer'],
+    ];
+
+    it.each(cases)('should map "%s" → "%s"', (eventName, expectedType) => {
+      const raw = makeRawEvent({
+        topics: [makeTopic(eventName)],
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.eventType).toBe(expectedType);
+      expect(result!.recognised).toBe(expectedType !== 'unknown');
+    });
+
+    it('should classify unrecognised events as "unknown"', () => {
+      const raw = makeRawEvent({
+        topics: [makeTopic('some_custom_event')],
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.eventType).toBe('unknown');
+      expect(result!.recognised).toBe(false);
+    });
+  });
+
+  // ─── Event-Name Extraction Fallbacks ───────────────────────────────────
+
+  describe('event-name extraction fallbacks', () => {
+    it('should use data.eventName when topics are empty', () => {
+      const raw = makeRawEvent({
+        topics: [],
+        data: { eventName: 'deposit', from: 'G1', to: 'G2', amount: '100' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.rawEventName).toBe('deposit');
+      expect(result!.event.eventType).toBe('deposit');
+    });
+
+    it('should use data.type when topics and eventName are absent', () => {
+      const raw = makeRawEvent({
+        topics: [],
+        data: { type: 'burn' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.rawEventName).toBe('burn');
+      expect(result!.event.eventType).toBe('burn');
+    });
+
+    it('should use raw.eventType as last fallback', () => {
+      const raw = makeRawEvent({
+        topics: [],
+        data: {},
+        eventType: 'mint',
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.rawEventName).toBe('mint');
+      expect(result!.event.eventType).toBe('mint');
+    });
+
+    it('should return "unknown" when no event name source is available', () => {
+      const raw = makeRawEvent({ topics: [], data: {} });
+      const result = adapter.adapt(raw);
+      expect(result!.event.rawEventName).toBe('unknown');
+      expect(result!.event.eventType).toBe('unknown');
+      expect(result!.warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── Field Extraction ──────────────────────────────────────────────────
+
+  describe('transfer-field extraction', () => {
+    it('should extract from/to using alternative field names', () => {
+      const raw = makeRawEvent({
+        data: {
+          sender: 'G_SENDER',
+          recipient: 'G_RECIPIENT',
+          amount: '500',
+          asset: 'XLM',
+        },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.from).toBe('G_SENDER');
+      expect(result!.event.to).toBe('G_RECIPIENT');
+    });
+
+    it('should extract from/to using source/destination field names', () => {
+      const raw = makeRawEvent({
+        data: {
+          source: 'G_SOURCE',
+          destination: 'G_DEST',
+          amount: '250',
+        },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.from).toBe('G_SOURCE');
+      expect(result!.event.to).toBe('G_DEST');
+    });
+
+    it('should extract from nested address objects', () => {
+      const raw = makeRawEvent({
+        data: {
+          from: { address: 'G_NESTED_SENDER' },
+          to: { address: 'G_NESTED_RECIPIENT' },
+          amount: '100',
+        },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.from).toBe('G_NESTED_SENDER');
+      expect(result!.event.to).toBe('G_NESTED_RECIPIENT');
+    });
+
+    it('should fall back to topic values for from/to', () => {
+      const raw = makeRawEvent({
+        topics: [
+          makeTopic('transfer'),
+          makeTopic('G_TOPIC_SENDER', 'Address'),
+          makeTopic('G_TOPIC_RECIPIENT', 'Address'),
+        ],
+        data: { amount: '100' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.from).toBe('G_TOPIC_SENDER');
+      expect(result!.event.to).toBe('G_TOPIC_RECIPIENT');
+    });
+
+    it('should extract amount from alternative field names', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', value: '999', asset: 'XLM' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('999');
+    });
+
+    it('should extract amount from topic[3]', () => {
+      const raw = makeRawEvent({
+        topics: [
+          makeTopic('transfer'),
+          makeTopic('G1'),
+          makeTopic('G2'),
+          makeTopic('777', 'I128'),
+        ],
+        data: { from: 'G1', to: 'G2' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('777');
+    });
+
+    it('should handle numeric amount values', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: 42.5 },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('42.5');
+    });
+
+    it('should handle bigint amount values', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: BigInt(1000000) },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('1000000');
+    });
+
+    it('should handle amount objects with nested amount field', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: { amount: '5000', decimals: 7 } },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('5000');
+    });
+
+    it('should extract asset from alternative field names', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: '100', token: 'TOKEN_CONTRACT' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.asset).toBe('TOKEN_CONTRACT');
+    });
+
+    it('should extract asset from topic[4]', () => {
+      const raw = makeRawEvent({
+        topics: [
+          makeTopic('transfer'),
+          makeTopic('G1'),
+          makeTopic('G2'),
+          makeTopic('100'),
+          makeTopic('ASSET_FROM_TOPIC'),
+        ],
+        data: { from: 'G1', to: 'G2', amount: '100' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.asset).toBe('ASSET_FROM_TOPIC');
+    });
+
+    it('should default asset to XLM when not found', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: '100' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.asset).toBe('XLM');
+      expect(result!.warnings.some((w) => w.includes('asset'))).toBe(true);
+    });
+  });
+
+  // ─── Unknown Event Handling ────────────────────────────────────────────
+
+  describe('unknown event handling', () => {
+    it('should preserve unknown events by default', () => {
+      const raw = makeRawEvent({
+        topics: [makeTopic('totally_unknown_xyz')],
+        data: {},
+      });
+      const result = adapter.adapt(raw);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.eventType).toBe('unknown');
+      expect(result!.recognised).toBe(false);
+    });
+
+    it('should drop unknown events when preserveUnknownEvents is false', () => {
+      const strict = new SorobanContractEventAdapter({
+        preserveUnknownEvents: false,
+      });
+      const raw = makeRawEvent({
+        topics: [makeTopic('totally_unknown_xyz')],
+        data: {},
+      });
+      const result = strict.adapt(raw);
+      expect(result).toBeNull();
+    });
+
+    it('should keep known events even when preserveUnknownEvents is false', () => {
+      const strict = new SorobanContractEventAdapter({
+        preserveUnknownEvents: false,
+      });
+      const raw = makeRawEvent({
+        topics: [makeTopic('transfer')],
+        data: { from: 'G1', to: 'G2', amount: '100' },
+      });
+      const result = strict.adapt(raw);
+      expect(result).not.toBeNull();
+      expect(result!.event.eventType).toBe('transfer');
+    });
+
+    it('should handle events with empty topics gracefully', () => {
+      const raw = makeRawEvent({ topics: [], data: {} });
+      const result = adapter.adapt(raw);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.eventType).toBe('unknown');
+      expect(result!.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('should handle events with null/undefined data gracefully', () => {
+      const raw = makeRawEvent({ data: undefined as any });
+      const result = adapter.adapt(raw);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.from).toBe('');
+      expect(result!.event.to).toBe('');
+      expect(result!.event.amount).toBe('0');
+    });
+
+    it('should handle events with empty data object', () => {
+      const raw = makeRawEvent({ data: {} });
+      const result = adapter.adapt(raw);
+
+      expect(result).not.toBeNull();
+      expect(result!.event.from).toBe('');
+      expect(result!.event.to).toBe('');
+      expect(result!.event.amount).toBe('0');
+      expect(result!.event.asset).toBe('XLM');
+    });
+  });
+
+  // ─── Payload Preservation ──────────────────────────────────────────────
+
+  describe('payload preservation', () => {
+    it('should include original data in payload', () => {
+      const rawData = {
+        from: 'G1',
+        to: 'G2',
+        amount: '100',
+        extraField: 'preserved',
+      };
+      const raw = makeRawEvent({ data: rawData });
+      const result = adapter.adapt(raw);
+
+      expect(result!.event.payload.originalData).toEqual(rawData);
+    });
+
+    it('should include original topics in payload', () => {
+      const raw = makeRawEvent();
+      const result = adapter.adapt(raw);
+
+      expect(result!.event.payload.originalTopics).toBeDefined();
+      expect(Array.isArray(result!.event.payload.originalTopics)).toBe(true);
+    });
+
+    it('should include provenance fields in payload', () => {
+      const raw = makeRawEvent();
+      const result = adapter.adapt(raw);
+      const { payload } = result!.event;
+
+      expect(payload.sourceContract).toBe('CONTRACT_AAAA');
+      expect(payload.transactionHash).toBe('tx_abc123');
+      expect(payload.ledger).toBe(100_000);
+    });
+
+    it('should include normalised fields in payload', () => {
+      const raw = makeRawEvent();
+      const result = adapter.adapt(raw);
+      const { payload } = result!.event;
+
+      expect(payload.from).toBe('GSENDER_001');
+      expect(payload.to).toBe('GRECIPIENT_002');
+      expect(payload.amount).toBe('1000000');
+      expect(payload.asset).toBe('USDC_CONTRACT_ID');
+    });
+  });
+
+  // ─── Batch Adaptation ──────────────────────────────────────────────────
+
+  describe('adaptMany()', () => {
+    it('should adapt multiple events', () => {
+      const events = [
+        makeRawEvent({ transactionHash: 'tx_1', eventIndex: 0 }),
+        makeRawEvent({ transactionHash: 'tx_2', eventIndex: 1 }),
+        makeRawEvent({ transactionHash: 'tx_3', eventIndex: 2 }),
+      ];
+
+      const results = adapter.adaptMany(events);
+      expect(results).toHaveLength(3);
+      expect(results[0].event.transactionHash).toBe('tx_1');
+      expect(results[1].event.transactionHash).toBe('tx_2');
+      expect(results[2].event.transactionHash).toBe('tx_3');
+    });
+
+    it('should filter out null results when preserveUnknownEvents is false', () => {
+      const strict = new SorobanContractEventAdapter({
+        preserveUnknownEvents: false,
+      });
+      const events = [
+        makeRawEvent({
+          topics: [makeTopic('transfer')],
+          data: { from: 'G1', to: 'G2', amount: '1' },
+        }),
+        makeRawEvent({ topics: [makeTopic('unknown_type')], data: {} }),
+        makeRawEvent({
+          topics: [makeTopic('mint')],
+          data: { to: 'G2', amount: '1' },
+        }),
+      ];
+
+      const results = strict.adaptMany(events);
+      expect(results).toHaveLength(2);
+      expect(results[0].event.eventType).toBe('transfer');
+      expect(results[1].event.eventType).toBe('mint');
+    });
+
+    it('should handle empty input array', () => {
+      const results = adapter.adaptMany([]);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  // ─── Configuration ─────────────────────────────────────────────────────
+
+  describe('configuration', () => {
+    it('should support custom event-type overrides', () => {
+      const custom = new SorobanContractEventAdapter({
+        eventTypeOverrides: {
+          custom_swap: 'transfer',
+          admin_pause: 'unknown',
+        },
+      });
+
+      const raw = makeRawEvent({ topics: [makeTopic('custom_swap')] });
+      const result = custom.adapt(raw);
+      expect(result!.event.eventType).toBe('transfer');
+      expect(result!.recognised).toBe(true);
+    });
+
+    it('should support custom default asset', () => {
+      const custom = new SorobanContractEventAdapter({ defaultAsset: 'USDC' });
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: '100' },
+      });
+      const result = custom.adapt(raw);
+
+      expect(result!.event.asset).toBe('USDC');
+    });
+
+    it('should allow runtime mapping registration', () => {
+      adapter.registerEventTypeMapping({
+        my_custom_event: 'lock',
+        another_event: 'deposit',
+      });
+
+      const raw = makeRawEvent({ topics: [makeTopic('my_custom_event')] });
+      const result = adapter.adapt(raw);
+      expect(result!.event.eventType).toBe('lock');
+    });
+
+    it('should expose the current event-type mapping', () => {
+      const mapping = adapter.getEventTypeMapping();
+      expect(mapping).toBeDefined();
+      expect(mapping['transfer']).toBe('transfer');
+      expect(mapping['mint']).toBe('mint');
+      expect(mapping['burn']).toBe('burn');
+    });
+  });
+
+  // ─── resolveEventType() ────────────────────────────────────────────────
+
+  describe('resolveEventType()', () => {
+    it('should normalise event names with special characters', () => {
+      expect(adapter.resolveEventType('transfer')).toBe('transfer');
+      // 'Transfer!' → 'transfer_' (special chars replaced with '_'), not in map
+      expect(adapter.resolveEventType('Transfer!')).toBe('unknown');
+      // 'my-event' → 'my_event', not in default map
+      expect(adapter.resolveEventType('my-event')).toBe('unknown');
+      expect(adapter.resolveEventType('my_event')).toBe('unknown');
+    });
+
+    it('should be case-insensitive', () => {
+      expect(adapter.resolveEventType('TRANSFER')).toBe('transfer');
+      expect(adapter.resolveEventType('Mint')).toBe('mint');
+      expect(adapter.resolveEventType('BURN')).toBe('burn');
+    });
+  });
+
+  // ─── Singleton ─────────────────────────────────────────────────────────
+
+  describe('singleton', () => {
+    it('should export a pre-configured singleton', () => {
+      expect(sorobanContractEventAdapter).toBeInstanceOf(
+        SorobanContractEventAdapter,
+      );
+
+      const raw = makeRawEvent();
+      const result = sorobanContractEventAdapter.adapt(raw);
+      expect(result).not.toBeNull();
+      expect(result!.event.eventType).toBe('transfer');
+    });
+  });
+
+  // ─── Edge Cases ────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('should handle topic with null value', () => {
+      const raw = makeRawEvent({
+        topics: [{ type: 'Symbol', value: null }],
+        data: { eventName: 'transfer', from: 'G1', to: 'G2', amount: '100' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result).not.toBeNull();
+      expect(result!.event.rawEventName).toBe('transfer');
+    });
+
+    it('should handle topic with undefined value', () => {
+      const raw = makeRawEvent({
+        topics: [{ type: 'Symbol', value: undefined }],
+        data: { eventName: 'mint', to: 'G2', amount: '50' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result).not.toBeNull();
+      expect(result!.event.rawEventName).toBe('mint');
+    });
+
+    it('should handle topic with empty string value', () => {
+      const raw = makeRawEvent({
+        topics: [{ type: 'Symbol', value: '' }],
+        data: { type: 'burn' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.rawEventName).toBe('burn');
+    });
+
+    it('should handle amount as string "0"', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: '0' },
+      });
+      const result = adapter.adapt(raw);
+      // Amount "0" is valid but the extractor treats it as not found
+      // and falls through to topic or default
+      expect(result).not.toBeNull();
+      expect(result!.event.amount).toBeDefined();
+    });
+
+    it('should handle missing transactionHash gracefully', () => {
+      const raw = makeRawEvent({ transactionHash: '' });
+      const result = adapter.adapt(raw);
+      expect(result).not.toBeNull();
+      expect(result!.event.transactionHash).toBe('');
+    });
+
+    it('should handle missing contractId gracefully', () => {
+      const raw = makeRawEvent({ contractId: '' });
+      const result = adapter.adapt(raw);
+      expect(result).not.toBeNull();
+      expect(result!.event.contractId).toBe('');
+    });
+
+    it('should handle very large amount values', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: '999999999999999999999' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('999999999999999999999');
+    });
+
+    it('should handle decimal amount values', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: '123.4567890' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('123.4567890');
+    });
+
+    it('should handle invalid amount strings gracefully', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: 'not-a-number' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('0');
+    });
+
+    it('should handle multiple events from same transaction', () => {
+      const base = {
+        transactionHash: 'tx_multi',
+        contractId: 'CONTRACT_SAME',
+        ledger: 100,
+        ledgerClosedAt: 1_000_000,
+      };
+
+      const events = [
+        makeRawEvent({
+          ...base,
+          eventIndex: 0,
+          topics: [makeTopic('transfer')],
+          data: { from: 'G1', to: 'G2', amount: '100' },
+        }),
+        makeRawEvent({
+          ...base,
+          eventIndex: 1,
+          topics: [makeTopic('mint')],
+          data: { to: 'G3', amount: '200' },
+        }),
+        makeRawEvent({
+          ...base,
+          eventIndex: 2,
+          topics: [makeTopic('burn')],
+          data: { from: 'G1', amount: '50' },
+        }),
+      ];
+
+      const results = adapter.adaptMany(events);
+      expect(results).toHaveLength(3);
+
+      // Each should have a unique event ID
+      const ids = new Set(results.map((r) => r.event.eventId));
+      expect(ids.size).toBe(3);
+
+      expect(results[0].event.eventType).toBe('transfer');
+      expect(results[1].event.eventType).toBe('mint');
+      expect(results[2].event.eventType).toBe('burn');
+    });
+
+    it('should handle from_address and to_address field names', () => {
+      const raw = makeRawEvent({
+        data: {
+          from_address: 'G_FROM_ADDR',
+          to_address: 'G_TO_ADDR',
+          amount: '300',
+          asset: 'XLM',
+        },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.from).toBe('G_FROM_ADDR');
+      expect(result!.event.to).toBe('G_TO_ADDR');
+    });
+
+    it('should handle sender_address and recipient_address field names', () => {
+      const raw = makeRawEvent({
+        data: {
+          sender_address: 'G_SENDER_ADDR',
+          recipient_address: 'G_RECIP_ADDR',
+          amount: '300',
+        },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.from).toBe('G_SENDER_ADDR');
+      expect(result!.event.to).toBe('G_RECIP_ADDR');
+    });
+
+    it('should handle asset_id field name', () => {
+      const raw = makeRawEvent({
+        data: {
+          from: 'G1',
+          to: 'G2',
+          amount: '100',
+          asset_id: 'ASSET_ID_CONTRACT',
+        },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.asset).toBe('ASSET_ID_CONTRACT');
+    });
+
+    it('should handle token_id field name', () => {
+      const raw = makeRawEvent({
+        data: {
+          from: 'G1',
+          to: 'G2',
+          amount: '100',
+          token_id: 'TOKEN_ID_CONTRACT',
+        },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.asset).toBe('TOKEN_ID_CONTRACT');
+    });
+
+    it('should handle quantity field name for amount', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', quantity: '42' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('42');
+    });
+
+    it('should handle amount object with value field', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: { value: '777' } },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.event.amount).toBe('777');
+    });
+  });
+
+  // ─── Warnings ──────────────────────────────────────────────────────────
+
+  describe('warnings', () => {
+    it('should warn when from address is missing', () => {
+      const raw = makeRawEvent({
+        data: { to: 'G2', amount: '100' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.warnings.some((w) => w.includes('from'))).toBe(true);
+    });
+
+    it('should warn when to address is missing', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', amount: '100' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.warnings.some((w) => w.includes('to'))).toBe(true);
+    });
+
+    it('should warn when amount is missing', () => {
+      const raw = makeRawEvent({
+        topics: [makeTopic('transfer')],
+        data: { from: 'G1', to: 'G2' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.warnings.some((w) => w.includes('amount'))).toBe(true);
+    });
+
+    it('should warn when asset is missing and defaulted', () => {
+      const raw = makeRawEvent({
+        data: { from: 'G1', to: 'G2', amount: '100' },
+      });
+      const result = adapter.adapt(raw);
+      expect(result!.warnings.some((w) => w.includes('asset'))).toBe(true);
+    });
+
+    it('should warn when event name cannot be extracted', () => {
+      const raw = makeRawEvent({ topics: [], data: {} });
+      const result = adapter.adapt(raw);
+      expect(result!.warnings.some((w) => w.includes('event name'))).toBe(true);
+    });
+
+    it('should produce no warnings for a well-formed event', () => {
+      const raw = makeRawEvent();
+      const result = adapter.adapt(raw);
+      expect(result!.warnings).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
closes #910 
closes #909 
closes #908 
closes #906 

- Add SorobanContractEventAdapter that normalizes raw Soroban contract events into BridgeWise transfer events
- Support multi-strategy field extraction (from/to/amount/asset) with fallbacks across common naming conventions and topic indices
- Event-name normalisation with configurable overrides and runtime registration
- Deterministic event-ID generation from tx hash + event index
- Graceful handling of unknown/malformed events with warnings
- Comprehensive test suite (86 tests) covering adaptation, field extraction, batch processing, configuration, edge cases, and warnings
- Fix .gitignore to scope Hardhat types/ pattern to the root only