### PR TITLE
feat: add Stellar bridge provider adapter interface

### DIFF
--- a/src/providers/stellar/adapters/index.ts
+++ b/src/providers/stellar/adapters/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Public Stellar provider adapter contract entry point.
+ *
+ * Concrete provider integrations should implement these types while keeping
+ * provider-specific APIs behind the adapter boundary.
+ */
+
+export * from '../interfaces';

--- a/src/providers/stellar/index.ts
+++ b/src/providers/stellar/index.ts
@@ -1,4 +1,8 @@
 export * from './history';
 export * from './score';
 export * from './flags';
+<<<<<<< HEAD
 export * from './settlement';
+=======
+export * from './adapters';
+>>>>>>> c1555ef2 (feat: add Stellar bridge provider adapter interface)

--- a/src/providers/stellar/index.ts
+++ b/src/providers/stellar/index.ts
@@ -1,8 +1,5 @@
 export * from './history';
 export * from './score';
 export * from './flags';
-<<<<<<< HEAD
 export * from './settlement';
-=======
 export * from './adapters';
->>>>>>> c1555ef2 (feat: add Stellar bridge provider adapter interface)

--- a/src/providers/stellar/interfaces/index.ts
+++ b/src/providers/stellar/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './stellar-bridge-provider-adapter.interface';

