### PR TITLE
feat(stellar): implement Stellar bridge provider circuit breaker #966

### DIFF
--- a/src/providers/circuit-breaker/stellar/index.ts
+++ b/src/providers/circuit-breaker/stellar/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Stellar Provider Circuit Breaker (issue #966).
+ *
+ * Temporarily disables unhealthy bridge providers after repeated failures
+ * and supports half-open recovery checks.
+ */
+
+export * from './stellar-provider-circuit-breaker';

--- a/src/providers/middleware/index.ts
+++ b/src/providers/middleware/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Stellar provider middleware (issue #966).
+ *
+ * Middleware layers that wrap provider calls so unhealthy providers are
+ * temporarily bypassed and recovered automatically.
+ */
+
+export * from './stellar';

--- a/src/providers/middleware/stellar/index.ts
+++ b/src/providers/middleware/stellar/index.ts
@@ -1,0 +1,1 @@
+export * from './stellar-circuit-breaker.middleware';

--- a/src/providers/middleware/stellar/stellar-circuit-breaker.middleware.ts
+++ b/src/providers/middleware/stellar/stellar-circuit-breaker.middleware.ts
@@ -1,0 +1,146 @@
+import {
+  StellarProviderCircuitBreakerRegistry,
+  type CircuitBreakerOptions,
+  type ProviderStatus,
+} from '../../circuit-breaker/stellar/stellar-provider-circuit-breaker';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CircuitBreakerMiddlewareOptions {
+  /** Invoked when a provider call is bypassed because its circuit is OPEN. */
+  onBypass?: (providerId: string) => void;
+}
+
+export interface ProviderCallResult<T> {
+  providerId: string;
+  /** True when the call was skipped because the circuit was OPEN. */
+  bypassed: boolean;
+  /** The resolved value from the provider, or `undefined` when bypassed. */
+  value: T | undefined;
+}
+
+// ─── Middleware ───────────────────────────────────────────────────────────────
+
+/**
+ * Provider-call middleware that gates every Stellar bridge provider request
+ * through the circuit breaker (issue #966).
+ *
+ * Responsibilities:
+ *  - Bypass providers whose circuit is OPEN so a failing provider is never
+ *    contacted during route discovery or quote generation.
+ *  - Record success/failure outcomes so the breaker can trip, cool down,
+ *    half-open, and eventually restore the provider.
+ *
+ * Accepts either a pre-built registry (to share state with the rest of the
+ * application) or circuit-breaker options (to construct one internally).
+ */
+export class StellarCircuitBreakerMiddleware {
+  readonly registry: StellarProviderCircuitBreakerRegistry;
+  private readonly onBypass?: (providerId: string) => void;
+
+  constructor(
+    registryOrOptions:
+      | StellarProviderCircuitBreakerRegistry
+      | (CircuitBreakerOptions & CircuitBreakerMiddlewareOptions) = {},
+  ) {
+    if (registryOrOptions instanceof StellarProviderCircuitBreakerRegistry) {
+      this.registry = registryOrOptions;
+      this.onBypass = undefined;
+    } else {
+      const { onBypass, ...breakerOptions } = registryOrOptions;
+      this.registry = new StellarProviderCircuitBreakerRegistry(breakerOptions);
+      this.onBypass = onBypass;
+    }
+  }
+
+  // ─── Call protection ────────────────────────────────────────────────────
+
+  /**
+   * Execute a provider call behind the circuit breaker.
+   *
+   * When the provider's circuit is OPEN the underlying function is NOT
+   * invoked; the call is short-circuited and a `bypassed` result is returned.
+   * Otherwise the function runs, its success/failure is recorded, and the
+   * resolved value is returned (failures are re-thrown).
+   */
+  async execute<T>(
+    providerId: string,
+    fn: () => Promise<T>,
+  ): Promise<ProviderCallResult<T>> {
+    if (!this.registry.isAvailable(providerId)) {
+      this.onBypass?.(providerId);
+      return { providerId, bypassed: true, value: undefined };
+    }
+
+    try {
+      const value = await fn();
+      this.registry.reportSuccess(providerId);
+      return { providerId, bypassed: false, value };
+    } catch (error) {
+      this.registry.reportFailure(providerId);
+      throw error;
+    }
+  }
+
+  // ─── Routing helpers ────────────────────────────────────────────────────
+
+  /** Whether a provider may currently be dispatched to. */
+  isAvailable(providerId: string): boolean {
+    return this.registry.isAvailable(providerId);
+  }
+
+  /**
+   * Filter an ordered candidate list down to providers whose circuit is not
+   * OPEN, preserving the caller's priority ordering.
+   */
+  filterAvailable(providerIds: string[]): string[] {
+    return this.registry.availableProviders(providerIds);
+  }
+
+  /**
+   * Select the first available provider from an ordered list.
+   * Returns `null` when every candidate's circuit is OPEN.
+   */
+  selectProvider(providerIds: string[]): string | null {
+    return this.registry.selectProvider(providerIds);
+  }
+
+  // ─── Reporting ──────────────────────────────────────────────────────────
+
+  /** Record the outcome of a provider call. */
+  report(providerId: string, ok: boolean): void {
+    this.registry.report(providerId, ok);
+  }
+
+  // ─── Recovery ───────────────────────────────────────────────────────────
+
+  /**
+   * Manually restore a provider by resetting its breaker to CLOSED.
+   * Typically used after an operator confirms the provider has recovered.
+   */
+  recover(providerId: string): void {
+    this.registry.resetProvider(providerId);
+  }
+
+  /** Reset every tracked breaker to CLOSED. */
+  reset(): void {
+    this.registry.resetAll();
+  }
+
+  // ─── Inspection ─────────────────────────────────────────────────────────
+
+  /** Providers whose circuit is currently OPEN (suspended). */
+  suspendedProviders(): string[] {
+    return this.registry.suspendedProviders();
+  }
+
+  /** Full snapshot of every known provider. */
+  allStatuses(): ProviderStatus[] {
+    return this.registry.allStatuses();
+  }
+
+  /** Snapshot for a single provider, or `null` if never contacted. */
+  statusFor(providerId: string): ProviderStatus | null {
+    return this.registry.statusFor(providerId);
+  }
+}

--- a/tests/providers/circuit-breaker/stellar-circuit-breaker-middleware.spec.ts
+++ b/tests/providers/circuit-breaker/stellar-circuit-breaker-middleware.spec.ts
@@ -1,0 +1,145 @@
+import { StellarProviderCircuitBreakerRegistry } from '../../../src/providers/circuit-breaker/stellar';
+import { StellarCircuitBreakerMiddleware } from '../../../src/providers/middleware';
+
+// ─── Middleware ───────────────────────────────────────────────────────────────
+
+describe('StellarCircuitBreakerMiddleware', () => {
+  it('executes healthy providers and records success', async () => {
+    const middleware = new StellarCircuitBreakerMiddleware({
+      failureThreshold: 2,
+      now: () => 0,
+    });
+
+    const calls: string[] = [];
+    const result = await middleware.execute('horizon-a', async () => {
+      calls.push('horizon-a');
+      return 'quote';
+    });
+
+    expect(result).toEqual({
+      providerId: 'horizon-a',
+      bypassed: false,
+      value: 'quote',
+    });
+    expect(calls).toEqual(['horizon-a']);
+    expect(middleware.isAvailable('horizon-a')).toBe(true);
+  });
+
+  it('bypasses a provider once its circuit is open', async () => {
+    const middleware = new StellarCircuitBreakerMiddleware({
+      failureThreshold: 1,
+      now: () => 0,
+    });
+    middleware.report('horizon-a', false); // trips horizon-a
+
+    const calls: string[] = [];
+    const result = await middleware.execute('horizon-a', async () => {
+      calls.push('horizon-a');
+      return 'should-not-happen';
+    });
+
+    expect(result).toEqual({
+      providerId: 'horizon-a',
+      bypassed: true,
+      value: undefined,
+    });
+    expect(calls).toEqual([]);
+    expect(middleware.suspendedProviders()).toEqual(['horizon-a']);
+  });
+
+  it('notifies on bypass via onBypass callback', async () => {
+    const bypassed: string[] = [];
+    const middleware = new StellarCircuitBreakerMiddleware({
+      failureThreshold: 1,
+      now: () => 0,
+      onBypass: (providerId) => bypassed.push(providerId),
+    });
+    middleware.report('horizon-a', false);
+
+    await middleware.execute('horizon-a', async () => 'nope');
+    expect(bypassed).toEqual(['horizon-a']);
+  });
+
+  it('records failures and trips the circuit', async () => {
+    const middleware = new StellarCircuitBreakerMiddleware({
+      failureThreshold: 2,
+      now: () => 0,
+    });
+
+    const failingCall = middleware.execute('horizon-a', async () => {
+      throw new Error('provider down');
+    });
+
+    await expect(failingCall).rejects.toThrow('provider down');
+    expect(middleware.isAvailable('horizon-a')).toBe(true); // 1 failure only
+
+    await expect(
+      middleware.execute('horizon-a', async () => {
+        throw new Error('provider down');
+      }),
+    ).rejects.toThrow('provider down');
+    expect(middleware.isAvailable('horizon-a')).toBe(false); // tripped
+  });
+
+  it('allows recovery after the cooldown and restores availability', async () => {
+    let clock = 0;
+    const middleware = new StellarCircuitBreakerMiddleware({
+      failureThreshold: 1,
+      resetTimeoutMs: 1000,
+      now: () => clock,
+    });
+    middleware.report('horizon-a', false);
+    expect(middleware.isAvailable('horizon-a')).toBe(false);
+
+    clock += 1000; // cooldown elapses -> half-open trial allowed
+    const result = await middleware.execute('horizon-a', async () => 'quote');
+    expect(result.bypassed).toBe(false);
+    expect(result.value).toBe('quote');
+    expect(middleware.statusFor('horizon-a')?.snapshot.state).toBe('closed');
+    expect(middleware.filterAvailable(['horizon-a'])).toEqual(['horizon-a']);
+  });
+
+  it('filters unhealthy providers out of route discovery', () => {
+    const middleware = new StellarCircuitBreakerMiddleware({
+      failureThreshold: 1,
+      now: () => 0,
+    });
+    middleware.report('horizon-a', false);
+
+    expect(middleware.filterAvailable(['horizon-a', 'horizon-b'])).toEqual([
+      'horizon-b',
+    ]);
+    expect(middleware.selectProvider(['horizon-a', 'horizon-b'])).toBe(
+      'horizon-b',
+    );
+    expect(middleware.selectProvider(['horizon-a'])).toBeNull();
+  });
+
+  it('manually recovers a suspended provider', async () => {
+    const middleware = new StellarCircuitBreakerMiddleware({
+      failureThreshold: 1,
+      now: () => 0,
+    });
+    middleware.report('horizon-a', false);
+    expect(middleware.isAvailable('horizon-a')).toBe(false);
+
+    middleware.recover('horizon-a');
+    expect(middleware.isAvailable('horizon-a')).toBe(true);
+    const result = await middleware.execute('horizon-a', async () => 'quote');
+    expect(result.bypassed).toBe(false);
+  });
+
+  it('shares state when constructed with an existing registry', async () => {
+    const registry = new StellarProviderCircuitBreakerRegistry({
+      failureThreshold: 1,
+      now: () => 0,
+    });
+    const middleware = new StellarCircuitBreakerMiddleware(registry);
+
+    registry.reportFailure('horizon-a');
+    expect(middleware.isAvailable('horizon-a')).toBe(false);
+
+    const result = await middleware.execute('horizon-a', async () => 'nope');
+    expect(result.bypassed).toBe(true);
+  });
+});

--- a/tests/providers/circuit-breaker/stellar-provider-circuit-breaker.spec.ts
+++ b/tests/providers/circuit-breaker/stellar-provider-circuit-breaker.spec.ts
@@ -1,0 +1,206 @@
+import {
+  CircuitBreaker,
+  StellarProviderCircuitBreakerRegistry,
+} from '../../../src/providers/circuit-breaker/stellar';
+
+// ─── CircuitBreaker ───────────────────────────────────────────────────────────
+
+describe('CircuitBreaker', () => {
+  it('starts closed and allows requests', () => {
+    const breaker = new CircuitBreaker({ now: () => 0 });
+    expect(breaker.getState()).toBe('closed');
+    expect(breaker.canRequest()).toBe(true);
+  });
+
+  it('opens after the failure threshold and blocks requests', () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 3, now: () => 0 });
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('closed');
+    expect(breaker.canRequest()).toBe(true);
+
+    breaker.recordFailure(); // 3rd consecutive failure trips it
+    expect(breaker.getState()).toBe('open');
+    expect(breaker.canRequest()).toBe(false);
+  });
+
+  it('exposes configurable failure thresholds', () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 5, now: () => 0 });
+    for (let i = 0; i < 4; i++) breaker.recordFailure();
+    expect(breaker.getState()).toBe('closed');
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+  });
+
+  it('moves to half-open after the cooldown and closes on success', () => {
+    let clock = 1000;
+    const breaker = new CircuitBreaker({
+      failureThreshold: 1,
+      resetTimeoutMs: 500,
+      now: () => clock,
+    });
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+
+    clock += 500; // cooldown elapses
+    expect(breaker.getState()).toBe('half_open');
+    expect(breaker.canRequest()).toBe(true);
+
+    breaker.recordSuccess();
+    expect(breaker.getState()).toBe('closed');
+    expect(breaker.canRequest()).toBe(true);
+  });
+
+  it('respects a half-open success threshold before closing', () => {
+    let clock = 0;
+    const breaker = new CircuitBreaker({
+      failureThreshold: 1,
+      resetTimeoutMs: 100,
+      halfOpenSuccessThreshold: 2,
+      now: () => clock,
+    });
+    breaker.recordFailure();
+    clock += 100;
+    expect(breaker.getState()).toBe('half_open');
+
+    breaker.recordSuccess();
+    expect(breaker.getState()).toBe('half_open');
+
+    breaker.recordSuccess();
+    expect(breaker.getState()).toBe('closed');
+  });
+
+  it('re-opens immediately when a half-open trial fails', () => {
+    let clock = 0;
+    const breaker = new CircuitBreaker({
+      failureThreshold: 1,
+      resetTimeoutMs: 100,
+      now: () => clock,
+    });
+    breaker.recordFailure();
+    clock += 100;
+    expect(breaker.getState()).toBe('half_open');
+
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+    expect(breaker.canRequest()).toBe(false);
+  });
+
+  it('records cooldown remaining in snapshots', () => {
+    let clock = 1000;
+    const breaker = new CircuitBreaker({
+      failureThreshold: 1,
+      resetTimeoutMs: 1000,
+      now: () => clock,
+    });
+    breaker.recordFailure();
+    clock += 250;
+    const snapshot = breaker.getSnapshot();
+    expect(snapshot.state).toBe('open');
+    expect(snapshot.cooldownRemainingMs).toBe(750);
+  });
+
+  it('resets a tripped breaker back to closed', () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 1, now: () => 0 });
+    breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+    breaker.reset();
+    expect(breaker.getState()).toBe('closed');
+    expect(breaker.canRequest()).toBe(true);
+  });
+
+  it('fires state-change events', () => {
+    const events: string[] = [];
+    const breaker = new CircuitBreaker({
+      failureThreshold: 1,
+      now: () => 0,
+      onStateChange: (e) => events.push(`${e.from}->${e.to}`),
+    });
+    breaker.recordFailure();
+    expect(events).toContain('closed->open');
+  });
+
+  it('rejects invalid thresholds', () => {
+    expect(() => new CircuitBreaker({ failureThreshold: 0 })).toThrow(
+      RangeError,
+    );
+    expect(() => new CircuitBreaker({ resetTimeoutMs: -1 })).toThrow(
+      RangeError,
+    );
+    expect(() => new CircuitBreaker({ halfOpenSuccessThreshold: 0 })).toThrow(
+      RangeError,
+    );
+  });
+});
+
+// ─── StellarProviderCircuitBreakerRegistry ────────────────────────────────────
+
+describe('StellarProviderCircuitBreakerRegistry', () => {
+  it('suspends an unhealthy provider and filters availability', () => {
+    const registry = new StellarProviderCircuitBreakerRegistry({
+      failureThreshold: 2,
+      now: () => 0,
+    });
+    registry.report('horizon-a', false);
+    registry.report('horizon-a', false); // trips horizon-a
+    registry.report('horizon-b', true);
+
+    expect(registry.isAvailable('horizon-a')).toBe(false);
+    expect(registry.isAvailable('horizon-b')).toBe(true);
+    expect(registry.availableProviders(['horizon-a', 'horizon-b'])).toEqual([
+      'horizon-b',
+    ]);
+    expect(registry.suspendedProviders()).toEqual(['horizon-a']);
+  });
+
+  it('selects the first available provider from an ordered list', () => {
+    const registry = new StellarProviderCircuitBreakerRegistry({
+      failureThreshold: 1,
+      now: () => 0,
+    });
+    registry.reportFailure('horizon-a');
+    expect(registry.selectProvider(['horizon-a', 'horizon-b'])).toBe(
+      'horizon-b',
+    );
+    expect(registry.selectProvider(['horizon-a'])).toBeNull();
+  });
+
+  it('restores provider availability after recovery', () => {
+    let clock = 0;
+    const registry = new StellarProviderCircuitBreakerRegistry({
+      failureThreshold: 1,
+      resetTimeoutMs: 1000,
+      now: () => clock,
+    });
+    registry.reportFailure('horizon-a');
+    expect(registry.isAvailable('horizon-a')).toBe(false);
+
+    clock += 1000; // cooldown elapses -> half-open
+    expect(registry.isAvailable('horizon-a')).toBe(true);
+
+    registry.reportSuccess('horizon-a'); // recovery confirmed
+    expect(registry.statusFor('horizon-a')?.snapshot.state).toBe('closed');
+    expect(registry.availableProviders(['horizon-a'])).toEqual(['horizon-a']);
+  });
+
+  it('keeps per-provider state isolated', () => {
+    const registry = new StellarProviderCircuitBreakerRegistry({
+      failureThreshold: 1,
+      now: () => 0,
+    });
+    registry.reportFailure('horizon-a');
+    expect(registry.isAvailable('horizon-a')).toBe(false);
+    expect(registry.isAvailable('horizon-b')).toBe(true);
+  });
+
+  it('resets providers manually', () => {
+    const registry = new StellarProviderCircuitBreakerRegistry({
+      failureThreshold: 1,
+      now: () => 0,
+    });
+    registry.reportFailure('horizon-a');
+    expect(registry.isAvailable('horizon-a')).toBe(false);
+    registry.resetProvider('horizon-a');
+    expect(registry.isAvailable('horizon-a')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds a **Stellar Bridge Provider Circuit Breaker** that temporarily disables unhealthy bridge providers after repeated failures, prevents wasted calls to failing providers during route discovery and quote generation, and automatically restores providers once they recover — with configurable failure thresholds and half-open recovery checks.

## Related Issue

Closes [#966](https://github.com/MDTechLabs/BridgeWise/issues/966)

## Changes

### 🛡️ Circuit Breaker Middleware

- **\[ADD\]** `src/providers/middleware/stellar/stellar-circuit-breaker.middleware.ts`
  - Gates every provider call through the breaker: bypasses OPEN providers before they are ever invoked.
  - Records success/failure outcomes so the breaker trips, cools down, half-opens, and restores availability.
  - Route-discovery helpers (`filterAvailable` / `selectProvider`) skip unhealthy providers while preserving priority order.
  - `recover()` / `reset()` manual recovery overrides.
- **\[ADD\]** `src/providers/middleware/stellar/index.ts`, `src/providers/middleware/index.ts` — barrel exports.

### 🧠 Circuit Breaker Core

- **\[EXISTING\]** `src/providers/circuit-breaker/stellar/stellar-provider-circuit-breaker.ts` — `CircuitBreaker` (CLOSED → OPEN → HALF_OPEN → CLOSED) + `StellarProviderCircuitBreakerRegistry`.
- **\[ADD\]** `src/providers/circuit-breaker/stellar/index.ts` — public barrel export for the module.

### ✅ Tests

- **\[ADD\]** `tests/providers/circuit-breaker/stellar-provider-circuit-breaker.spec.ts`
  - Configurable failure thresholds, OPEN trip behavior, HALF_OPEN recovery, cooldown snapshots, state-change hooks, registry filtering/selection/reset.
- **\[ADD\]** `tests/providers/circuit-breaker/stellar-circuit-breaker-middleware.spec.ts`
  - Bypass behavior, outcome recording, cooldown-based recovery, route filtering, manual recovery, shared-registry wiring.

## Verification Results

```
npx jest src/providers/circuit-breaker tests/providers/circuit-breaker
✅ 27/27 passed

npx jest src/providers
✅ 94/94 passed

npx eslint src/providers/middleware src/providers/circuit-breaker/stellar/index.ts
✅ clean

npx tsc --noEmit
✅ no errors in changed files
```

Acceptance Criteria | Status
---|---
Circuit breaker implemented | ✅ CLOSED → OPEN → HALF_OPEN → CLOSED state machine + per-provider registry
Failure thresholds configurable | ✅ `failureThreshold` option (default 5, validated ≥ 1)
Unhealthy providers temporarily bypassed | ✅ middleware bypasses OPEN providers before any call; route helpers skip them
Provider recovery supported | ✅ HALF_OPEN trial checks + `recover()` / `reset()` manual overrides
