### PR TITLE
feat(quotes): implement Stellar Bridge Quote Comparison Engine

### DIFF
--- a/src/quotes/comparison/stellar/index.ts
+++ b/src/quotes/comparison/stellar/index.ts
@@ -1,0 +1,13 @@
+// ─── Quote Comparison ────────────────────────────────────────────────────────
+
+export { QuoteComparator } from './quote-comparator';
+
+export {
+  DEFAULT_COMPARISON_WEIGHTS,
+  type QuoteComparisonWeights,
+  type QuoteComparisonOptions,
+  type QuoteDimensionScores,
+  type QuoteComparisonEntry,
+  type QuoteComparisonMetadata,
+  type QuoteComparisonResult,
+} from './types';

--- a/src/quotes/comparison/stellar/quote-comparator.ts
+++ b/src/quotes/comparison/stellar/quote-comparator.ts
@@ -1,0 +1,373 @@
+/**
+ * File: src/quotes/comparison/stellar/quote-comparator.ts
+ *
+ * Stellar Bridge Quote Comparison Engine
+ *
+ * Compares normalised bridge quotes using configurable evaluation
+ * criteria and returns a ranked result set with per-dimension scores
+ * and aggregate metadata.
+ *
+ * Design goals:
+ *   - Pure / dependency-free so the engine is trivial to test.
+ *   - Configurable ranking weights that do not need to sum to 1.
+ *   - Every dimension is normalised to [0, 1] where 1 = best.
+ *   - Expired-quote filtering is opt-in.
+ *   - Deterministic timestamps via injected clock.
+ */
+
+import type { StellarBridgeQuote } from '../../types/canonical-quote';
+
+import {
+  DEFAULT_COMPARISON_WEIGHTS,
+  type QuoteComparisonEntry,
+  type QuoteComparisonMetadata,
+  type QuoteComparisonOptions,
+  type QuoteComparisonResult,
+  type QuoteDimensionScores,
+  type QuoteComparisonWeights,
+} from './types';
+
+// ─── Engine ──────────────────────────────────────────────────────────────────
+
+export class QuoteComparator {
+  private readonly weights: QuoteComparisonWeights;
+  private readonly now: () => number;
+
+  constructor(options: QuoteComparisonOptions = {}) {
+    this.weights = {
+      ...DEFAULT_COMPARISON_WEIGHTS,
+      ...(options.weights ?? {}),
+    };
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  // ─── Public API ────────────────────────────────────────────────────────
+
+  /**
+   * Compare a set of quotes and return them ranked best-first together
+   * with comparison metadata.
+   *
+   * If `quotes` is empty the result contains an empty ranked array and
+   * null metadata fields.
+   */
+  compare(
+    quotes: StellarBridgeQuote[],
+    options: QuoteComparisonOptions = {},
+  ): QuoteComparisonResult {
+    const weights = { ...this.weights, ...(options.weights ?? {}) };
+    const now = options.now ? options.now() : this.now();
+    const excludeExpired = options.excludeExpired ?? false;
+
+    // 1 — Optionally filter expired quotes.
+    const { eligible, excludedCount } = this.filterQuotes(
+      quotes,
+      now,
+      excludeExpired,
+    );
+
+    if (eligible.length === 0) {
+      return {
+        ranked: [],
+        metadata: this.emptyMetadata(
+          weights,
+          quotes.length,
+          excludedCount,
+          now,
+        ),
+      };
+    }
+
+    // 2 — Extract raw dimension values.
+    const receivedAmounts = eligible.map((q) => this.parseReceivedAmount(q));
+    const fees = eligible.map((q) => q.fees.totalFeeUsdCents);
+    const times = eligible.map((q) => q.execution.estimatedTimeSeconds);
+    const reliabilities = eligible.map((q) => q.execution.successRate);
+
+    // 3 — Compute min/max for each dimension.
+    const ranges = {
+      receivedAmount: minMax(receivedAmounts),
+      fee: minMax(fees),
+      time: minMax(times),
+      reliability: minMax(reliabilities),
+    };
+
+    // 4 — Score each quote.
+    const scored: QuoteComparisonEntry[] = eligible.map((quote, i) => {
+      const dimensionScores: QuoteDimensionScores = {
+        receivedAmountScore: normalize(
+          receivedAmounts[i],
+          ranges.receivedAmount,
+          /* lowerIsBetter */ false,
+        ),
+        feeScore: normalize(fees[i], ranges.fee, /* lowerIsBetter */ true),
+        speedScore: normalize(times[i], ranges.time, /* lowerIsBetter */ true),
+        reliabilityScore: normalize(
+          reliabilities[i],
+          ranges.reliability,
+          /* lowerIsBetter */ false,
+        ),
+      };
+
+      const compositeScore = weightedComposite(dimensionScores, weights);
+
+      return {
+        quote,
+        dimensionScores,
+        compositeScore,
+        rank: 0,
+        deltaToBest: 0,
+      };
+    });
+
+    // 5 — Sort descending by composite score and assign ranks.
+    scored.sort((a, b) => b.compositeScore - a.compositeScore);
+    const bestScore = scored[0].compositeScore;
+    scored.forEach((entry, idx) => {
+      entry.rank = idx + 1;
+      entry.deltaToBest = bestScore - entry.compositeScore;
+    });
+
+    // 6 — Apply maxResults cap.
+    const maxResults = options.maxResults;
+    const ranked =
+      typeof maxResults === 'number' && maxResults > 0
+        ? scored.slice(0, maxResults)
+        : scored;
+
+    // 7 — Build metadata.
+    const metadata = this.buildMetadata(
+      ranked,
+      weights,
+      quotes.length,
+      excludedCount,
+      now,
+    );
+
+    return { ranked, metadata };
+  }
+
+  /**
+   * Convenience wrapper that returns only the best quote entry, or
+   * `null` if the input is empty.
+   */
+  getBest(
+    quotes: StellarBridgeQuote[],
+    options: QuoteComparisonOptions = {},
+  ): QuoteComparisonEntry | null {
+    const result = this.compare(quotes, { ...options, maxResults: 1 });
+    return result.ranked.length > 0 ? result.ranked[0] : null;
+  }
+
+  /**
+   * Compare exactly two quotes and return both ranked.
+   * Useful for head-to-head provider comparisons.
+   */
+  comparePair(
+    a: StellarBridgeQuote,
+    b: StellarBridgeQuote,
+    options: QuoteComparisonOptions = {},
+  ): [QuoteComparisonEntry, QuoteComparisonEntry] {
+    const result = this.compare([a, b], options);
+    return result.ranked as [QuoteComparisonEntry, QuoteComparisonEntry];
+  }
+
+  /** Returns the currently configured default weights. */
+  getDefaultWeights(): QuoteComparisonWeights {
+    return { ...this.weights };
+  }
+
+  // ─── Dimension helpers (static, exported for external use) ─────────────
+
+  /**
+   * Parse the effective received amount from a quote.
+   * Prefers `netOutputAmount` (post-fee) and falls back to `outputAmount`.
+   */
+  static parseReceivedAmount(quote: StellarBridgeQuote): number {
+    const net = parseFloat(quote.output.netOutputAmount);
+    if (Number.isFinite(net) && net > 0) return net;
+    const gross = parseFloat(quote.output.outputAmount);
+    return Number.isFinite(gross) ? gross : 0;
+  }
+
+  /**
+   * Compare quotes solely by received amount (highest first).
+   */
+  static compareByReceivedAmount(
+    quotes: StellarBridgeQuote[],
+  ): StellarBridgeQuote[] {
+    return [...quotes].sort(
+      (a, b) =>
+        QuoteComparator.parseReceivedAmount(b) -
+        QuoteComparator.parseReceivedAmount(a),
+    );
+  }
+
+  /**
+   * Compare quotes solely by total fee (lowest first).
+   */
+  static compareByFee(quotes: StellarBridgeQuote[]): StellarBridgeQuote[] {
+    return [...quotes].sort(
+      (a, b) => a.fees.totalFeeUsdCents - b.fees.totalFeeUsdCents,
+    );
+  }
+
+  /**
+   * Compare quotes solely by estimated execution time (fastest first).
+   */
+  static compareBySpeed(quotes: StellarBridgeQuote[]): StellarBridgeQuote[] {
+    return [...quotes].sort(
+      (a, b) =>
+        a.execution.estimatedTimeSeconds - b.execution.estimatedTimeSeconds,
+    );
+  }
+
+  /**
+   * Compare quotes solely by success rate (highest first).
+   */
+  static compareByReliability(
+    quotes: StellarBridgeQuote[],
+  ): StellarBridgeQuote[] {
+    return [...quotes].sort(
+      (a, b) => b.execution.successRate - a.execution.successRate,
+    );
+  }
+
+  // ─── Internals ─────────────────────────────────────────────────────────
+
+  private parseReceivedAmount(quote: StellarBridgeQuote): number {
+    return QuoteComparator.parseReceivedAmount(quote);
+  }
+
+  private filterQuotes(
+    quotes: StellarBridgeQuote[],
+    now: number,
+    excludeExpired: boolean,
+  ): { eligible: StellarBridgeQuote[]; excludedCount: number } {
+    if (!excludeExpired) {
+      return { eligible: [...quotes], excludedCount: 0 };
+    }
+    const eligible: StellarBridgeQuote[] = [];
+    let excludedCount = 0;
+    for (const q of quotes) {
+      if (q.expiresAt !== undefined && q.expiresAt < now) {
+        excludedCount++;
+      } else {
+        eligible.push(q);
+      }
+    }
+    return { eligible, excludedCount };
+  }
+
+  private buildMetadata(
+    ranked: QuoteComparisonEntry[],
+    weights: QuoteComparisonWeights,
+    totalQuotes: number,
+    excludedQuotes: number,
+    comparedAt: number,
+  ): QuoteComparisonMetadata {
+    const scores = ranked.map((e) => e.compositeScore);
+    const providerDistribution: Record<string, number> = {};
+    for (const e of ranked) {
+      providerDistribution[e.quote.providerId] =
+        (providerDistribution[e.quote.providerId] ?? 0) + 1;
+    }
+
+    return {
+      totalQuotes,
+      excludedQuotes,
+      bestQuoteId: ranked.length > 0 ? ranked[0].quote.id : null,
+      bestCompositeScore: scores.length > 0 ? scores[0] : 0,
+      averageCompositeScore:
+        scores.length > 0
+          ? scores.reduce((s, v) => s + v, 0) / scores.length
+          : 0,
+      scoreRange: {
+        min: scores.length > 0 ? Math.min(...scores) : 0,
+        max: scores.length > 0 ? Math.max(...scores) : 0,
+      },
+      providerDistribution,
+      appliedWeights: weights,
+      comparedAt,
+    };
+  }
+
+  private emptyMetadata(
+    weights: QuoteComparisonWeights,
+    totalQuotes: number,
+    excludedQuotes: number,
+    comparedAt: number,
+  ): QuoteComparisonMetadata {
+    return {
+      totalQuotes,
+      excludedQuotes,
+      bestQuoteId: null,
+      bestCompositeScore: 0,
+      averageCompositeScore: 0,
+      scoreRange: { min: 0, max: 0 },
+      providerDistribution: {},
+      appliedWeights: weights,
+      comparedAt,
+    };
+  }
+}
+
+// ─── Pure helpers ────────────────────────────────────────────────────────────
+
+interface Range {
+  min: number;
+  max: number;
+}
+
+function minMax(values: number[]): Range {
+  if (values.length === 0) return { min: 0, max: 0 };
+  let min = values[0];
+  let max = values[0];
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] < min) min = values[i];
+    if (values[i] > max) max = values[i];
+  }
+  return { min, max };
+}
+
+/**
+ * Normalise a single value to [0, 1] using min-max scaling.
+ *
+ * - If `lowerIsBetter` is true the score is inverted so that lower raw
+ *   values produce higher scores.
+ * - If min === max (all values identical) the score is 0.5 (neutral).
+ */
+function normalize(
+  value: number,
+  range: Range,
+  lowerIsBetter: boolean,
+): number {
+  if (range.max === range.min) return 0.5;
+  const ratio = (value - range.min) / (range.max - range.min);
+  return lowerIsBetter ? 1 - ratio : ratio;
+}
+
+/**
+ * Compute a weighted composite score from dimension scores.
+ *
+ * The result is in [0, 1] because the weights are divided out.
+ */
+function weightedComposite(
+  scores: QuoteDimensionScores,
+  weights: QuoteComparisonWeights,
+): number {
+  const totalWeight =
+    weights.receivedAmountWeight +
+    weights.feeWeight +
+    weights.speedWeight +
+    weights.reliabilityWeight;
+
+  if (totalWeight === 0) return 0.5;
+
+  return (
+    (scores.receivedAmountScore * weights.receivedAmountWeight +
+      scores.feeScore * weights.feeWeight +
+      scores.speedScore * weights.speedWeight +
+      scores.reliabilityScore * weights.reliabilityWeight) /
+    totalWeight
+  );
+}

