### PR TITLE
feat(stellar): route locks, Soroban compatibility, simulation diffs, and pre-exec safety

### DIFF
--- a/src/contracts/metadata/bridgewise-interface.ts
+++ b/src/contracts/metadata/bridgewise-interface.ts
@@ -1,0 +1,50 @@
+/**
+ * Expected BridgeWise interface capabilities for a Soroban bridge contract.
+ */
+
+export interface ExpectedMethodCapability {
+  name: string;
+  arguments: Array<{ name: string; type: string }>;
+  returnType?: string;
+}
+
+export interface ExpectedContractCapabilities {
+  specVersionPrefix?: string;
+  methods: ExpectedMethodCapability[];
+  requiredMetadata?: string[];
+}
+
+export const DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES: ExpectedContractCapabilities = {
+  specVersionPrefix: '1',
+  methods: [
+    {
+      name: 'bridge',
+      arguments: [
+        { name: 'source_chain', type: 'string' },
+        { name: 'target_chain', type: 'string' },
+        { name: 'amount', type: 'i128' },
+        { name: 'recipient', type: 'address' },
+      ],
+      returnType: 'bytes',
+    },
+    {
+      name: 'quote',
+      arguments: [
+        { name: 'source_chain', type: 'string' },
+        { name: 'target_chain', type: 'string' },
+        { name: 'amount', type: 'i128' },
+      ],
+      returnType: 'i128',
+    },
+    {
+      name: 'cancel',
+      arguments: [{ name: 'operation_id', type: 'bytes' }],
+      returnType: 'void',
+    },
+  ],
+  requiredMetadata: ['contractAddress', 'network', 'functions'],
+};
+
+export function normalizeType(type: string): string {
+  return type.trim().toLowerCase().replace(/\s+/g, '');
+}

--- a/src/contracts/metadata/index.ts
+++ b/src/contracts/metadata/index.ts
@@ -1,0 +1,10 @@
+export * from './soroban-metadata.types';
+export { SorobanContractMetadataResolver } from './soroban-metadata-resolver';
+export {
+  DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES,
+  normalizeType,
+} from './bridgewise-interface';
+export type {
+  ExpectedContractCapabilities,
+  ExpectedMethodCapability,
+} from './bridgewise-interface';

--- a/src/execution/route-lock.ts
+++ b/src/execution/route-lock.ts
@@ -1,0 +1,16 @@
+/**
+ * Execution-layer access to Stellar bridge route locks.
+ * Locks are keyed by execution ID so preparation and signing share one route.
+ */
+export {
+  StellarBridgeRouteLockService,
+  DEFAULT_ROUTE_LOCK_DURATION_MS,
+} from '../routing/locks/stellar';
+export type {
+  LockedBridgeRoute,
+  RouteLockConfig,
+  RouteLockRecord,
+  RouteLockResult,
+  RouteUpdateGuardResult,
+  RouteLockStatus,
+} from '../routing/locks/stellar';

--- a/src/execution/safety/stellar/index.ts
+++ b/src/execution/safety/stellar/index.ts
@@ -1,0 +1,1 @@
+export { StellarPreExecutionSafetyPipeline } from './stellar-pre-execution-safety-pipeline';

--- a/src/execution/safety/stellar/stellar-pre-execution-safety-pipeline.ts
+++ b/src/execution/safety/stellar/stellar-pre-execution-safety-pipeline.ts
@@ -1,0 +1,46 @@
+import {
+  SafetyPipelineConfig,
+  StellarPreExecutionSafetyContext,
+  StellarPreExecutionSafetyResult,
+  validateAssetBalance,
+  validateContractCompatibility,
+  validateDestinationAccount,
+  validateMinimumOutput,
+  validateQuoteFreshness,
+  validateTransactionResources,
+  validateTrustlineRequirements,
+} from '../../validation';
+
+/**
+ * Final safety pipeline run before a Stellar bridge transaction is signed.
+ * All checks execute; any error blocks signing.
+ */
+export class StellarPreExecutionSafetyPipeline {
+  private readonly now: () => number;
+
+  constructor(config: SafetyPipelineConfig = {}) {
+    this.now = config.now ?? (() => Date.now());
+  }
+
+  run(context: StellarPreExecutionSafetyContext): StellarPreExecutionSafetyResult {
+    const checkedAt = this.now();
+    const checks = [
+      validateQuoteFreshness(context, checkedAt),
+      validateDestinationAccount(context),
+      validateAssetBalance(context),
+      validateTrustlineRequirements(context),
+      validateMinimumOutput(context),
+      validateTransactionResources(context),
+      validateContractCompatibility(context),
+    ];
+    const failures = checks.flatMap((check) => check.failures);
+    const blocked = failures.some((failure) => failure.severity === 'error');
+    return {
+      safe: !blocked,
+      blocked,
+      checkedAt,
+      checks,
+      failures,
+    };
+  }
+}

--- a/src/execution/validation/index.ts
+++ b/src/execution/validation/index.ts
@@ -1,0 +1,10 @@
+export * from './types';
+export {
+  validateQuoteFreshness,
+  validateDestinationAccount,
+  validateAssetBalance,
+  validateTrustlineRequirements,
+  validateMinimumOutput,
+  validateTransactionResources,
+  validateContractCompatibility,
+} from './stellar-pre-execution-validators';

