### PR TITLE
feat: add Stellar bridge resilience adapters

### DIFF
--- a/src/cross-chain/timeline/stellar/cross-chain-transaction-timeline.ts
+++ b/src/cross-chain/timeline/stellar/cross-chain-transaction-timeline.ts
@@ -1,0 +1,19 @@
+import { StellarTransferTimelineGenerator } from '../../../timeline/transfers/stellar/stellar-transfer-timeline';
+import type {
+  TimelineRenderOptions,
+  TransferTimeline,
+} from '../../../timeline/transfers/stellar/types';
+import type { TransferLifecycle } from '../../../transfers/state-machine/stellar';
+
+export class CrossChainTransactionTimeline {
+  private readonly generator = new StellarTransferTimelineGenerator();
+
+  build(lifecycle: TransferLifecycle): TransferTimeline {
+    return this.generator.generate(lifecycle);
+  }
+
+  render(timeline: TransferTimeline, options: TimelineRenderOptions = {}): string {
+    return this.generator.render(timeline, options);
+  }
+}
+

--- a/src/cross-chain/timeline/stellar/index.ts
+++ b/src/cross-chain/timeline/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './cross-chain-transaction-timeline';
+

--- a/src/providers/stellar/index.ts
+++ b/src/providers/stellar/index.ts
@@ -1,3 +1,4 @@
 export * from './history';
 export * from './score';
 export * from './flags';
+export * from './settlement';

--- a/src/providers/stellar/settlement/index.ts
+++ b/src/providers/stellar/settlement/index.ts
@@ -1,0 +1,2 @@
+export * from './stellar-provider-settlement-adapter';
+

--- a/src/providers/stellar/settlement/stellar-provider-settlement-adapter.ts
+++ b/src/providers/stellar/settlement/stellar-provider-settlement-adapter.ts
@@ -1,0 +1,23 @@
+import {
+  StellarBridgeProviderSandboxAdapter,
+} from '../stellar-bridge-provider-sandbox-adapter';
+import type {
+  BridgeQuote,
+  BridgeExecutionResult,
+} from '../stellar-bridge-provider-sandbox-adapter';
+
+export class StellarProviderSettlementAdapter extends StellarBridgeProviderSandboxAdapter {
+  quoteSettlement(
+    amount: string,
+    fromAsset: string,
+    toAsset: string,
+    sourceChain: string,
+    destinationChain: string,
+  ): Promise<BridgeQuote> {
+    return this.getQuote(amount, fromAsset, toAsset, sourceChain, destinationChain);
+  }
+
+  executeSettlement(sourceTxHash: string, quote: BridgeQuote): Promise<BridgeExecutionResult> {
+    return this.executeTransfer(sourceTxHash, quote);
+  }
+}

--- a/src/recovery/index.ts
+++ b/src/recovery/index.ts
@@ -1,1 +1,2 @@
 export * from './queue/index';
+export * from './policies/stellar';

--- a/src/recovery/policies/stellar/index.ts
+++ b/src/recovery/policies/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './stellar-execution-recovery-policy.service';
+

--- a/src/recovery/policies/stellar/stellar-execution-recovery-policy.service.ts
+++ b/src/recovery/policies/stellar/stellar-execution-recovery-policy.service.ts
@@ -1,0 +1,30 @@
+import {
+  SorobanTransferRecoveryPlanner,
+  classifyFailure,
+} from '../../transfers/stellar/transfer-recovery-planner';
+import type {
+  RecoveryPlan,
+  RecoveryExecutor,
+  TransferFailure,
+  AutomationResult,
+} from '../../transfers/stellar/transfer-recovery-planner.types';
+
+export class StellarExecutionRecoveryPolicy {
+  private readonly planner = new SorobanTransferRecoveryPlanner();
+
+  classify(reason: string): ReturnType<typeof classifyFailure> {
+    return classifyFailure(reason);
+  }
+
+  assess(failure: TransferFailure): RecoveryPlan {
+    return this.planner.plan(failure);
+  }
+
+  automate(
+    failure: TransferFailure,
+    executor: RecoveryExecutor,
+    maxSteps?: number,
+  ): Promise<AutomationResult> {
+    return this.planner.automate(failure, executor, maxSteps);
+  }
+}

--- a/src/security/replay/soroban/index.ts
+++ b/src/security/replay/soroban/index.ts
@@ -1,0 +1,2 @@
+export * from './soroban-bridge-transfer-replay-protection.service';
+

--- a/src/security/replay/soroban/soroban-bridge-transfer-replay-protection.service.ts
+++ b/src/security/replay/soroban/soroban-bridge-transfer-replay-protection.service.ts
@@ -1,0 +1,31 @@
+import { StellarReplayProtectionCache } from '../../../cache/replay/stellar/stellar-replay-protection-cache';
+import type { ReplayMetadata, ReplayCacheConfig } from '../../../cache/replay/stellar/stellar-replay-protection-cache';
+
+export class SorobanBridgeTransferReplayProtectionService {
+  private readonly cache: StellarReplayProtectionCache;
+
+  constructor(config: Partial<ReplayCacheConfig> = {}) {
+    this.cache = new StellarReplayProtectionCache(config);
+  }
+
+  record(metadata: ReplayMetadata): void {
+    this.cache.store(metadata);
+  }
+
+  isReplay(transactionHash: string, sourceAccount: string, sequenceNumber: string): boolean {
+    return this.cache.isReplay(transactionHash, sourceAccount, sequenceNumber);
+  }
+
+  get(transactionHash: string, sourceAccount: string, sequenceNumber: string): ReplayMetadata | null {
+    return this.cache.get(transactionHash, sourceAccount, sequenceNumber);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  destroy(): void {
+    this.cache.destroy();
+  }
+}
+


### PR DESCRIPTION
This change adds minimal resilience adapters for replay protection, recovery planning, cross-chain timelines, and provider settlement execution.

Closes #1014
Closes #1013
Closes #1012
Closes #1011