--- a/src/quotes/comparison/stellar/types.ts
+++ b/src/quotes/comparison/stellar/types.ts
@@ -1,0 +1,145 @@
+// ─── Quote Comparison Types ──────────────────────────────────────────────────
+//
+// Configurable evaluation criteria for ranking normalised Stellar bridge
+// quotes across multiple providers.
+
+import type { StellarBridgeQuote } from '../../types/canonical-quote';
+
+// ─── Weights ─────────────────────────────────────────────────────────────────
+
+/**
+ * Configurable weights that control how much each evaluation dimension
+ * contributes to the final composite score.
+ *
+ * All values must be in the range [0, 1]. The engine normalises them
+ * internally so they do not need to sum to 1.
+ */
+export interface QuoteComparisonWeights {
+  /** Importance of receiving a higher output amount (0–1). */
+  receivedAmountWeight: number;
+  /** Importance of lower total fees (0–1). */
+  feeWeight: number;
+  /** Importance of faster estimated execution time (0–1). */
+  speedWeight: number;
+  /** Importance of higher historical success rate (0–1). */
+  reliabilityWeight: number;
+}
+
+// ─── Options ─────────────────────────────────────────────────────────────────
+
+/**
+ * Options accepted by the quote comparison engine.
+ */
+export interface QuoteComparisonOptions {
+  /** Override the default weights. Missing keys fall back to defaults. */
+  weights?: Partial<QuoteComparisonWeights>;
+
+  /** Injected clock (epoch ms) for deterministic timestamps in tests. */
+  now?: () => number;
+
+  /**
+   * Maximum number of ranked results to return.
+   * Defaults to the length of the input quotes (i.e. return all).
+   */
+  maxResults?: number;
+
+  /**
+   * If true, quotes that have expired (expiresAt < now) are silently
+   * excluded before comparison. Defaults to false.
+   */
+  excludeExpired?: boolean;
+}
+
+// ─── Dimension Scores ────────────────────────────────────────────────────────
+
+/**
+ * Per-dimension normalised scores for a single quote.
+ *
+ * Every value is in the range [0, 1] where **1 is the best** outcome
+ * within the compared set.
+ */
+export interface QuoteDimensionScores {
+  /** Higher received amount → higher score. */
+  receivedAmountScore: number;
+  /** Lower total fee → higher score. */
+  feeScore: number;
+  /** Faster execution → higher score. */
+  speedScore: number;
+  /** Higher success rate → higher score. */
+  reliabilityScore: number;
+}
+
+// ─── Per-Quote Comparison Result ─────────────────────────────────────────────
+
+/**
+ * The comparison result for a single quote, enriched with dimension
+ * scores, a composite weighted score, and a 1-based rank.
+ */
+export interface QuoteComparisonEntry {
+  /** The original canonical quote that was compared. */
+  quote: StellarBridgeQuote;
+  /** Normalised per-dimension scores. */
+  dimensionScores: QuoteDimensionScores;
+  /** Weighted composite score (0–1, higher is better). */
+  compositeScore: number;
+  /** 1-based rank within the compared set (1 = best). */
+  rank: number;
+  /**
+   * Delta of the composite score relative to the best quote.
+   * 0 for the top-ranked quote; positive for all others.
+   */
+  deltaToBest: number;
+}
+
+// ─── Comparison Metadata ─────────────────────────────────────────────────────
+
+/**
+ * Aggregate metadata about a comparison run.
+ */
+export interface QuoteComparisonMetadata {
+  /** Number of quotes that entered the comparison. */
+  totalQuotes: number;
+  /** Number of quotes that were excluded (e.g. expired). */
+  excludedQuotes: number;
+  /** Quote ID of the top-ranked result. */
+  bestQuoteId: string | null;
+  /** Composite score of the top-ranked result. */
+  bestCompositeScore: number;
+  /** Mean composite score across all ranked quotes. */
+  averageCompositeScore: number;
+  /** Score range across all ranked quotes. */
+  scoreRange: { min: number; max: number };
+  /** Provider distribution in the ranked set. */
+  providerDistribution: Record<string, number>;
+  /** Weights that were applied for this comparison. */
+  appliedWeights: QuoteComparisonWeights;
+  /** Epoch ms when the comparison was generated. */
+  comparedAt: number;
+}
+
+// ─── Full Comparison Result ──────────────────────────────────────────────────
+
+/**
+ * The full result returned by the comparison engine.
+ */
+export interface QuoteComparisonResult {
+  /** Ranked list of compared quotes (best first). */
+  ranked: QuoteComparisonEntry[];
+  /** Aggregate comparison metadata. */
+  metadata: QuoteComparisonMetadata;
+}
+
+// ─── Defaults ────────────────────────────────────────────────────────────────
+
+/**
+ * Default comparison weights.
+ *
+ * The defaults favour received amount and fees equally, with speed and
+ * reliability as secondary signals.
+ */
+export const DEFAULT_COMPARISON_WEIGHTS: QuoteComparisonWeights = {
+  receivedAmountWeight: 0.35,
+  feeWeight: 0.3,
+  speedWeight: 0.15,
+  reliabilityWeight: 0.2,
+};

