### PR TITLE
Closes #965

### DIFF
--- a/src/metrics/contracts/ContractMetricsCollector.ts
+++ b/src/metrics/contracts/ContractMetricsCollector.ts
@@ -1,0 +1,115 @@
+import {
+  SorobanInvocationMetricsTracker,
+  SorobanInvocationReport,
+  SorobanObservatoryConfig,
+} from '../../observability/soroban';
+import { ContractAggregatedMetrics } from './contract-metrics.types';
+
+export class ContractMetricsCollector {
+  private readonly tracker: SorobanInvocationMetricsTracker;
+
+  constructor(
+    tracker?: SorobanInvocationMetricsTracker,
+    config?: SorobanObservatoryConfig,
+  ) {
+    this.tracker = tracker ?? new SorobanInvocationMetricsTracker(config);
+  }
+
+  /**
+   * Returns the underlying tracker instance.
+   */
+  public getTracker(): SorobanInvocationMetricsTracker {
+    return this.tracker;
+  }
+
+  /**
+   * Records a contract invocation sample directly.
+   */
+  public recordInvocation(
+    contractId: string,
+    latencyMs: number,
+    success: boolean = true,
+  ): void {
+    this.tracker.recordSample({
+      contractId,
+      latencyMs,
+      timestamp: new Date(),
+      success,
+    });
+  }
+
+  /**
+   * Measures execution time of a contract action and records the metric.
+   */
+  public async measure<T>(
+    contractId: string,
+    action: () => Promise<T>,
+  ): Promise<T> {
+    return this.tracker.measure(contractId, action);
+  }
+
+  /**
+   * Returns performance report for a specific contract.
+   */
+  public getContractReport(contractId: string): SorobanInvocationReport | null {
+    return this.tracker.generateReport(contractId);
+  }
+
+  /**
+   * Returns performance reports for all tracked contracts.
+   */
+  public getAllContractReports(): SorobanInvocationReport[] {
+    return this.tracker.generateAllReports();
+  }
+
+  /**
+   * Returns aggregate metrics across all tracked contracts.
+   */
+  public getAggregatedMetrics(): ContractAggregatedMetrics {
+    const reports = this.tracker.generateAllReports();
+    let totalInvocations = 0;
+    let successfulInvocations = 0;
+    let failedInvocations = 0;
+    let totalLatencyMs = 0;
+
+    for (const report of reports) {
+      totalInvocations += report.totalInvocations;
+      successfulInvocations += report.successCount;
+      failedInvocations += report.failureCount;
+      totalLatencyMs += report.averageLatencyMs * report.totalInvocations;
+    }
+
+    const globalSuccessRate =
+      totalInvocations > 0
+        ? Number(((successfulInvocations / totalInvocations) * 100).toFixed(2))
+        : 0;
+
+    const averageLatencyMs =
+      totalInvocations > 0 ? Math.round(totalLatencyMs / totalInvocations) : 0;
+
+    return {
+      totalContracts: reports.length,
+      totalInvocations,
+      successfulInvocations,
+      failedInvocations,
+      globalSuccessRate,
+      averageLatencyMs,
+      reports,
+      lastUpdated: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Generates a human-readable JSON report.
+   */
+  public generateReport(): string {
+    return JSON.stringify(this.getAggregatedMetrics(), null, 2);
+  }
+
+  /**
+   * Clears metrics for a given contract or all contracts.
+   */
+  public clear(contractId?: string): void {
+    this.tracker.clear(contractId);
+  }
+}

--- a/src/metrics/contracts/contract-metrics.types.ts
+++ b/src/metrics/contracts/contract-metrics.types.ts
@@ -1,0 +1,12 @@
+import { SorobanInvocationReport } from '../../observability/soroban';
+
+export interface ContractAggregatedMetrics {
+  totalContracts: number;
+  totalInvocations: number;
+  successfulInvocations: number;
+  failedInvocations: number;
+  globalSuccessRate: number;
+  averageLatencyMs: number;
+  reports: SorobanInvocationReport[];
+  lastUpdated: string;
+}

--- a/src/metrics/contracts/index.ts
+++ b/src/metrics/contracts/index.ts
@@ -1,0 +1,2 @@
+export { ContractMetricsCollector } from './ContractMetricsCollector';
+export type { ContractAggregatedMetrics } from './contract-metrics.types';

--- a/src/observability/soroban/index.ts
+++ b/src/observability/soroban/index.ts
@@ -1,0 +1,6 @@
+export { SorobanInvocationMetricsTracker } from './soroban-invocation-metrics.service';
+export type {
+  SorobanInvocationSample,
+  SorobanInvocationReport,
+  SorobanObservatoryConfig,
+} from './soroban-invocation-metrics.types';

--- a/src/observability/soroban/soroban-invocation-metrics.service.ts
+++ b/src/observability/soroban/soroban-invocation-metrics.service.ts
@@ -1,0 +1,135 @@
+import {
+  SorobanInvocationSample,
+  SorobanInvocationReport,
+  SorobanObservatoryConfig,
+} from './soroban-invocation-metrics.types';
+
+export class SorobanInvocationMetricsTracker {
+  private readonly samplesMap = new Map<string, SorobanInvocationSample[]>();
+  private readonly degradedThresholdMs: number;
+  private readonly errorRateThresholdPercent: number;
+  private readonly sampleWindowSize: number;
+
+  constructor(config?: SorobanObservatoryConfig) {
+    this.degradedThresholdMs = config?.latencyDegradedThresholdMs ?? 1500;
+    this.errorRateThresholdPercent = config?.errorRateThresholdPercent ?? 10;
+    this.sampleWindowSize = config?.sampleWindowSize ?? 50;
+  }
+
+  /**
+   * Executes a contract action, measures execution duration, and records the sample.
+   */
+  public async measure<T>(
+    contractId: string,
+    action: () => Promise<T>,
+  ): Promise<T> {
+    const startTime = performance.now();
+    let success = true;
+
+    try {
+      return await action();
+    } catch (error) {
+      success = false;
+      throw error;
+    } finally {
+      const durationMs = Math.round(performance.now() - startTime);
+      this.recordSample({
+        contractId,
+        latencyMs: durationMs,
+        timestamp: new Date(),
+        success,
+      });
+    }
+  }
+
+  /**
+   * Directly records a pre-measured contract invocation sample.
+   */
+  public recordSample(sample: SorobanInvocationSample): void {
+    const { contractId } = sample;
+    const existingSamples = this.samplesMap.get(contractId) ?? [];
+
+    existingSamples.push(sample);
+
+    // Maintain sliding window size
+    if (existingSamples.length > this.sampleWindowSize) {
+      existingSamples.shift();
+    }
+
+    this.samplesMap.set(contractId, existingSamples);
+  }
+
+  /**
+   * Generates a performance and health report for a specific contract.
+   */
+  public generateReport(contractId: string): SorobanInvocationReport | null {
+    const samples = this.samplesMap.get(contractId);
+
+    if (!samples || samples.length === 0) {
+      return null;
+    }
+
+    const sampleCount = samples.length;
+    const totalInvocations = sampleCount;
+    const latencies = samples.map((s) => s.latencyMs).sort((a, b) => a - b);
+    const failureCount = samples.filter((s) => !s.success).length;
+    const successCount = samples.filter((s) => s.success).length;
+
+    const totalLatency = latencies.reduce((acc, curr) => acc + curr, 0);
+    const averageLatencyMs = Math.round(totalLatency / sampleCount);
+    const minLatencyMs = latencies[0];
+    const maxLatencyMs = latencies[latencies.length - 1];
+
+    // Compute P95 Latency
+    const p95Index = Math.ceil(0.95 * sampleCount) - 1;
+    const p95LatencyMs = latencies[p95Index];
+
+    const errorRate = Number(((failureCount / sampleCount) * 100).toFixed(2));
+
+    // Detect degraded performance
+    const isDegraded =
+      p95LatencyMs >= this.degradedThresholdMs ||
+      errorRate >= this.errorRateThresholdPercent;
+
+    return {
+      contractId,
+      totalInvocations,
+      sampleCount,
+      successCount,
+      failureCount,
+      averageLatencyMs,
+      p95LatencyMs,
+      minLatencyMs,
+      maxLatencyMs,
+      errorRate,
+      isDegraded,
+    };
+  }
+
+  /**
+   * Retrieves reports across all tracked Soroban contracts.
+   */
+  public generateAllReports(): SorobanInvocationReport[] {
+    const reports: SorobanInvocationReport[] = [];
+
+    for (const contractId of Array.from(this.samplesMap.keys())) {
+      const report = this.generateReport(contractId);
+      if (report) {
+        reports.push(report);
+      }
+    }
+
+    return reports;
+  }
+
+  /**
+   * Resets recorded metrics for a contract or all contracts.
+   */
+  public clear(contractId?: string): void {
+    if (contractId) {
+      this.samplesMap.delete(contractId);
+    } else {
+      this.samplesMap.clear();
+    }
+  }
+}

--- a/src/observability/soroban/soroban-invocation-metrics.types.ts
+++ b/src/observability/soroban/soroban-invocation-metrics.types.ts
@@ -1,0 +1,26 @@
+export interface SorobanInvocationSample {
+  contractId: string;
+  latencyMs: number;
+  timestamp: Date;
+  success: boolean;
+}
+
+export interface SorobanInvocationReport {
+  contractId: string;
+  totalInvocations: number;
+  sampleCount: number;
+  successCount: number;
+  failureCount: number;
+  averageLatencyMs: number;
+  p95LatencyMs: number;
+  minLatencyMs: number;
+  maxLatencyMs: number;
+  errorRate: number; // percentage 0 - 100
+  isDegraded: boolean;
+}
+
+export interface SorobanObservatoryConfig {
+  latencyDegradedThresholdMs?: number; // e.g. 1500ms
+  errorRateThresholdPercent?: number; // e.g. 10%
+  sampleWindowSize?: number; // e.g. 50 samples
+}


### PR DESCRIPTION
## Summary

Implements Soroban contract invocation metrics tracking as specified in issue #965.

## Changes

### `src/observability/soroban/`
- `soroban-invocation-metrics.types.ts` — defines `SorobanInvocationSample`, `SorobanInvocationReport`, and `SorobanObservatoryConfig`
- `soroban-invocation-metrics.service.ts` — implements `SorobanInvocationMetricsTracker` with `measure()`, `recordSample()`, `generateReport()`, `generateAllReports()`, and `clear()`; computes average latency, min/max, P95, success/failure counts, and error rate with sliding window retention
- `index.ts` — re-exports service and types

### `src/metrics/contracts/`
- `contract-metrics.types.ts` — defines `ContractAggregatedMetrics`
- `ContractMetricsCollector.ts` — thin collector wrapping `SorobanInvocationMetricsTracker`, exposes `recordInvocation()`, `measure()`, `getContractReport()`, `getAllContractReports()`, `getAggregatedMetrics()`, and `clear()`
- `index.ts` — re-exports collector and types

## Verification

- `npx tsc --noEmit` — exit code 0, no type errors
- `pnpm run build` — exit code 0, build passes

## Notes

No existing files were modified. All new code follows the plain TypeScript class-based pattern established by `StellarLatencyObservatoryService` and `EcosystemMetricsCollector`.

Closes #965