--- a/src/execution/validation/stellar-pre-execution-validators.ts
+++ b/src/execution/validation/stellar-pre-execution-validators.ts
@@ -1,0 +1,210 @@
+import {
+  SafetyCheckFailure,
+  SafetyCheckResult,
+  StellarPreExecutionSafetyContext,
+} from './types';
+
+function fail(
+  check: SafetyCheckResult['check'],
+  code: string,
+  reason: string,
+  action: string,
+): SafetyCheckFailure {
+  return { check, code, severity: 'error', reason, action };
+}
+
+export function validateQuoteFreshness(
+  ctx: StellarPreExecutionSafetyContext,
+  now: number,
+): SafetyCheckResult {
+  const check = 'quote_freshness' as const;
+  const failures: SafetyCheckFailure[] = [];
+  if (ctx.quoteTtlMs <= 0) {
+    failures.push(
+      fail(check, 'QUOTE_TTL_INVALID', 'Quote TTL must be greater than zero.', 'Set a positive quote TTL before signing.'),
+    );
+  }
+  if (now - ctx.quoteQuotedAt > ctx.quoteTtlMs) {
+    failures.push(
+      fail(
+        check,
+        'QUOTE_STALE',
+        'The selected quote has expired and may no longer match executable prices.',
+        'Refresh the quote and lock the route again before signing.',
+      ),
+    );
+  }
+  return { check, passed: failures.length === 0, failures };
+}
+
+export function validateDestinationAccount(
+  ctx: StellarPreExecutionSafetyContext,
+): SafetyCheckResult {
+  const check = 'destination_account' as const;
+  const failures: SafetyCheckFailure[] = [];
+  const account = ctx.destinationAccount?.trim() ?? '';
+  if (!/^[GC][A-Z2-7]{55}$/.test(account)) {
+    failures.push(
+      fail(
+        check,
+        'DESTINATION_INVALID',
+        'Destination account is not a valid Stellar account or contract address.',
+        'Correct the destination address and retry.',
+      ),
+    );
+  }
+  if (!ctx.destinationExists) {
+    failures.push(
+      fail(
+        check,
+        'DESTINATION_MISSING',
+        'Destination account does not exist on the network.',
+        'Create or fund the destination account before signing.',
+      ),
+    );
+  }
+  if (!ctx.destinationFunded) {
+    failures.push(
+      fail(
+        check,
+        'DESTINATION_UNFUNDED',
+        'Destination account is not funded above the reserve.',
+        'Send the minimum XLM reserve to the destination account.',
+      ),
+    );
+  }
+  return { check, passed: failures.length === 0, failures };
+}
+
+export function validateAssetBalance(
+  ctx: StellarPreExecutionSafetyContext,
+): SafetyCheckResult {
+  const check = 'asset_balance' as const;
+  const failures: SafetyCheckFailure[] = [];
+  const required = ctx.transferAmount + ctx.estimatedNetworkFee;
+  if (ctx.availableTransferBalance < ctx.transferAmount) {
+    failures.push(
+      fail(
+        check,
+        'INSUFFICIENT_TRANSFER_BALANCE',
+        `Available ${ctx.transferAsset} balance ${ctx.availableTransferBalance} is below the transfer amount ${ctx.transferAmount}.`,
+        `Top up ${ctx.transferAsset} before signing.`,
+      ),
+    );
+  }
+  if (ctx.availableFeeBalance < ctx.estimatedNetworkFee) {
+    failures.push(
+      fail(
+        check,
+        'INSUFFICIENT_FEE_BALANCE',
+        `Available fee balance ${ctx.availableFeeBalance} is below the estimated network fee ${ctx.estimatedNetworkFee}.`,
+        'Add XLM to cover network fees.',
+      ),
+    );
+  }
+  if (required < 0) {
+    failures.push(
+      fail(check, 'INVALID_AMOUNTS', 'Transfer amount or fee cannot be negative.', 'Correct the quoted amounts.'),
+    );
+  }
+  return { check, passed: failures.length === 0, failures };
+}
+
+export function validateTrustlineRequirements(
+  ctx: StellarPreExecutionSafetyContext,
+): SafetyCheckResult {
+  const check = 'trustline' as const;
+  const failures: SafetyCheckFailure[] = [];
+  const existing = new Set(
+    ctx.existingTrustlines.map((line) => `${line.code}:${line.issuer}`),
+  );
+  for (const required of ctx.requiredTrustlines) {
+    const key = `${required.code}:${required.issuer}`;
+    if (!existing.has(key)) {
+      failures.push(
+        fail(
+          check,
+          'TRUSTLINE_MISSING',
+          `Missing trustline for ${required.code} issued by ${required.issuer}.`,
+          `Establish a trustline for ${required.code} before signing.`,
+        ),
+      );
+    }
+  }
+  return { check, passed: failures.length === 0, failures };
+}
+
+export function validateMinimumOutput(
+  ctx: StellarPreExecutionSafetyContext,
+): SafetyCheckResult {
+  const check = 'minimum_output' as const;
+  const failures: SafetyCheckFailure[] = [];
+  if (ctx.quotedOutput < ctx.minimumOutput) {
+    failures.push(
+      fail(
+        check,
+        'OUTPUT_BELOW_MINIMUM',
+        `Quoted output ${ctx.quotedOutput} is below the minimum accepted output ${ctx.minimumOutput}.`,
+        'Increase slippage tolerance or select a better route.',
+      ),
+    );
+  }
+  return { check, passed: failures.length === 0, failures };
+}
+
+export function validateTransactionResources(
+  ctx: StellarPreExecutionSafetyContext,
+): SafetyCheckResult {
+  const check = 'transaction_resources' as const;
+  const failures: SafetyCheckFailure[] = [];
+  if (ctx.resources.cpuInstructions > ctx.resourceLimits.cpuInstructions) {
+    failures.push(
+      fail(
+        check,
+        'CPU_LIMIT_EXCEEDED',
+        `Simulated CPU instructions ${ctx.resources.cpuInstructions} exceed the limit ${ctx.resourceLimits.cpuInstructions}.`,
+        'Reduce transaction complexity or raise the resource ceiling after review.',
+      ),
+    );
+  }
+  if (ctx.resources.memoryBytes > ctx.resourceLimits.memoryBytes) {
+    failures.push(
+      fail(
+        check,
+        'MEMORY_LIMIT_EXCEEDED',
+        `Simulated memory ${ctx.resources.memoryBytes} exceeds the limit ${ctx.resourceLimits.memoryBytes}.`,
+        'Split the operation or adjust contract resource settings.',
+      ),
+    );
+  }
+  if (ctx.resources.fee > ctx.resourceLimits.fee) {
+    failures.push(
+      fail(
+        check,
+        'FEE_LIMIT_EXCEEDED',
+        `Simulated fee ${ctx.resources.fee} exceeds the limit ${ctx.resourceLimits.fee}.`,
+        'Wait for lower network fees or increase the allowed fee cap.',
+      ),
+    );
+  }
+  return { check, passed: failures.length === 0, failures };
+}
+
+export function validateContractCompatibility(
+  ctx: StellarPreExecutionSafetyContext,
+): SafetyCheckResult {
+  const check = 'contract_compatibility' as const;
+  const failures: SafetyCheckFailure[] = [];
+  if (!ctx.contractCompatible) {
+    const detail = ctx.contractCompatibilityReasons?.join('; ') || 'Contract does not match the BridgeWise interface.';
+    failures.push(
+      fail(
+        check,
+        'CONTRACT_INCOMPATIBLE',
+        detail,
+        'Use a BridgeWise-compatible Soroban contract before signing.',
+      ),
+    );
+  }
+  return { check, passed: failures.length === 0, failures };
+}