--- a/src/routing/scoring/index.ts
+++ b/src/routing/scoring/index.ts
@@ -1,0 +1,14 @@
+// ─── Routing Scoring ─────────────────────────────────────────────────────────
+
+export {
+  DEFAULT_ROUTING_SCORING_WEIGHTS,
+  type RoutingScoringWeights,
+  type RoutingDimensionScores,
+  type RoutingScoredEntry,
+} from './types';
+
+export {
+  validateScoringWeights,
+  mergeScoringWeights,
+  normaliseWeights,
+} from './scoring-weights';

--- a/src/routing/scoring/scoring-weights.ts
+++ b/src/routing/scoring/scoring-weights.ts
@@ -1,0 +1,85 @@
+/**
+ * File: src/routing/scoring/scoring-weights.ts
+ *
+ * Utility helpers for working with routing scoring weights.
+ *
+ * These helpers are shared by the route-level scoring layer and can be
+ * used by any consumer that needs to validate, merge, or normalise
+ * weight configurations.
+ */
+
+import {
+  DEFAULT_ROUTING_SCORING_WEIGHTS,
+  type RoutingScoringWeights,
+} from './types';
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Validates that all weights are in the range [0, 1].
+ *
+ * Returns an array of error messages. An empty array means the weights
+ * are valid.
+ */
+export function validateScoringWeights(
+  weights: RoutingScoringWeights,
+): string[] {
+  const errors: string[] = [];
+  for (const [key, value] of Object.entries(weights)) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      errors.push(`${key} must be a finite number, got ${value}`);
+    } else if (value < 0 || value > 1) {
+      errors.push(`${key} must be between 0 and 1, got ${value}`);
+    }
+  }
+  return errors;
+}
+
+// ─── Merging ─────────────────────────────────────────────────────────────────
+
+/**
+ * Merge partial weight overrides onto a base weight configuration.
+ *
+ * Missing keys in the override fall back to the base values.
+ */
+export function mergeScoringWeights(
+  base: RoutingScoringWeights = DEFAULT_ROUTING_SCORING_WEIGHTS,
+  overrides: Partial<RoutingScoringWeights> = {},
+): RoutingScoringWeights {
+  return { ...base, ...overrides };
+}
+
+// ─── Normalisation ───────────────────────────────────────────────────────────
+
+/**
+ * Normalise weights so they sum to exactly 1.
+ *
+ * If all weights are 0 the function returns equal weights for each
+ * dimension. This is useful for display or for feeding into algorithms
+ * that require a probability distribution.
+ */
+export function normaliseWeights(
+  weights: RoutingScoringWeights,
+): RoutingScoringWeights {
+  const total =
+    weights.feeWeight +
+    weights.speedWeight +
+    weights.reliabilityWeight +
+    weights.confidenceWeight;
+
+  if (total === 0) {
+    return {
+      feeWeight: 0.25,
+      speedWeight: 0.25,
+      reliabilityWeight: 0.25,
+      confidenceWeight: 0.25,
+    };
+  }
+
+  return {
+    feeWeight: weights.feeWeight / total,
+    speedWeight: weights.speedWeight / total,
+    reliabilityWeight: weights.reliabilityWeight / total,
+    confidenceWeight: weights.confidenceWeight / total,
+  };
+}