--- a/src/providers/stellar/interfaces/stellar-bridge-provider-adapter.interface.ts
+++ b/src/providers/stellar/interfaces/stellar-bridge-provider-adapter.interface.ts
@@ -1,0 +1,145 @@
+/**
+ * Stellar bridge provider adapter contract.
+ *
+ * A provider adapter hides each bridge provider's proprietary API behind one
+ * predictable boundary. The routing layer should request quotes/routes,
+ * execute the selected route, and poll execution status through this interface
+ * instead of depending on provider-specific request or response shapes.
+ */
+
+import type { StellarBridgeQuote } from '../../../quotes/types/canonical-quote';
+import type { BridgeRoute } from '../../../services/route-ranker';
+import type { TransactionStatus } from '../../../tracking/stellar/soroban-transaction-status-tracker';
+
+/** Routing-compatible route returned by Stellar provider adapters. */
+export type StellarBridgeRoute = BridgeRoute;
+
+/**
+ * Standard quote/route request accepted by Stellar bridge providers.
+ *
+ * Fields mirror the transfer and route request shapes already used in the
+ * routing layer: source/destination chains, source/destination assets, amount,
+ * participant addresses, and optional slippage tolerance.
+ */
+export interface StellarBridgeQuoteRequest {
+  sourceChain: string;
+  destinationChain: string;
+  sourceAsset: string;
+  destinationAsset: string;
+  amount: string;
+  sender?: string;
+  recipient?: string;
+  slippage?: number;
+}
+
+/** Execution status vocabulary normalized for provider adapters. */
+export type StellarBridgeExecutionStatus =
+  | TransactionStatus
+  | 'cancelled'
+  | 'unknown';
+
+/** Request to execute a route selected by the routing layer. */
+export interface StellarBridgeExecutionRequest {
+  route: StellarBridgeRoute;
+  quote?: StellarBridgeQuote;
+  /** Signed transaction envelope when execution is submit-only. */
+  signedTransaction?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** Result returned after a provider accepts or rejects execution. */
+export interface StellarBridgeExecutionResult {
+  providerId: string;
+  routeId: string;
+  executionId: string;
+  status: StellarBridgeExecutionStatus;
+  transactionHash?: string;
+  submittedAt: number;
+  error?: StellarBridgeProviderError;
+  metadata?: Record<string, unknown>;
+}
+
+/** Request to check the current status of a submitted bridge execution. */
+export interface StellarBridgeStatusRequest {
+  executionId: string;
+  transactionHash?: string;
+}
+
+/** Provider-normalized execution status result. */
+export interface StellarBridgeStatusResult {
+  providerId: string;
+  executionId: string;
+  status: StellarBridgeExecutionStatus;
+  transactionHash?: string;
+  updatedAt: number;
+  error?: StellarBridgeProviderError;
+  metadata?: Record<string, unknown>;
+}
+
+/** Adapter operation associated with a provider failure. */
+export type StellarBridgeProviderOperation =
+  | 'quote'
+  | 'route'
+  | 'execution'
+  | 'status';
+
+/** Standard provider error code vocabulary for routing-layer handling. */
+export type StellarBridgeProviderErrorCode =
+  | 'PROVIDER_UNAVAILABLE'
+  | 'UNSUPPORTED_ROUTE'
+  | 'INVALID_REQUEST'
+  | 'QUOTE_FAILED'
+  | 'ROUTE_FAILED'
+  | 'EXECUTION_FAILED'
+  | 'STATUS_FAILED'
+  | 'TIMEOUT'
+  | 'RATE_LIMITED'
+  | 'UNKNOWN';
+
+/**
+ * Standard provider failure shape.
+ *
+ * Adapters should map proprietary provider errors into this contract so
+ * routing can make consistent retry/fallback decisions without parsing
+ * provider-specific error payloads.
+ */
+export interface StellarBridgeProviderError {
+  providerId: string;
+  operation: StellarBridgeProviderOperation;
+  code: StellarBridgeProviderErrorCode;
+  message: string;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Interface all Stellar bridge provider adapters must satisfy.
+ */
+export interface StellarBridgeProviderAdapter {
+  /** Stable provider identifier, matching registry provider ids. */
+  readonly providerId: string;
+
+  /** Request a normalized quote for a transfer. */
+  getQuote(request: StellarBridgeQuoteRequest): Promise<StellarBridgeQuote>;
+
+  /** Fetch routing-compatible candidate routes for a transfer. */
+  getRoutes(request: StellarBridgeQuoteRequest): Promise<StellarBridgeRoute[]>;
+
+  /** Execute or submit a route selected by the routing layer. */
+  execute(
+    request: StellarBridgeExecutionRequest,
+  ): Promise<StellarBridgeExecutionResult>;
+
+  /** Check the normalized status of a submitted execution. */
+  getStatus(
+    request: StellarBridgeStatusRequest,
+  ): Promise<StellarBridgeStatusResult>;
+
+  /** Normalize a proprietary provider failure into the standard error shape. */
+  normalizeError(
+    error: unknown,
+    operation: StellarBridgeProviderOperation,
+  ): StellarBridgeProviderError;
+}
+
+export type { StellarBridgeQuote } from '../../../quotes/types/canonical-quote';

--- a/src/quotes/types/canonical-quote.ts
+++ b/src/quotes/types/canonical-quote.ts
@@ -1,0 +1,52 @@
+/**
+ * Canonical Stellar bridge quote types.
+ *
+ * Provider adapters normalize proprietary quote responses into this shape
+ * before the routing and quote-comparison layers evaluate them.
+ */
+
+/** Route metadata embedded in a canonical Stellar bridge quote. */
+export interface StellarBridgeQuoteRoute {
+  sourceChain: string;
+  destinationChain: string;
+  sourceAsset: string;
+  destinationAsset: string;
+  hops: number;
+}
+
+/** Fee fields used by quote comparison and routing decisions. */
+export interface StellarBridgeQuoteFees {
+  bridgeFeeBps?: number;
+  bridgeFeeFlatUsdCents?: number;
+  networkFeeUsdCents: number;
+  totalFeeUsdCents: number;
+  feeToken: string;
+}
+
+/** Execution estimates attached to a quote. */
+export interface StellarBridgeQuoteExecution {
+  estimatedTimeSeconds: number;
+  successRate: number;
+}
+
+/** Amount fields normalized as decimal strings to preserve precision. */
+export interface StellarBridgeQuoteOutput {
+  inputAmount: string;
+  outputAmount: string;
+  netOutputAmount: string;
+  minOutputAmount: string;
+}
+
+/** Provider-normalized quote consumed by Stellar routing and comparison. */
+export interface StellarBridgeQuote {
+  id: string;
+  providerId: string;
+  providerName: string;
+  route: StellarBridgeQuoteRoute;
+  fees: StellarBridgeQuoteFees;
+  execution: StellarBridgeQuoteExecution;
+  output: StellarBridgeQuoteOutput;
+  metadata: Record<string, unknown>;
+  quotedAt: number;
+  expiresAt?: number;
+}

--- a/src/quotes/types/index.ts
+++ b/src/quotes/types/index.ts
@@ -1,0 +1,7 @@
+export type {
+  StellarBridgeQuote,
+  StellarBridgeQuoteExecution,
+  StellarBridgeQuoteFees,
+  StellarBridgeQuoteOutput,
+  StellarBridgeQuoteRoute,
+} from './canonical-quote';

--- a/tests/providers/stellar/stellar-bridge-provider-adapter.interface.spec.ts
+++ b/tests/providers/stellar/stellar-bridge-provider-adapter.interface.spec.ts
@@ -1,0 +1,254 @@
+import type {
+  StellarBridgeExecutionRequest,
+  StellarBridgeExecutionResult,
+  StellarBridgeProviderAdapter,
+  StellarBridgeProviderError,
+  StellarBridgeProviderOperation,
+  StellarBridgeQuote,
+  StellarBridgeQuoteRequest,
+  StellarBridgeRoute,
+  StellarBridgeStatusRequest,
+  StellarBridgeStatusResult,
+} from '../../../src/providers/stellar/adapters';
+
+const quoteRequest: StellarBridgeQuoteRequest = {
+  sourceChain: 'stellar',
+  destinationChain: 'ethereum',
+  sourceAsset: 'USDC',
+  destinationAsset: 'USDC',
+  amount: '100',
+  sender: 'G_SOURCE',
+  recipient: '0xRecipient',
+  slippage: 0.5,
+};
+
+const route: StellarBridgeRoute = {
+  id: 'route-1',
+  fromChain: quoteRequest.sourceChain,
+  toChain: quoteRequest.destinationChain,
+  fromToken: quoteRequest.sourceAsset,
+  toToken: quoteRequest.destinationAsset,
+  amount: quoteRequest.amount,
+  fee: {
+    amount: '0.10',
+    token: 'USDC',
+    usdValue: 0.1,
+  },
+  estimatedTime: 1,
+  successRate: 0.98,
+  provider: 'stub-provider',
+  slippage: quoteRequest.slippage,
+  confidence: 0.95,
+};
+
+const quote: StellarBridgeQuote = {
+  id: 'quote-1',
+  providerId: 'stub-provider',
+  providerName: 'Stub Provider',
+  route: {
+    sourceChain: quoteRequest.sourceChain,
+    destinationChain: quoteRequest.destinationChain,
+    sourceAsset: quoteRequest.sourceAsset,
+    destinationAsset: quoteRequest.destinationAsset,
+    hops: 1,
+  },
+  fees: {
+    bridgeFeeBps: 10,
+    bridgeFeeFlatUsdCents: 5,
+    networkFeeUsdCents: 5,
+    totalFeeUsdCents: 10,
+    feeToken: 'USDC',
+  },
+  execution: {
+    estimatedTimeSeconds: 60,
+    successRate: 0.98,
+  },
+  output: {
+    inputAmount: '100',
+    outputAmount: '99.9',
+    netOutputAmount: '99.8',
+    minOutputAmount: '99.3',
+  },
+  metadata: {},
+  quotedAt: 1_700_000_000_000,
+  expiresAt: 1_700_000_060_000,
+};
+
+class StubStellarBridgeProviderAdapter
+  implements StellarBridgeProviderAdapter
+{
+  readonly providerId = 'stub-provider';
+
+  async getQuote(
+    request: StellarBridgeQuoteRequest,
+  ): Promise<StellarBridgeQuote> {
+    return {
+      ...quote,
+      route: {
+        ...quote.route,
+        sourceChain: request.sourceChain,
+        destinationChain: request.destinationChain,
+        sourceAsset: request.sourceAsset,
+        destinationAsset: request.destinationAsset,
+      },
+      output: {
+        ...quote.output,
+        inputAmount: request.amount,
+      },
+    };
+  }
+
+  async getRoutes(
+    request: StellarBridgeQuoteRequest,
+  ): Promise<StellarBridgeRoute[]> {
+    return [
+      {
+        ...route,
+        fromChain: request.sourceChain,
+        toChain: request.destinationChain,
+        fromToken: request.sourceAsset,
+        toToken: request.destinationAsset,
+        amount: request.amount,
+      },
+    ];
+  }
+
+  async execute(
+    request: StellarBridgeExecutionRequest,
+  ): Promise<StellarBridgeExecutionResult> {
+    return {
+      providerId: this.providerId,
+      routeId: request.route.id,
+      executionId: 'execution-1',
+      status: 'submitted',
+      transactionHash: 'tx_hash_1',
+      submittedAt: 1_700_000_001_000,
+      metadata: request.metadata,
+    };
+  }
+
+  async getStatus(
+    request: StellarBridgeStatusRequest,
+  ): Promise<StellarBridgeStatusResult> {
+    return {
+      providerId: this.providerId,
+      executionId: request.executionId,
+      status: 'completed',
+      transactionHash: request.transactionHash,
+      updatedAt: 1_700_000_002_000,
+    };
+  }
+
+  normalizeError(
+    error: unknown,
+    operation: StellarBridgeProviderOperation,
+  ): StellarBridgeProviderError {
+    const message = error instanceof Error ? error.message : String(error);
+    const timedOut = /timeout/i.test(message);
+
+    return {
+      providerId: this.providerId,
+      operation,
+      code: timedOut ? 'TIMEOUT' : 'UNKNOWN',
+      message,
+      retryable: timedOut,
+      details: { source: 'stub' },
+    };
+  }
+}
+
+describe('StellarBridgeProviderAdapter contract', () => {
+  let adapter: StellarBridgeProviderAdapter;
+
+  beforeEach(() => {
+    adapter = new StubStellarBridgeProviderAdapter();
+  });
+
+  it('exposes the complete adapter surface', () => {
+    expect(adapter.providerId).toBe('stub-provider');
+    expect(typeof adapter.getQuote).toBe('function');
+    expect(typeof adapter.getRoutes).toBe('function');
+    expect(typeof adapter.execute).toBe('function');
+    expect(typeof adapter.getStatus).toBe('function');
+    expect(typeof adapter.normalizeError).toBe('function');
+  });
+
+  it('returns a normalized quote from getQuote()', async () => {
+    const result = await adapter.getQuote(quoteRequest);
+
+    expect(result.providerId).toBe(adapter.providerId);
+    expect(result.route).toMatchObject({
+      sourceChain: 'stellar',
+      destinationChain: 'ethereum',
+      sourceAsset: 'USDC',
+      destinationAsset: 'USDC',
+    });
+    expect(result.output.inputAmount).toBe('100');
+    expect(result.fees.totalFeeUsdCents).toBe(10);
+  });
+
+  it('returns routing-compatible routes from getRoutes()', async () => {
+    const [result] = await adapter.getRoutes(quoteRequest);
+
+    expect(result).toMatchObject({
+      id: 'route-1',
+      provider: adapter.providerId,
+      fromChain: 'stellar',
+      toChain: 'ethereum',
+      fromToken: 'USDC',
+      toToken: 'USDC',
+      amount: '100',
+    });
+    expect(result.fee.token).toBe('USDC');
+    expect(result.successRate).toBeGreaterThan(0);
+  });
+
+  it('executes a selected route through the standard execution contract', async () => {
+    const result = await adapter.execute({
+      route,
+      quote,
+      signedTransaction: 'signed-envelope',
+      metadata: { requestId: 'req-1' },
+    });
+
+    expect(result).toMatchObject({
+      providerId: adapter.providerId,
+      routeId: route.id,
+      executionId: 'execution-1',
+      status: 'submitted',
+      transactionHash: 'tx_hash_1',
+    });
+    expect(result.submittedAt).toBeGreaterThan(0);
+  });
+
+  it('checks execution status through the standard status contract', async () => {
+    const result = await adapter.getStatus({
+      executionId: 'execution-1',
+      transactionHash: 'tx_hash_1',
+    });
+
+    expect(result).toMatchObject({
+      providerId: adapter.providerId,
+      executionId: 'execution-1',
+      status: 'completed',
+      transactionHash: 'tx_hash_1',
+    });
+    expect(result.updatedAt).toBeGreaterThan(0);
+  });
+
+  it('normalizes provider-specific failures into the provider error contract', () => {
+    const result = adapter.normalizeError(
+      new Error('provider timeout'),
+      'quote',
+    );
+
+    expect(result).toEqual({
+      providerId: adapter.providerId,
+      operation: 'quote',
+      code: 'TIMEOUT',
+      message: 'provider timeout',
+      retryable: true,
+      details: { source: 'stub' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

  Adds a provider-agnostic adapter contract for Stellar bridge integrations.

  - Introduces normalized quote, route, execution, status, and error types.
  - Defines the `StellarBridgeProviderAdapter` interface for bridge providers.
  - Adds public exports for the Stellar adapter and quote type modules.
  - Adds contract tests using a stub provider implementation.

  ## Testing

  - Added adapter contract test coverage for quotes, routes, execution, status checks, and error
  normalization.

  ## Notes

  - This establishes the integration boundary only; no concrete external bridge provider is implemented
  in this change.