--- a/src/execution/validation/types.ts
+++ b/src/execution/validation/types.ts
@@ -1,0 +1,65 @@
+export type SafetyCheckName =
+  | 'quote_freshness'
+  | 'destination_account'
+  | 'asset_balance'
+  | 'trustline'
+  | 'minimum_output'
+  | 'transaction_resources'
+  | 'contract_compatibility';
+
+export type SafetySeverity = 'error' | 'warning';
+
+export interface SafetyCheckFailure {
+  check: SafetyCheckName;
+  code: string;
+  severity: SafetySeverity;
+  reason: string;
+  action: string;
+}
+
+export interface SafetyCheckResult {
+  check: SafetyCheckName;
+  passed: boolean;
+  failures: SafetyCheckFailure[];
+}
+
+export interface StellarPreExecutionSafetyContext {
+  quoteQuotedAt: number;
+  quoteTtlMs: number;
+  destinationAccount: string;
+  destinationExists: boolean;
+  destinationFunded: boolean;
+  transferAsset: string;
+  transferAmount: number;
+  availableTransferBalance: number;
+  estimatedNetworkFee: number;
+  availableFeeBalance: number;
+  requiredTrustlines: Array<{ code: string; issuer: string }>;
+  existingTrustlines: Array<{ code: string; issuer: string }>;
+  quotedOutput: number;
+  minimumOutput: number;
+  resources: {
+    cpuInstructions: number;
+    memoryBytes: number;
+    fee: number;
+  };
+  resourceLimits: {
+    cpuInstructions: number;
+    memoryBytes: number;
+    fee: number;
+  };
+  contractCompatible: boolean;
+  contractCompatibilityReasons?: string[];
+}
+
+export interface StellarPreExecutionSafetyResult {
+  safe: boolean;
+  blocked: boolean;
+  checkedAt: number;
+  checks: SafetyCheckResult[];
+  failures: SafetyCheckFailure[];
+}
+
+export interface SafetyPipelineConfig {
+  now?: () => number;
+}

--- a/src/routing/locks/stellar/index.ts
+++ b/src/routing/locks/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { StellarBridgeRouteLockService } from './stellar-bridge-route-lock';