--- a/src/routing/scoring/types.ts
+++ b/src/routing/scoring/types.ts
@@ -1,0 +1,69 @@
+// ─── Routing Scoring Types ───────────────────────────────────────────────────
+//
+// Re-usable ranking weight types for the routing layer. These types
+// mirror the quote comparison weights but are scoped to route-level
+// scoring where the dimensions are fee, speed, reliability, and
+// confidence (matching the existing RouteRanker contract).
+
+// ─── Weights ─────────────────────────────────────────────────────────────────
+
+/**
+ * Configurable weights for route-level scoring.
+ *
+ * All values must be in the range [0, 1]. The scorer normalises them
+ * internally so they do not need to sum to 1.
+ */
+export interface RoutingScoringWeights {
+  /** Importance of lower fees (0–1). */
+  feeWeight: number;
+  /** Importance of faster execution (0–1). */
+  speedWeight: number;
+  /** Importance of higher historical success rate (0–1). */
+  reliabilityWeight: number;
+  /** Importance of higher confidence estimates (0–1). */
+  confidenceWeight: number;
+}
+
+// ─── Score Breakdown ─────────────────────────────────────────────────────────
+
+/**
+ * Per-dimension normalised scores for a single route.
+ *
+ * Every value is in the range [0, 1] where 1 = best within the
+ * compared set.
+ */
+export interface RoutingDimensionScores {
+  feeScore: number;
+  speedScore: number;
+  reliabilityScore: number;
+  confidenceScore: number;
+}
+
+// ─── Scored Route Entry ──────────────────────────────────────────────────────
+
+/**
+ * A generic scored route entry that the routing layer can use for
+ * any route shape.
+ */
+export interface RoutingScoredEntry<T = unknown> {
+  /** The original route data. */
+  route: T;
+  /** Per-dimension normalised scores. */
+  dimensionScores: RoutingDimensionScores;
+  /** Weighted composite score (0–1, higher is better). */
+  compositeScore: number;
+  /** 1-based rank within the scored set. */
+  rank: number;
+}
+
+// ─── Defaults ────────────────────────────────────────────────────────────────
+
+/**
+ * Default routing scoring weights.
+ */
+export const DEFAULT_ROUTING_SCORING_WEIGHTS: RoutingScoringWeights = {
+  feeWeight: 0.3,
+  speedWeight: 0.25,
+  reliabilityWeight: 0.25,
+  confidenceWeight: 0.2,
+};