--- a/src/routing/locks/stellar/stellar-bridge-route-lock.ts
+++ b/src/routing/locks/stellar/stellar-bridge-route-lock.ts
@@ -1,0 +1,167 @@
+import {
+  DEFAULT_ROUTE_LOCK_DURATION_MS,
+  LockedBridgeRoute,
+  RouteLockConfig,
+  RouteLockRecord,
+  RouteLockResult,
+  RouteLockStatus,
+  RouteUpdateGuardResult,
+} from './types';
+
+function fingerprintRoute(route: LockedBridgeRoute): string {
+  return [
+    route.routeId,
+    route.providerId,
+    route.sourceAsset,
+    route.destinationAsset,
+    route.quotedInput,
+    route.quotedOutput,
+  ].join('|');
+}
+
+function createLockId(executionId: string, now: number): string {
+  return `lock-${executionId}-${now.toString(36)}`;
+}
+
+/**
+ * Locks a selected Stellar bridge route to an execution ID so concurrent
+ * quote refreshes cannot silently replace the route the user is about to sign.
+ */
+export class StellarBridgeRouteLockService {
+  private readonly locks = new Map<string, RouteLockRecord>();
+  private readonly durationMs: number;
+  private readonly now: () => number;
+
+  constructor(config: RouteLockConfig = {}) {
+    this.durationMs = config.durationMs ?? DEFAULT_ROUTE_LOCK_DURATION_MS;
+    this.now = config.now ?? (() => Date.now());
+  }
+
+  acquire(executionId: string, route: LockedBridgeRoute, durationMs?: number): RouteLockResult {
+    this.assertExecutionId(executionId);
+    this.assertRoute(route);
+
+    this.purgeIfExpired(executionId);
+
+    const existing = this.locks.get(executionId);
+    if (existing && existing.status === 'active') {
+      if (existing.fingerprint === fingerprintRoute(route)) {
+        return { acquired: true, lock: existing };
+      }
+      return {
+        acquired: false,
+        lock: existing,
+        reason: `Execution ${executionId} already holds a lock on a different route (${existing.route.routeId}).`,
+      };
+    }
+
+    const acquiredAt = this.now();
+    const ttl = durationMs ?? this.durationMs;
+    const lock: RouteLockRecord = {
+      lockId: createLockId(executionId, acquiredAt),
+      executionId,
+      route: { ...route },
+      fingerprint: fingerprintRoute(route),
+      acquiredAt,
+      expiresAt: acquiredAt + ttl,
+      status: 'active',
+    };
+    this.locks.set(executionId, lock);
+    return { acquired: true, lock };
+  }
+
+  getLock(executionId: string): RouteLockRecord | undefined {
+    this.purgeIfExpired(executionId);
+    return this.locks.get(executionId);
+  }
+
+  status(executionId: string): RouteLockStatus {
+    this.purgeIfExpired(executionId);
+    const lock = this.locks.get(executionId);
+    if (!lock) {
+      return 'absent';
+    }
+    return lock.status;
+  }
+
+  /**
+   * Rejects a conflicting route replacement while the lock is active.
+   * Identical routes are allowed (idempotent refresh of the same quote).
+   */
+  guardRouteUpdate(executionId: string, candidate: LockedBridgeRoute): RouteUpdateGuardResult {
+    this.assertExecutionId(executionId);
+    this.assertRoute(candidate);
+    this.purgeIfExpired(executionId);
+
+    const lock = this.locks.get(executionId);
+    if (!lock || lock.status !== 'active') {
+      return { allowed: true };
+    }
+
+    if (lock.fingerprint === fingerprintRoute(candidate)) {
+      return { allowed: true, lock };
+    }
+
+    return {
+      allowed: false,
+      lock,
+      reason:
+        'Locked route cannot be replaced while the lock is active. Release or wait for expiration first.',
+    };
+  }
+
+  release(executionId: string): boolean {
+    this.assertExecutionId(executionId);
+    const lock = this.locks.get(executionId);
+    if (!lock || lock.status === 'released') {
+      return false;
+    }
+    lock.status = 'released';
+    lock.releasedAt = this.now();
+    this.locks.delete(executionId);
+    return true;
+  }
+
+  /** Called when execution finishes (success or failure). */
+  releaseAfterExecution(executionId: string): boolean {
+    return this.release(executionId);
+  }
+
+  sweepExpired(): number {
+    let removed = 0;
+    for (const executionId of [...this.locks.keys()]) {
+      if (this.purgeIfExpired(executionId)) {
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  private purgeIfExpired(executionId: string): boolean {
+    const lock = this.locks.get(executionId);
+    if (!lock || lock.status !== 'active') {
+      return false;
+    }
+    if (this.now() >= lock.expiresAt) {
+      lock.status = 'expired';
+      this.locks.delete(executionId);
+      return true;
+    }
+    return false;
+  }
+
+  private assertExecutionId(executionId: string): void {
+    if (!executionId?.trim()) {
+      throw new Error('executionId is required');
+    }
+  }
+
+  private assertRoute(route: LockedBridgeRoute): void {
+    if (!route?.routeId?.trim()) {
+      throw new Error('route.routeId is required');
+    }
+    if (!route.providerId?.trim()) {
+      throw new Error('route.providerId is required');
+    }
+  }
+}

--- a/src/routing/locks/stellar/types.ts
+++ b/src/routing/locks/stellar/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Types for Stellar bridge route locking during transaction preparation.
+ */
+
+export interface LockedBridgeRoute {
+  routeId: string;
+  providerId: string;
+  sourceAsset: string;
+  destinationAsset: string;
+  quotedInput: string;
+  quotedOutput: string;
+}
+
+export interface RouteLockConfig {
+  /** How long a lock remains valid. Default: 120_000 ms. */
+  durationMs?: number;
+  /** Clock injection for tests. */
+  now?: () => number;
+}
+
+export type RouteLockStatus = 'active' | 'expired' | 'released' | 'absent';
+
+export interface RouteLockRecord {
+  lockId: string;
+  executionId: string;
+  route: LockedBridgeRoute;
+  fingerprint: string;
+  acquiredAt: number;
+  expiresAt: number;
+  releasedAt?: number;
+  status: Exclude<RouteLockStatus, 'absent'>;
+}
+
+export interface RouteLockResult {
+  acquired: boolean;
+  lock?: RouteLockRecord;
+  reason?: string;
+}
+
+export interface RouteUpdateGuardResult {
+  allowed: boolean;
+  reason?: string;
+  lock?: RouteLockRecord;
+}
+
+export const DEFAULT_ROUTE_LOCK_DURATION_MS = 120_000;

--- a/src/soroban/compatibility/index.ts
+++ b/src/soroban/compatibility/index.ts
@@ -1,0 +1,8 @@
+export {
+  SorobanContractCompatibilityChecker,
+} from './soroban-contract-compatibility-checker';
+export type {
+  CompatibilityCheckResult,
+  CompatibilityIssue,
+  CompatibilityIssueSeverity,
+} from './soroban-contract-compatibility-checker';

--- a/src/soroban/compatibility/soroban-contract-compatibility-checker.ts
+++ b/src/soroban/compatibility/soroban-contract-compatibility-checker.ts
@@ -1,0 +1,176 @@
+import {
+  ContractInterfaceMetadata,
+  ContractFunctionSpec,
+} from '../../contracts/metadata/soroban/soroban-metadata.types';
+import {
+  DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES,
+  ExpectedContractCapabilities,
+  ExpectedMethodCapability,
+  normalizeType,
+} from '../../contracts/metadata/bridgewise-interface';
+import { MetadataStatus } from '../../contracts/metadata/soroban/soroban-metadata.types';
+
+export type CompatibilityIssueSeverity = 'error' | 'warning';
+
+export interface CompatibilityIssue {
+  code: string;
+  severity: CompatibilityIssueSeverity;
+  message: string;
+  method?: string;
+}
+
+export interface CompatibilityCheckResult {
+  compatible: boolean;
+  contractAddress: string;
+  issues: CompatibilityIssue[];
+  verifiedMethods: string[];
+  missingMethods: string[];
+}
+
+export class SorobanContractCompatibilityChecker {
+  constructor(
+    private readonly expected: ExpectedContractCapabilities = DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES,
+  ) {}
+
+  check(metadata: ContractInterfaceMetadata | null | undefined): CompatibilityCheckResult {
+    const issues: CompatibilityIssue[] = [];
+    const contractAddress = metadata?.contractAddress ?? '';
+
+    if (!metadata) {
+      return {
+        compatible: false,
+        contractAddress,
+        issues: [
+          {
+            code: 'METADATA_MISSING',
+            severity: 'error',
+            message: 'Contract metadata is missing; cannot verify BridgeWise compatibility.',
+          },
+        ],
+        verifiedMethods: [],
+        missingMethods: this.expected.methods.map((m) => m.name),
+      };
+    }
+
+    this.validateMetadata(metadata, issues);
+
+    const functionsByName = new Map<string, ContractFunctionSpec>();
+    for (const fn of metadata.functions ?? []) {
+      functionsByName.set(fn.name, fn);
+    }
+
+    const verifiedMethods: string[] = [];
+    const missingMethods: string[] = [];
+
+    for (const method of this.expected.methods) {
+      const found = functionsByName.get(method.name);
+      if (!found) {
+        missingMethods.push(method.name);
+        issues.push({
+          code: 'MISSING_METHOD',
+          severity: 'error',
+          method: method.name,
+          message: `Required method "${method.name}" is not present on the contract.`,
+        });
+        continue;
+      }
+      this.verifyArguments(method, found, issues);
+      verifiedMethods.push(method.name);
+    }
+
+    const compatible = !issues.some((issue) => issue.severity === 'error');
+    return {
+      compatible,
+      contractAddress,
+      issues,
+      verifiedMethods,
+      missingMethods,
+    };
+  }
+
+  private validateMetadata(
+    metadata: ContractInterfaceMetadata,
+    issues: CompatibilityIssue[],
+  ): void {
+    if (!metadata.contractAddress?.trim()) {
+      issues.push({
+        code: 'INVALID_METADATA',
+        severity: 'error',
+        message: 'Contract metadata is missing a contractAddress.',
+      });
+    }
+    if (!metadata.network) {
+      issues.push({
+        code: 'INVALID_METADATA',
+        severity: 'error',
+        message: 'Contract metadata is missing a network.',
+      });
+    }
+    if (!Array.isArray(metadata.functions)) {
+      issues.push({
+        code: 'INVALID_METADATA',
+        severity: 'error',
+        message: 'Contract metadata does not include a functions list.',
+      });
+    }
+    if (
+      metadata.status &&
+      metadata.status !== MetadataStatus.RESOLVED &&
+      metadata.status !== MetadataStatus.STALE
+    ) {
+      issues.push({
+        code: 'METADATA_NOT_READY',
+        severity: 'error',
+        message: `Contract metadata status "${metadata.status}" is not usable for compatibility checks.`,
+      });
+    }
+    if (
+      this.expected.specVersionPrefix &&
+      metadata.specVersion &&
+      !metadata.specVersion.startsWith(this.expected.specVersionPrefix)
+    ) {
+      issues.push({
+        code: 'SPEC_VERSION_MISMATCH',
+        severity: 'warning',
+        message: `Spec version "${metadata.specVersion}" does not start with expected prefix "${this.expected.specVersionPrefix}".`,
+      });
+    }
+  }
+
+  private verifyArguments(
+    expected: ExpectedMethodCapability,
+    actual: ContractFunctionSpec,
+    issues: CompatibilityIssue[],
+  ): void {
+    const actualParams = actual.parameters ?? [];
+    if (actualParams.length !== expected.arguments.length) {
+      issues.push({
+        code: 'ARGUMENT_COUNT_MISMATCH',
+        severity: 'error',
+        method: expected.name,
+        message: `Method "${expected.name}" expects ${expected.arguments.length} argument(s) but found ${actualParams.length}.`,
+      });
+      return;
+    }
+
+    expected.arguments.forEach((arg, index) => {
+      const actualArg = actualParams[index];
+      if (actualArg.name !== arg.name) {
+        issues.push({
+          code: 'ARGUMENT_NAME_MISMATCH',
+          severity: 'error',
+          method: expected.name,
+          message: `Method "${expected.name}" argument ${index} expected name "${arg.name}" but found "${actualArg.name}".`,
+        });
+      }
+      if (normalizeType(actualArg.type) !== normalizeType(arg.type)) {
+        issues.push({
+          code: 'ARGUMENT_TYPE_MISMATCH',
+          severity: 'error',
+          method: expected.name,
+          message: `Method "${expected.name}" argument "${arg.name}" expected type "${arg.type}" but found "${actualArg.type}".`,
+        });
+      }
+    });
+  }
+}

--- a/src/soroban/simulation/diff/index.ts
+++ b/src/soroban/simulation/diff/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { SorobanSimulationDiffService } from './soroban-simulation-diff';

--- a/src/soroban/simulation/diff/soroban-simulation-diff.ts
+++ b/src/soroban/simulation/diff/soroban-simulation-diff.ts
@@ -1,0 +1,168 @@
+import {
+  ComparableSimulationSnapshot,
+  DEFAULT_MATERIAL_THRESHOLDS,
+  MaterialDifferenceThresholds,
+  NumericChange,
+  SimulationDiffResult,
+  SimulationEvent,
+} from './types';
+
+function toNumber(value: string | number | undefined): number | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function eventKey(event: SimulationEvent): string {
+  return JSON.stringify({
+    type: event.type,
+    topics: event.topics ?? [],
+    data: event.data ?? null,
+  });
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Compares two Soroban simulation snapshots and reports resource, output,
+ * and event differences, including which changes are material.
+ */
+export class SorobanSimulationDiffService {
+  constructor(
+    private readonly thresholds: MaterialDifferenceThresholds = DEFAULT_MATERIAL_THRESHOLDS,
+  ) {}
+
+  diff(
+    before: ComparableSimulationSnapshot,
+    after: ComparableSimulationSnapshot,
+  ): SimulationDiffResult {
+    const limits = { ...DEFAULT_MATERIAL_THRESHOLDS, ...this.thresholds };
+    const resourceChanges = this.diffResources(before, after, limits);
+    const outputBefore = before.expectedOutput ?? (before as { result?: unknown }).result;
+    const outputAfter = after.expectedOutput ?? (after as { result?: unknown }).result;
+    const outputChanged = stableSerialize(outputBefore) !== stableSerialize(outputAfter);
+    const eventChanges = this.diffEvents(before.events ?? [], after.events ?? []);
+
+    const hasMaterialDifferences =
+      resourceChanges.some((change) => change.material) || outputChanged || eventChanges.added.length > 0 || eventChanges.removed.length > 0;
+
+    const summary: string[] = [];
+    for (const change of resourceChanges.filter((c) => c.material)) {
+      summary.push(
+        `${change.field} changed from ${change.before ?? 'n/a'} to ${change.after ?? 'n/a'} (delta ${change.delta ?? 'n/a'}).`,
+      );
+    }
+    if (outputChanged) {
+      summary.push('Expected simulation output changed.');
+    }
+    if (eventChanges.added.length > 0 || eventChanges.removed.length > 0) {
+      summary.push(
+        `Simulation events changed (${eventChanges.added.length} added, ${eventChanges.removed.length} removed).`,
+      );
+    }
+
+    return {
+      hasChanges: resourceChanges.length > 0 || outputChanged || eventChanges.added.length > 0 || eventChanges.removed.length > 0,
+      hasMaterialDifferences,
+      resourceChanges,
+      outputChanged,
+      outputBefore,
+      outputAfter,
+      eventChanges,
+      summary,
+    };
+  }
+
+  private diffResources(
+    before: ComparableSimulationSnapshot,
+    after: ComparableSimulationSnapshot,
+    limits: Required<MaterialDifferenceThresholds>,
+  ): NumericChange[] {
+    const fields: Array<{
+      field: keyof Required<MaterialDifferenceThresholds>;
+      before: string | number | undefined;
+      after: string | number | undefined;
+    }> = [
+      {
+        field: 'cpuInstructions',
+        before: before.resourceEstimates.cpuInstructions,
+        after: after.resourceEstimates.cpuInstructions,
+      },
+      {
+        field: 'memoryBytes',
+        before: before.resourceEstimates.memoryBytes,
+        after: after.resourceEstimates.memoryBytes,
+      },
+      {
+        field: 'ledgerReadBytes',
+        before: before.resourceEstimates.ledgerReadBytes,
+        after: after.resourceEstimates.ledgerReadBytes,
+      },
+      {
+        field: 'ledgerWriteBytes',
+        before: before.resourceEstimates.ledgerWriteBytes,
+        after: after.resourceEstimates.ledgerWriteBytes,
+      },
+      {
+        field: 'fee',
+        before: before.resourceEstimates.fee,
+        after: after.resourceEstimates.fee,
+      },
+    ];
+
+    const changes: NumericChange[] = [];
+    for (const item of fields) {
+      const beforeValue = toNumber(item.before);
+      const afterValue = toNumber(item.after);
+      if (beforeValue === afterValue) {
+        continue;
+      }
+      const delta =
+        beforeValue === null || afterValue === null ? null : afterValue - beforeValue;
+      const material =
+        delta === null ? true : Math.abs(delta) >= limits[item.field];
+      changes.push({
+        field: item.field,
+        before: beforeValue,
+        after: afterValue,
+        delta,
+        material,
+      });
+    }
+    return changes;
+  }
+
+  private diffEvents(before: SimulationEvent[], after: SimulationEvent[]) {
+    const beforeKeys = new Map(before.map((event) => [eventKey(event), event]));
+    const afterKeys = new Map(after.map((event) => [eventKey(event), event]));
+    const added: SimulationEvent[] = [];
+    const removed: SimulationEvent[] = [];
+    let unchangedCount = 0;
+
+    for (const [key, event] of afterKeys) {
+      if (beforeKeys.has(key)) {
+        unchangedCount += 1;
+      } else {
+        added.push(event);
+      }
+    }
+    for (const [key, event] of beforeKeys) {
+      if (!afterKeys.has(key)) {
+        removed.push(event);
+      }
+    }
+
+    return { added, removed, unchangedCount };
+  }
+}

--- a/src/soroban/simulation/diff/types.ts
+++ b/src/soroban/simulation/diff/types.ts
@@ -1,0 +1,59 @@
+import { SorobanSimulationResult } from '../soroban-simulation.adapter';
+
+export interface SimulationEvent {
+  type: string;
+  topics?: string[];
+  data?: unknown;
+}
+
+export interface ComparableSimulationSnapshot {
+  resourceEstimates: SorobanSimulationResult['resourceEstimates'] & {
+    cpuInstructions?: number;
+    memoryBytes?: number;
+    ledgerReadBytes?: number;
+    ledgerWriteBytes?: number;
+    fee?: string | number;
+  };
+  expectedOutput?: unknown;
+  events?: SimulationEvent[];
+  success?: boolean;
+}
+
+export interface MaterialDifferenceThresholds {
+  cpuInstructions?: number;
+  memoryBytes?: number;
+  ledgerReadBytes?: number;
+  ledgerWriteBytes?: number;
+  fee?: number;
+}
+
+export const DEFAULT_MATERIAL_THRESHOLDS: Required<MaterialDifferenceThresholds> = {
+  cpuInstructions: 1,
+  memoryBytes: 1,
+  ledgerReadBytes: 1,
+  ledgerWriteBytes: 1,
+  fee: 1,
+};
+
+export interface NumericChange {
+  field: string;
+  before: number | null;
+  after: number | null;
+  delta: number | null;
+  material: boolean;
+}
+
+export interface SimulationDiffResult {
+  hasChanges: boolean;
+  hasMaterialDifferences: boolean;
+  resourceChanges: NumericChange[];
+  outputChanged: boolean;
+  outputBefore: unknown;
+  outputAfter: unknown;
+  eventChanges: {
+    added: SimulationEvent[];
+    removed: SimulationEvent[];
+    unchangedCount: number;
+  };
+  summary: string[];
+}

--- a/src/soroban/simulation/index.ts
+++ b/src/soroban/simulation/index.ts
@@ -1,1 +1,2 @@
 export * from './soroban-simulation.adapter';
+export * from './diff';

--- a/tests/execution/safety/stellar-pre-execution-safety-pipeline.spec.ts
+++ b/tests/execution/safety/stellar-pre-execution-safety-pipeline.spec.ts
@@ -1,0 +1,82 @@
+import { StellarPreExecutionSafetyPipeline } from '../../../src/execution/safety/stellar';
+import type { StellarPreExecutionSafetyContext } from '../../../src/execution/validation';
+
+function validContext(
+  overrides: Partial<StellarPreExecutionSafetyContext> = {},
+): StellarPreExecutionSafetyContext {
+  return {
+    quoteQuotedAt: 1_000,
+    quoteTtlMs: 5_000,
+    destinationAccount: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    destinationExists: true,
+    destinationFunded: true,
+    transferAsset: 'USDC',
+    transferAmount: 100,
+    availableTransferBalance: 150,
+    estimatedNetworkFee: 1,
+    availableFeeBalance: 10,
+    requiredTrustlines: [{ code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' }],
+    existingTrustlines: [{ code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' }],
+    quotedOutput: 98,
+    minimumOutput: 95,
+    resources: { cpuInstructions: 100, memoryBytes: 50, fee: 20 },
+    resourceLimits: { cpuInstructions: 1000, memoryBytes: 500, fee: 100 },
+    contractCompatible: true,
+    ...overrides,
+  };
+}
+
+describe('StellarPreExecutionSafetyPipeline (#999)', () => {
+  const pipeline = new StellarPreExecutionSafetyPipeline({ now: () => 2_000 });
+
+  it('passes when every check succeeds', () => {
+    const result = pipeline.run(validContext());
+    expect(result.safe).toBe(true);
+    expect(result.blocked).toBe(false);
+    expect(result.checks).toHaveLength(7);
+    expect(result.failures).toEqual([]);
+  });
+
+  it('blocks stale quotes with an actionable reason', () => {
+    const result = pipeline.run(validContext({ quoteQuotedAt: 0, quoteTtlMs: 500 }));
+    expect(result.blocked).toBe(true);
+    expect(result.failures.some((f) => f.code === 'QUOTE_STALE')).toBe(true);
+    expect(result.failures.find((f) => f.code === 'QUOTE_STALE')?.action).toMatch(/Refresh the quote/);
+  });
+
+  it('blocks missing trustlines, low output, and incompatible contracts', () => {
+    const result = pipeline.run(
+      validContext({
+        existingTrustlines: [],
+        quotedOutput: 10,
+        minimumOutput: 95,
+        contractCompatible: false,
+        contractCompatibilityReasons: ['missing bridge()'],
+      }),
+    );
+    expect(result.safe).toBe(false);
+    expect(result.failures.map((f) => f.code)).toEqual(
+      expect.arrayContaining(['TRUSTLINE_MISSING', 'OUTPUT_BELOW_MINIMUM', 'CONTRACT_INCOMPATIBLE']),
+    );
+  });
+
+  it('blocks insufficient balances and resource overruns', () => {
+    const result = pipeline.run(
+      validContext({
+        availableTransferBalance: 1,
+        availableFeeBalance: 0,
+        resources: { cpuInstructions: 9_000, memoryBytes: 9_000, fee: 9_000 },
+      }),
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.failures.map((f) => f.code)).toEqual(
+      expect.arrayContaining([
+        'INSUFFICIENT_TRANSFER_BALANCE',
+        'INSUFFICIENT_FEE_BALANCE',
+        'CPU_LIMIT_EXCEEDED',
+        'MEMORY_LIMIT_EXCEEDED',
+        'FEE_LIMIT_EXCEEDED',
+      ]),
+    );
+  });
+});

--- a/tests/routing/locks/stellar-bridge-route-lock.spec.ts
+++ b/tests/routing/locks/stellar-bridge-route-lock.spec.ts
@@ -1,0 +1,77 @@
+import { StellarBridgeRouteLockService } from '../../../src/routing/locks/stellar';
+import type { LockedBridgeRoute } from '../../../src/routing/locks/stellar';
+
+const routeA: LockedBridgeRoute = {
+  routeId: 'route-a',
+  providerId: 'stellar-bridge',
+  sourceAsset: 'USDC',
+  destinationAsset: 'EURC',
+  quotedInput: '100',
+  quotedOutput: '98.5',
+};
+
+const routeB: LockedBridgeRoute = {
+  ...routeA,
+  routeId: 'route-b',
+  quotedOutput: '97.0',
+};
+
+describe('StellarBridgeRouteLockService (#997)', () => {
+  it('associates a lock with an execution ID', () => {
+    const service = new StellarBridgeRouteLockService({ now: () => 1_000 });
+    const result = service.acquire('exec-1', routeA, 5_000);
+    expect(result.acquired).toBe(true);
+    expect(result.lock?.executionId).toBe('exec-1');
+    expect(service.getLock('exec-1')?.route.routeId).toBe('route-a');
+  });
+
+  it('uses a configurable lock duration', () => {
+    let now = 0;
+    const service = new StellarBridgeRouteLockService({
+      durationMs: 100,
+      now: () => now,
+    });
+    service.acquire('exec-1', routeA);
+    expect(service.status('exec-1')).toBe('active');
+    now = 99;
+    expect(service.status('exec-1')).toBe('active');
+    now = 100;
+    expect(service.status('exec-1')).toBe('absent');
+    expect(service.getLock('exec-1')).toBeUndefined();
+  });
+
+  it('prevents a conflicting route update while locked', () => {
+    const service = new StellarBridgeRouteLockService({ now: () => 1 });
+    service.acquire('exec-1', routeA);
+    const guard = service.guardRouteUpdate('exec-1', routeB);
+    expect(guard.allowed).toBe(false);
+    expect(guard.reason).toMatch(/cannot be replaced/i);
+    expect(service.acquire('exec-1', routeB).acquired).toBe(false);
+  });
+
+  it('allows the same locked route to be re-acquired', () => {
+    const service = new StellarBridgeRouteLockService({ now: () => 1 });
+    expect(service.acquire('exec-1', routeA).acquired).toBe(true);
+    expect(service.acquire('exec-1', routeA).acquired).toBe(true);
+    expect(service.guardRouteUpdate('exec-1', routeA).allowed).toBe(true);
+  });
+
+  it('releases the lock after execution', () => {
+    const service = new StellarBridgeRouteLockService({ now: () => 1 });
+    service.acquire('exec-1', routeA);
+    expect(service.releaseAfterExecution('exec-1')).toBe(true);
+    expect(service.status('exec-1')).toBe('absent');
+    expect(service.guardRouteUpdate('exec-1', routeB).allowed).toBe(true);
+  });
+
+  it('sweeps expired locks', () => {
+    let now = 0;
+    const service = new StellarBridgeRouteLockService({
+      durationMs: 10,
+      now: () => now,
+    });
+    service.acquire('exec-1', routeA);
+    now = 11;
+    expect(service.sweepExpired()).toBe(1);
+  });
+});

--- a/tests/soroban/compatibility/soroban-contract-compatibility-checker.spec.ts
+++ b/tests/soroban/compatibility/soroban-contract-compatibility-checker.spec.ts
@@ -1,0 +1,83 @@
+import {
+  MetadataNetwork,
+  MetadataStatus,
+  ContractInterfaceMetadata,
+} from '../../../src/contracts/metadata/soroban';
+import { DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES } from '../../../src/contracts/metadata';
+import { SorobanContractCompatibilityChecker } from '../../../src/soroban/compatibility';
+
+function compatibleMetadata(
+  overrides: Partial<ContractInterfaceMetadata> = {},
+): ContractInterfaceMetadata {
+  return {
+    contractAddress: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M',
+    network: MetadataNetwork.TESTNET,
+    specVersion: '1.0',
+    resolvedAt: Date.now(),
+    status: MetadataStatus.RESOLVED,
+    functions: DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES.methods.map((method) => ({
+      name: method.name,
+      parameters: method.arguments.map((arg) => ({ name: arg.name, type: arg.type })),
+      returnType: method.returnType,
+    })),
+    events: [],
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe('SorobanContractCompatibilityChecker (#998)', () => {
+  const checker = new SorobanContractCompatibilityChecker();
+
+  it('accepts a contract that matches expected capabilities', () => {
+    const result = checker.check(compatibleMetadata());
+    expect(result.compatible).toBe(true);
+    expect(result.missingMethods).toEqual([]);
+    expect(result.verifiedMethods).toEqual(['bridge', 'quote', 'cancel']);
+  });
+
+  it('rejects a contract missing required methods', () => {
+    const result = checker.check(
+      compatibleMetadata({
+        functions: [
+          {
+            name: 'bridge',
+            parameters: DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES.methods[0].arguments,
+          },
+        ],
+      }),
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.missingMethods).toEqual(['quote', 'cancel']);
+    expect(result.issues.some((issue) => issue.code === 'MISSING_METHOD')).toBe(true);
+  });
+
+  it('rejects argument mismatches', () => {
+    const result = checker.check(
+      compatibleMetadata({
+        functions: [
+          {
+            name: 'bridge',
+            parameters: [{ name: 'amount', type: 'u32' }],
+          },
+          {
+            name: 'quote',
+            parameters: DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES.methods[1].arguments,
+          },
+          {
+            name: 'cancel',
+            parameters: DEFAULT_BRIDGEWISE_SOROBAN_CAPABILITIES.methods[2].arguments,
+          },
+        ],
+      }),
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.issues.some((issue) => issue.code === 'ARGUMENT_COUNT_MISMATCH')).toBe(true);
+  });
+
+  it('rejects missing metadata', () => {
+    const result = checker.check(null);
+    expect(result.compatible).toBe(false);
+    expect(result.issues[0].code).toBe('METADATA_MISSING');
+  });
+});

--- a/tests/soroban/simulation/soroban-simulation-diff.spec.ts
+++ b/tests/soroban/simulation/soroban-simulation-diff.spec.ts
@@ -1,0 +1,68 @@
+import { SorobanSimulationDiffService } from '../../../src/soroban/simulation/diff';
+import type { ComparableSimulationSnapshot } from '../../../src/soroban/simulation/diff';
+
+function snapshot(
+  overrides: Partial<ComparableSimulationSnapshot> = {},
+): ComparableSimulationSnapshot {
+  return {
+    resourceEstimates: {
+      cpuInstructions: 1000,
+      memoryBytes: 200,
+      ledgerReadBytes: 50,
+      ledgerWriteBytes: 10,
+      fee: '100',
+    },
+    expectedOutput: { amount: '98' },
+    events: [{ type: 'transfer', topics: ['bridge'], data: { ok: true } }],
+    success: true,
+    ...overrides,
+  };
+}
+
+describe('SorobanSimulationDiffService (#996)', () => {
+  const service = new SorobanSimulationDiffService();
+
+  it('detects resource estimate changes', () => {
+    const result = service.diff(
+      snapshot(),
+      snapshot({
+        resourceEstimates: {
+          cpuInstructions: 1500,
+          memoryBytes: 200,
+          ledgerReadBytes: 50,
+          ledgerWriteBytes: 10,
+          fee: '100',
+        },
+      }),
+    );
+    expect(result.resourceChanges.some((c) => c.field === 'cpuInstructions' && c.material)).toBe(
+      true,
+    );
+    expect(result.hasMaterialDifferences).toBe(true);
+  });
+
+  it('detects expected output changes', () => {
+    const result = service.diff(snapshot(), snapshot({ expectedOutput: { amount: '90' } }));
+    expect(result.outputChanged).toBe(true);
+    expect(result.summary).toContain('Expected simulation output changed.');
+  });
+
+  it('reports material event differences', () => {
+    const result = service.diff(
+      snapshot(),
+      snapshot({
+        events: [{ type: 'refund', topics: ['bridge'], data: { ok: false } }],
+      }),
+    );
+    expect(result.eventChanges.added).toHaveLength(1);
+    expect(result.eventChanges.removed).toHaveLength(1);
+    expect(result.hasMaterialDifferences).toBe(true);
+  });
+
+  it('returns no material differences for identical snapshots', () => {
+    const result = service.diff(snapshot(), snapshot());
+    expect(result.hasChanges).toBe(false);
+    expect(result.hasMaterialDifferences).toBe(false);
+    expect(result.summary).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR ships four related Stellar/Soroban pre-execution guards as one change set. Together they pin the route the user selected, confirm the on-chain contract matches BridgeWise’s expected interface, surface material simulation drift when a tx or route changes, and block signing unless a full safety pipeline passes.

---

## Why

During preparation, quotes can refresh and routes can be recalculated. Without a lock, the user can sign a different path than the one they picked. Independently, Soroban deployments can drift in methods or arguments, simulation results can change after parameter tweaks, and several safety checks currently live as separate concerns that are easy to skip before signing.

---

## #997 — Stellar bridge route lock

**Problem:** Concurrent quote refreshes or route recalculations can cause the user to sign a different route from the one originally selected.

**Solution:** `StellarBridgeRouteLockService` (`src/routing/locks/stellar/`) associates a lock with an **execution ID**.

### Behavior
- **Acquire** a lock for `executionId` + selected route (provider, assets, quoted in/out).
- **Configurable duration** (default 120s); clock is injectable for tests.
- Route identity is a fingerprint of route id, provider, assets, and quoted amounts.
- While active, a **different** route is rejected (`guardRouteUpdate` / re-acquire). The **same** route can be re-acquired (idempotent).
- **Release** after execution (`releaseAfterExecution`) or when the TTL expires (`sweepExpired` / lazy purge on read).
- Execution-layer re-export: `src/execution/route-lock.ts`.

### Acceptance
- [x] Route locking implemented
- [x] Locked routes cannot be replaced unexpectedly
- [x] Lock expiration supported
- [x] Locks released after execution

**Tests:** `tests/routing/locks/stellar-bridge-route-lock.spec.ts`

---

## #998 — Soroban contract compatibility checker

**Problem:** Contract deployments can differ in methods, arguments, or supported behavior versus the BridgeWise interface.

**Solution:** Expected capabilities live in `src/contracts/metadata/bridgewise-interface.ts`. `SorobanContractCompatibilityChecker` (`src/soroban/compatibility/`) compares resolved `ContractInterfaceMetadata` against that spec.

### Expected interface (defaults)
- `bridge(source_chain, target_chain, amount, recipient)`
- `quote(source_chain, target_chain, amount)`
- `cancel(operation_id)`
- Metadata must include address, network, and a functions list; unusable metadata status is rejected.

### Result shape
Returns `compatible`, `issues[]` (codes such as `MISSING_METHOD`, `ARGUMENT_COUNT_MISMATCH`, `ARGUMENT_NAME_MISMATCH`, `ARGUMENT_TYPE_MISMATCH`, `METADATA_MISSING`), plus `verifiedMethods` / `missingMethods`. Incompatible contracts are rejected (`compatible: false`).

### Acceptance
- [x] Compatibility checker implemented
- [x] Required methods verified
- [x] Incompatible contracts rejected
- [x] Compatibility results exposed

**Tests:** `tests/soroban/compatibility/soroban-contract-compatibility-checker.spec.ts`

---

## #996 — Soroban transaction simulation diff

**Problem:** Changes to transaction parameters can significantly alter resource usage or expected outcomes, and those shifts are hard to see without a structured before/after.

**Solution:** `SorobanSimulationDiffService` (`src/soroban/simulation/diff/`) compares two simulation snapshots.

### Compared
- **Resources:** CPU instructions, memory, ledger read/write bytes, fee (numeric delta; material if `|delta|` ≥ threshold)
- **Expected output:** stable JSON serialization
- **Events:** added / removed / unchanged by type, topics, and data

Configurable `MaterialDifferenceThresholds` (default: any change of 1+ is material). Result includes `hasChanges`, `hasMaterialDifferences`, `resourceChanges`, `outputChanged`, `eventChanges`, and a human-readable `summary`.

Re-exported from `src/soroban/simulation`.

### Acceptance
- [x] Simulation diff service implemented
- [x] Resource changes detected
- [x] Output changes detected
- [x] Material differences reported

**Tests:** `tests/soroban/simulation/soroban-simulation-diff.spec.ts`

---

## #999 — Stellar bridge pre-execution safety pipeline

**Problem:** Multiple independent checks need to be coordinated before the user signs.

**Solution:** `StellarPreExecutionSafetyPipeline` (`src/execution/safety/stellar/`) always runs the full set of validators in `src/execution/validation/`. Any error **blocks** signing. Failures include `code`, `reason`, and an **actionable** `action` string.

### Checks (all executed)
| Check | What it validates |
| --- | --- |
| Quote freshness | Quoted-at + TTL vs now; stale quotes must be refreshed |
| Destination account | G/C StrKey shape, exists, funded |
| Asset balance | Transfer amount and fee vs available balances |
| Trustlines | Required destination assets have trustlines |
| Minimum output | Quoted output ≥ min accepted |
| Transaction resources | Simulated CPU / memory / fee vs limits |
| Contract compatibility | BridgeWise-compatible contract (feeds #998) |

Consolidated result: `safe`, `blocked`, `checkedAt`, per-check results, and a flat `failures` list.

### Acceptance
- [x] Pre-execution safety pipeline implemented
- [x] All required validation checks executed
- [x] Unsafe transactions blocked before signing
- [x] Validation failures include actionable reasons
- [x] Pipeline tests cover success and failure scenarios

**Tests:** `tests/execution/safety/stellar-pre-execution-safety-pipeline.spec.ts`

---

## How these pieces fit

```
select route → lock (#997)
            → simulate & diff if params changed (#996)
            → compatibility check (#998)
            → safety pipeline (#999)
            → sign only if safe && lock still holds the same route
```

The pipeline can consume compatibility output; the lock should still be held through signing so a late quote refresh cannot swap the route.

---

## Test plan

- [ ] Route lock: acquire by execution ID, reject a conflicting route, allow the same route, expire after TTL, release after execution
- [ ] Compatibility: matching metadata passes; missing methods / argument mismatches / missing metadata fail
- [ ] Simulation diff: CPU/resource deltas, output changes, event add/remove, identical snapshots have no material diff
- [ ] Safety pipeline: all-green context is `safe`; stale quote, missing trustline, low output, incompatible contract, insufficient balance, and resource overruns set `blocked` with actionable failures
- [ ] Confirm Nest/API build still uses `apps/api/tsconfig.json` (this PR does not change app wiring; services are standalone and can be composed at the execution layer)

Closes #996
Closes #997
Closes #998
Closes #999