--- a/tests/quotes/comparison/quote-comparator.spec.ts
+++ b/tests/quotes/comparison/quote-comparator.spec.ts
@@ -1,0 +1,776 @@
+import { QuoteComparator } from '../../../src/quotes/comparison/stellar/quote-comparator';
+import { DEFAULT_COMPARISON_WEIGHTS } from '../../../src/quotes/comparison/stellar/types';
+import type { StellarBridgeQuote } from '../../../src/quotes/types/canonical-quote';
+import type {
+  QuoteComparisonWeights,
+  QuoteComparisonEntry,
+} from '../../../src/quotes/comparison/stellar/types';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const FIXED_NOW = 1_700_000_000_000;
+
+function buildQuote(
+  overrides: Partial<StellarBridgeQuote> = {},
+): StellarBridgeQuote {
+  return {
+    id: 'quote-1',
+    providerId: 'allbridge',
+    providerName: 'AllBridge',
+    route: {
+      sourceChain: 'stellar',
+      destinationChain: 'ethereum',
+      sourceAsset: 'USDC',
+      destinationAsset: 'USDC',
+      hops: 1,
+    },
+    fees: {
+      bridgeFeeBps: 30,
+      bridgeFeeFlatUsdCents: 50,
+      networkFeeUsdCents: 25,
+      totalFeeUsdCents: 100,
+      feeToken: 'USDC',
+    },
+    execution: {
+      estimatedTimeSeconds: 30,
+      successRate: 0.98,
+    },
+    output: {
+      inputAmount: '100',
+      outputAmount: '99.5',
+      netOutputAmount: '99.0',
+      minOutputAmount: '98.0',
+    },
+    metadata: {},
+    quotedAt: FIXED_NOW,
+    ...overrides,
+  };
+}
+
+function buildQuoteSet(): StellarBridgeQuote[] {
+  return [
+    buildQuote({
+      id: 'q-cheap-slow',
+      providerId: 'cheap-provider',
+      providerName: 'CheapProvider',
+      fees: {
+        bridgeFeeBps: 10,
+        bridgeFeeFlatUsdCents: 10,
+        networkFeeUsdCents: 10,
+        totalFeeUsdCents: 30,
+        feeToken: 'USDC',
+      },
+      execution: { estimatedTimeSeconds: 120, successRate: 0.9 },
+      output: {
+        inputAmount: '100',
+        outputAmount: '99.7',
+        netOutputAmount: '99.4',
+        minOutputAmount: '98.5',
+      },
+    }),
+    buildQuote({
+      id: 'q-fast-expensive',
+      providerId: 'fast-provider',
+      providerName: 'FastProvider',
+      fees: {
+        bridgeFeeBps: 80,
+        bridgeFeeFlatUsdCents: 200,
+        networkFeeUsdCents: 100,
+        totalFeeUsdCents: 380,
+        feeToken: 'USDC',
+      },
+      execution: { estimatedTimeSeconds: 5, successRate: 0.99 },
+      output: {
+        inputAmount: '100',
+        outputAmount: '98.0',
+        netOutputAmount: '96.5',
+        minOutputAmount: '95.0',
+      },
+    }),
+    buildQuote({
+      id: 'q-balanced',
+      providerId: 'balanced-provider',
+      providerName: 'BalancedProvider',
+      fees: {
+        bridgeFeeBps: 40,
+        bridgeFeeFlatUsdCents: 80,
+        networkFeeUsdCents: 50,
+        totalFeeUsdCents: 170,
+        feeToken: 'USDC',
+      },
+      execution: { estimatedTimeSeconds: 45, successRate: 0.95 },
+      output: {
+        inputAmount: '100',
+        outputAmount: '99.0',
+        netOutputAmount: '98.0',
+        minOutputAmount: '97.0',
+      },
+    }),
+  ];
+}
+
+// ─── Test Suite ──────────────────────────────────────────────────────────────
+
+describe('QuoteComparator', () => {
+  let comparator: QuoteComparator;
+
+  beforeEach(() => {
+    comparator = new QuoteComparator({ now: () => FIXED_NOW });
+  });
+
+  // ─── Basic Comparison ───────────────────────────────────────────────────
+
+  describe('compare()', () => {
+    it('returns an empty result for an empty input', () => {
+      const result = comparator.compare([]);
+      expect(result.ranked).toEqual([]);
+      expect(result.metadata.bestQuoteId).toBeNull();
+      expect(result.metadata.totalQuotes).toBe(0);
+      expect(result.metadata.averageCompositeScore).toBe(0);
+    });
+
+    it('returns a single entry for a single quote with neutral scores', () => {
+      const quote = buildQuote();
+      const result = comparator.compare([quote]);
+
+      expect(result.ranked).toHaveLength(1);
+      expect(result.ranked[0].rank).toBe(1);
+      expect(result.ranked[0].deltaToBest).toBe(0);
+      // With a single quote all ranges are equal → each dimension = 0.5
+      expect(result.ranked[0].dimensionScores.receivedAmountScore).toBe(0.5);
+      expect(result.ranked[0].dimensionScores.feeScore).toBe(0.5);
+      expect(result.ranked[0].dimensionScores.speedScore).toBe(0.5);
+      expect(result.ranked[0].dimensionScores.reliabilityScore).toBe(0.5);
+    });
+
+    it('ranks quotes correctly: best composite score gets rank 1', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+
+      expect(result.ranked.length).toBe(3);
+      // Ranks should be sequential 1, 2, 3
+      const ranks = result.ranked.map((e) => e.rank);
+      expect(ranks).toEqual([1, 2, 3]);
+      // Scores should be descending
+      for (let i = 1; i < result.ranked.length; i++) {
+        expect(result.ranked[i - 1].compositeScore).toBeGreaterThanOrEqual(
+          result.ranked[i].compositeScore,
+        );
+      }
+    });
+
+    it('the top-ranked entry has deltaToBest === 0', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      expect(result.ranked[0].deltaToBest).toBe(0);
+    });
+
+    it('all other entries have deltaToBest > 0', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      for (let i = 1; i < result.ranked.length; i++) {
+        expect(result.ranked[i].deltaToBest).toBeGreaterThan(0);
+      }
+    });
+
+    it('preserves the original quote reference in each entry', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      for (const entry of result.ranked) {
+        const original = quotes.find((q) => q.id === entry.quote.id);
+        expect(original).toBeDefined();
+        expect(entry.quote).toBe(original);
+      }
+    });
+  });
+
+  // ─── Received Amount Comparison ─────────────────────────────────────────
+
+  describe('received amount comparison', () => {
+    it('gives a higher receivedAmountScore to quotes with more output', () => {
+      const low = buildQuote({
+        id: 'low',
+        output: {
+          inputAmount: '100',
+          outputAmount: '90',
+          netOutputAmount: '89',
+          minOutputAmount: '88',
+        },
+      });
+      const high = buildQuote({
+        id: 'high',
+        output: {
+          inputAmount: '100',
+          outputAmount: '99',
+          netOutputAmount: '98',
+          minOutputAmount: '97',
+        },
+      });
+
+      const result = comparator.compare([low, high]);
+      const highEntry = result.ranked.find((e) => e.quote.id === 'high')!;
+      const lowEntry = result.ranked.find((e) => e.quote.id === 'low')!;
+
+      expect(highEntry.dimensionScores.receivedAmountScore).toBeGreaterThan(
+        lowEntry.dimensionScores.receivedAmountScore,
+      );
+    });
+
+    it('falls back to outputAmount when netOutputAmount is 0', () => {
+      const quote = buildQuote({
+        output: {
+          inputAmount: '100',
+          outputAmount: '95',
+          netOutputAmount: '0',
+          minOutputAmount: '90',
+        },
+      });
+      const amount = QuoteComparator.parseReceivedAmount(quote);
+      expect(amount).toBe(95);
+    });
+  });
+
+  // ─── Fee Comparison ─────────────────────────────────────────────────────
+
+  describe('fee comparison', () => {
+    it('gives a higher feeScore to quotes with lower total fees', () => {
+      const expensive = buildQuote({
+        id: 'expensive',
+        fees: {
+          bridgeFeeBps: 100,
+          bridgeFeeFlatUsdCents: 500,
+          networkFeeUsdCents: 200,
+          totalFeeUsdCents: 700,
+          feeToken: 'USDC',
+        },
+      });
+      const cheap = buildQuote({
+        id: 'cheap',
+        fees: {
+          bridgeFeeBps: 5,
+          bridgeFeeFlatUsdCents: 10,
+          networkFeeUsdCents: 5,
+          totalFeeUsdCents: 20,
+          feeToken: 'USDC',
+        },
+      });
+
+      const result = comparator.compare([expensive, cheap]);
+      const cheapEntry = result.ranked.find((e) => e.quote.id === 'cheap')!;
+      const expensiveEntry = result.ranked.find(
+        (e) => e.quote.id === 'expensive',
+      )!;
+
+      expect(cheapEntry.dimensionScores.feeScore).toBeGreaterThan(
+        expensiveEntry.dimensionScores.feeScore,
+      );
+    });
+
+    it('compareByFee sorts lowest fee first', () => {
+      const quotes = buildQuoteSet();
+      const sorted = QuoteComparator.compareByFee(quotes);
+      for (let i = 1; i < sorted.length; i++) {
+        expect(sorted[i - 1].fees.totalFeeUsdCents).toBeLessThanOrEqual(
+          sorted[i].fees.totalFeeUsdCents,
+        );
+      }
+    });
+  });
+
+  // ─── Speed Comparison ───────────────────────────────────────────────────
+
+  describe('speed comparison', () => {
+    it('gives a higher speedScore to faster quotes', () => {
+      const slow = buildQuote({
+        id: 'slow',
+        execution: { estimatedTimeSeconds: 300, successRate: 0.95 },
+      });
+      const fast = buildQuote({
+        id: 'fast',
+        execution: { estimatedTimeSeconds: 5, successRate: 0.95 },
+      });
+
+      const result = comparator.compare([slow, fast]);
+      const fastEntry = result.ranked.find((e) => e.quote.id === 'fast')!;
+      const slowEntry = result.ranked.find((e) => e.quote.id === 'slow')!;
+
+      expect(fastEntry.dimensionScores.speedScore).toBeGreaterThan(
+        slowEntry.dimensionScores.speedScore,
+      );
+    });
+
+    it('compareBySpeed sorts fastest first', () => {
+      const quotes = buildQuoteSet();
+      const sorted = QuoteComparator.compareBySpeed(quotes);
+      for (let i = 1; i < sorted.length; i++) {
+        expect(
+          sorted[i - 1].execution.estimatedTimeSeconds,
+        ).toBeLessThanOrEqual(sorted[i].execution.estimatedTimeSeconds);
+      }
+    });
+  });
+
+  // ─── Reliability Comparison ─────────────────────────────────────────────
+
+  describe('reliability comparison', () => {
+    it('gives a higher reliabilityScore to quotes with higher success rate', () => {
+      const unreliable = buildQuote({
+        id: 'unreliable',
+        execution: { estimatedTimeSeconds: 30, successRate: 0.5 },
+      });
+      const reliable = buildQuote({
+        id: 'reliable',
+        execution: { estimatedTimeSeconds: 30, successRate: 0.99 },
+      });
+
+      const result = comparator.compare([unreliable, reliable]);
+      const reliableEntry = result.ranked.find(
+        (e) => e.quote.id === 'reliable',
+      )!;
+      const unreliableEntry = result.ranked.find(
+        (e) => e.quote.id === 'unreliable',
+      )!;
+
+      expect(reliableEntry.dimensionScores.reliabilityScore).toBeGreaterThan(
+        unreliableEntry.dimensionScores.reliabilityScore,
+      );
+    });
+
+    it('compareByReliability sorts highest success rate first', () => {
+      const quotes = buildQuoteSet();
+      const sorted = QuoteComparator.compareByReliability(quotes);
+      for (let i = 1; i < sorted.length; i++) {
+        expect(sorted[i - 1].execution.successRate).toBeGreaterThanOrEqual(
+          sorted[i].execution.successRate,
+        );
+      }
+    });
+  });
+
+  // ─── Configurable Weights ───────────────────────────────────────────────
+
+  describe('configurable weights', () => {
+    it('uses default weights when none are provided', () => {
+      const weights = comparator.getDefaultWeights();
+      expect(weights).toEqual(DEFAULT_COMPARISON_WEIGHTS);
+    });
+
+    it('allows overriding individual weights', () => {
+      const custom: QuoteComparator = new QuoteComparator({
+        weights: { feeWeight: 0.8 },
+      });
+      const weights = custom.getDefaultWeights();
+      expect(weights.feeWeight).toBe(0.8);
+      // Other weights should remain at defaults
+      expect(weights.receivedAmountWeight).toBe(
+        DEFAULT_COMPARISON_WEIGHTS.receivedAmountWeight,
+      );
+    });
+
+    it('fee-heavy weights rank the cheapest quote first', () => {
+      const quotes = buildQuoteSet();
+      const feeHeavy = new QuoteComparator({
+        weights: {
+          receivedAmountWeight: 0,
+          feeWeight: 1,
+          speedWeight: 0,
+          reliabilityWeight: 0,
+        },
+      });
+      const result = feeHeavy.compare(quotes);
+      // The cheapest quote (q-cheap-slow, totalFeeUsdCents=30) should be rank 1
+      expect(result.ranked[0].quote.id).toBe('q-cheap-slow');
+    });
+
+    it('speed-heavy weights rank the fastest quote first', () => {
+      const quotes = buildQuoteSet();
+      const speedHeavy = new QuoteComparator({
+        weights: {
+          receivedAmountWeight: 0,
+          feeWeight: 0,
+          speedWeight: 1,
+          reliabilityWeight: 0,
+        },
+      });
+      const result = speedHeavy.compare(quotes);
+      // The fastest quote (q-fast-expensive, 5s) should be rank 1
+      expect(result.ranked[0].quote.id).toBe('q-fast-expensive');
+    });
+
+    it('reliability-heavy weights rank the most reliable quote first', () => {
+      const quotes = buildQuoteSet();
+      const reliabilityHeavy = new QuoteComparator({
+        weights: {
+          receivedAmountWeight: 0,
+          feeWeight: 0,
+          speedWeight: 0,
+          reliabilityWeight: 1,
+        },
+      });
+      const result = reliabilityHeavy.compare(quotes);
+      // Most reliable: q-fast-expensive (0.99)
+      expect(result.ranked[0].quote.id).toBe('q-fast-expensive');
+    });
+
+    it('received-amount-heavy weights rank the highest output first', () => {
+      const quotes = buildQuoteSet();
+      const amountHeavy = new QuoteComparator({
+        weights: {
+          receivedAmountWeight: 1,
+          feeWeight: 0,
+          speedWeight: 0,
+          reliabilityWeight: 0,
+        },
+      });
+      const result = amountHeavy.compare(quotes);
+      // Highest netOutputAmount: q-cheap-slow (99.4)
+      expect(result.ranked[0].quote.id).toBe('q-cheap-slow');
+    });
+
+    it('all-zero weights produce a neutral 0.5 composite score', () => {
+      const quotes = buildQuoteSet();
+      const zeroWeights = new QuoteComparator({
+        weights: {
+          receivedAmountWeight: 0,
+          feeWeight: 0,
+          speedWeight: 0,
+          reliabilityWeight: 0,
+        },
+      });
+      const result = zeroWeights.compare(quotes);
+      for (const entry of result.ranked) {
+        expect(entry.compositeScore).toBe(0.5);
+      }
+    });
+
+    it('per-call weight overrides take precedence over constructor weights', () => {
+      const quotes = buildQuoteSet();
+      const defaultComparator = new QuoteComparator();
+      const result = defaultComparator.compare(quotes, {
+        weights: {
+          feeWeight: 1,
+          receivedAmountWeight: 0,
+          speedWeight: 0,
+          reliabilityWeight: 0,
+        },
+      });
+      expect(result.ranked[0].quote.id).toBe('q-cheap-slow');
+    });
+  });
+
+  // ─── maxResults ─────────────────────────────────────────────────────────
+
+  describe('maxResults', () => {
+    it('limits the number of returned results', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes, { maxResults: 2 });
+      expect(result.ranked).toHaveLength(2);
+    });
+
+    it('still returns the best quote when maxResults is 1', () => {
+      const quotes = buildQuoteSet();
+      const fullResult = comparator.compare(quotes);
+      const limitedResult = comparator.compare(quotes, { maxResults: 1 });
+
+      expect(limitedResult.ranked).toHaveLength(1);
+      expect(limitedResult.ranked[0].quote.id).toBe(
+        fullResult.ranked[0].quote.id,
+      );
+    });
+  });
+
+  // ─── Expired Quote Filtering ────────────────────────────────────────────
+
+  describe('expired quote filtering', () => {
+    it('does not filter expired quotes by default', () => {
+      const quotes = [
+        buildQuote({ id: 'expired', expiresAt: FIXED_NOW - 1000 }),
+        buildQuote({ id: 'valid' }),
+      ];
+      const result = comparator.compare(quotes);
+      expect(result.ranked).toHaveLength(2);
+      expect(result.metadata.excludedQuotes).toBe(0);
+    });
+
+    it('excludes expired quotes when excludeExpired is true', () => {
+      const quotes = [
+        buildQuote({ id: 'expired', expiresAt: FIXED_NOW - 1000 }),
+        buildQuote({ id: 'valid' }),
+      ];
+      const result = comparator.compare(quotes, { excludeExpired: true });
+      expect(result.ranked).toHaveLength(1);
+      expect(result.ranked[0].quote.id).toBe('valid');
+      expect(result.metadata.excludedQuotes).toBe(1);
+    });
+
+    it('returns empty result when all quotes are expired', () => {
+      const quotes = [
+        buildQuote({ id: 'a', expiresAt: FIXED_NOW - 5000 }),
+        buildQuote({ id: 'b', expiresAt: FIXED_NOW - 1000 }),
+      ];
+      const result = comparator.compare(quotes, { excludeExpired: true });
+      expect(result.ranked).toHaveLength(0);
+      expect(result.metadata.excludedQuotes).toBe(2);
+      expect(result.metadata.bestQuoteId).toBeNull();
+    });
+
+    it('quotes without expiresAt are never excluded', () => {
+      const quotes = [buildQuote({ id: 'no-expiry' })];
+      const result = comparator.compare(quotes, { excludeExpired: true });
+      expect(result.ranked).toHaveLength(1);
+    });
+  });
+
+  // ─── getBest() ──────────────────────────────────────────────────────────
+
+  describe('getBest()', () => {
+    it('returns the top-ranked entry', () => {
+      const quotes = buildQuoteSet();
+      const best = comparator.getBest(quotes);
+      expect(best).not.toBeNull();
+      expect(best!.rank).toBe(1);
+    });
+
+    it('returns null for an empty input', () => {
+      const best = comparator.getBest([]);
+      expect(best).toBeNull();
+    });
+  });
+
+  // ─── comparePair() ──────────────────────────────────────────────────────
+
+  describe('comparePair()', () => {
+    it('returns exactly two ranked entries', () => {
+      const a = buildQuote({ id: 'a' });
+      const b = buildQuote({ id: 'b' });
+      const [first, second] = comparator.comparePair(a, b);
+      expect(first.rank).toBe(1);
+      expect(second.rank).toBe(2);
+    });
+
+    it('ranks the better quote first', () => {
+      const cheapQuote = buildQuote({
+        id: 'cheap',
+        fees: {
+          bridgeFeeBps: 5,
+          bridgeFeeFlatUsdCents: 5,
+          networkFeeUsdCents: 5,
+          totalFeeUsdCents: 15,
+          feeToken: 'USDC',
+        },
+      });
+      const expensiveQuote = buildQuote({
+        id: 'expensive',
+        fees: {
+          bridgeFeeBps: 200,
+          bridgeFeeFlatUsdCents: 500,
+          networkFeeUsdCents: 300,
+          totalFeeUsdCents: 1000,
+          feeToken: 'USDC',
+        },
+      });
+      const [first] = comparator.comparePair(cheapQuote, expensiveQuote);
+      expect(first.quote.id).toBe('cheap');
+    });
+  });
+
+  // ─── Metadata ───────────────────────────────────────────────────────────
+
+  describe('comparison metadata', () => {
+    it('records totalQuotes correctly', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      expect(result.metadata.totalQuotes).toBe(3);
+    });
+
+    it('records the correct bestQuoteId', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      expect(result.metadata.bestQuoteId).toBe(result.ranked[0].quote.id);
+    });
+
+    it('records the correct bestCompositeScore', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      expect(result.metadata.bestCompositeScore).toBe(
+        result.ranked[0].compositeScore,
+      );
+    });
+
+    it('records the correct averageCompositeScore', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      const expected =
+        result.ranked.reduce((sum, e) => sum + e.compositeScore, 0) /
+        result.ranked.length;
+      expect(result.metadata.averageCompositeScore).toBeCloseTo(expected);
+    });
+
+    it('records the correct scoreRange', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      const scores = result.ranked.map((e) => e.compositeScore);
+      expect(result.metadata.scoreRange.min).toBe(Math.min(...scores));
+      expect(result.metadata.scoreRange.max).toBe(Math.max(...scores));
+    });
+
+    it('records the provider distribution', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      expect(result.metadata.providerDistribution['cheap-provider']).toBe(1);
+      expect(result.metadata.providerDistribution['fast-provider']).toBe(1);
+      expect(result.metadata.providerDistribution['balanced-provider']).toBe(1);
+    });
+
+    it('records the applied weights', () => {
+      const quotes = buildQuoteSet();
+      const customWeights: Partial<QuoteComparisonWeights> = { feeWeight: 0.5 };
+      const result = comparator.compare(quotes, { weights: customWeights });
+      expect(result.metadata.appliedWeights.feeWeight).toBe(0.5);
+      expect(result.metadata.appliedWeights.receivedAmountWeight).toBe(
+        DEFAULT_COMPARISON_WEIGHTS.receivedAmountWeight,
+      );
+    });
+
+    it('records comparedAt timestamp', () => {
+      const result = comparator.compare(buildQuoteSet());
+      expect(result.metadata.comparedAt).toBe(FIXED_NOW);
+    });
+  });
+
+  // ─── Deterministic Ranking ──────────────────────────────────────────────
+
+  describe('deterministic ranking', () => {
+    it('produces the same ranking on repeated calls with the same input', () => {
+      const quotes = buildQuoteSet();
+      const r1 = comparator.compare(quotes);
+      const r2 = comparator.compare(quotes);
+
+      expect(r1.ranked.map((e) => e.quote.id)).toEqual(
+        r2.ranked.map((e) => e.quote.id),
+      );
+      expect(r1.ranked.map((e) => e.compositeScore)).toEqual(
+        r2.ranked.map((e) => e.compositeScore),
+      );
+    });
+
+    it('ranking is consistent regardless of input order', () => {
+      const quotes = buildQuoteSet();
+      const reversed = [...quotes].reverse();
+      const r1 = comparator.compare(quotes);
+      const r2 = comparator.compare(reversed);
+
+      // Same set of IDs should appear in the same order
+      expect(r1.ranked.map((e) => e.quote.id)).toEqual(
+        r2.ranked.map((e) => e.quote.id),
+      );
+    });
+  });
+
+  // ─── Static Dimension Comparators ───────────────────────────────────────
+
+  describe('static dimension comparators', () => {
+    it('compareByReceivedAmount returns a new array (does not mutate input)', () => {
+      const quotes = buildQuoteSet();
+      const original = [...quotes];
+      QuoteComparator.compareByReceivedAmount(quotes);
+      expect(quotes).toEqual(original);
+    });
+
+    it('compareByFee returns a new array (does not mutate input)', () => {
+      const quotes = buildQuoteSet();
+      const original = [...quotes];
+      QuoteComparator.compareByFee(quotes);
+      expect(quotes).toEqual(original);
+    });
+
+    it('compareBySpeed returns a new array (does not mutate input)', () => {
+      const quotes = buildQuoteSet();
+      const original = [...quotes];
+      QuoteComparator.compareBySpeed(quotes);
+      expect(quotes).toEqual(original);
+    });
+
+    it('compareByReliability returns a new array (does not mutate input)', () => {
+      const quotes = buildQuoteSet();
+      const original = [...quotes];
+      QuoteComparator.compareByReliability(quotes);
+      expect(quotes).toEqual(original);
+    });
+  });
+
+  // ─── Edge Cases ─────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles quotes with identical dimension values', () => {
+      const a = buildQuote({ id: 'a' });
+      const b = buildQuote({ id: 'b' });
+      const result = comparator.compare([a, b]);
+      // All dimensions are identical → all scores should be 0.5
+      for (const entry of result.ranked) {
+        expect(entry.compositeScore).toBe(0.5);
+      }
+    });
+
+    it('handles quotes with zero fees', () => {
+      const free = buildQuote({
+        id: 'free',
+        fees: {
+          bridgeFeeBps: 0,
+          bridgeFeeFlatUsdCents: 0,
+          networkFeeUsdCents: 0,
+          totalFeeUsdCents: 0,
+          feeToken: 'USDC',
+        },
+      });
+      const paid = buildQuote({
+        id: 'paid',
+        fees: {
+          bridgeFeeBps: 50,
+          bridgeFeeFlatUsdCents: 100,
+          networkFeeUsdCents: 50,
+          totalFeeUsdCents: 200,
+          feeToken: 'USDC',
+        },
+      });
+      const result = comparator.compare([free, paid]);
+      const freeEntry = result.ranked.find((e) => e.quote.id === 'free')!;
+      expect(freeEntry.dimensionScores.feeScore).toBe(1);
+    });
+
+    it('handles quotes with zero estimated time', () => {
+      const instant = buildQuote({
+        id: 'instant',
+        execution: { estimatedTimeSeconds: 0, successRate: 0.95 },
+      });
+      const slow = buildQuote({
+        id: 'slow',
+        execution: { estimatedTimeSeconds: 600, successRate: 0.95 },
+      });
+      const result = comparator.compare([instant, slow]);
+      const instantEntry = result.ranked.find((e) => e.quote.id === 'instant')!;
+      expect(instantEntry.dimensionScores.speedScore).toBe(1);
+    });
+
+    it('composite scores are always in [0, 1]', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      for (const entry of result.ranked) {
+        expect(entry.compositeScore).toBeGreaterThanOrEqual(0);
+        expect(entry.compositeScore).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('dimension scores are always in [0, 1]', () => {
+      const quotes = buildQuoteSet();
+      const result = comparator.compare(quotes);
+      for (const entry of result.ranked) {
+        const ds = entry.dimensionScores;
+        for (const val of Object.values(ds)) {
+          expect(val).toBeGreaterThanOrEqual(0);
+          expect(val).toBeLessThanOrEqual(1);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
closes #903
closes #904 
closes #905 
closes #907 

- Add QuoteComparator engine with configurable ranking weights
- Compare received amounts, bridge fees, execution times, and reliability
- Support per-call and constructor-level weight overrides
- Add expired-quote filtering (opt-in via excludeExpired)
- Include comparison metadata (score distribution, provider breakdown)
- Add static per-dimension sort helpers (compareByFee, compareBySpeed, etc.)
- Add routing scoring types and weight utilities (validate, merge, normalise)
- Add 51 comprehensive tests covering all acceptance criteria
- All 139 quote tests pass (comparison + normalization + expiration)