### PR TITLE
Soroban contract integration health checks and Stellar provider dependency graph

### DIFF
--- a/src/contracts/health/soroban/index.ts
+++ b/src/contracts/health/soroban/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './soroban-contract-health';

--- a/src/contracts/health/soroban/soroban-contract-health.ts
+++ b/src/contracts/health/soroban/soroban-contract-health.ts
@@ -1,0 +1,242 @@
+import type {
+  ContractHealthCheck,
+  ContractHealthResult,
+  ContractHealthStatus,
+  HealthCheckOptions,
+  SorobanContractConfig,
+  SorobanContractProbe,
+} from './types';
+
+export const DEFAULT_TIMEOUT_MS = 5_000;
+
+/**
+ * Reject if `promise` has not settled within `timeoutMs`.
+ *
+ * A probe that hangs is a failure mode in its own right — an integration that
+ * never answers is not healthy, and without a bound the whole health check
+ * would hang with it.
+ */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * A readable message for anything that can be thrown.
+ *
+ * `String(error)` on a plain object yields `[object Object]`, which tells an
+ * operator reading a health report nothing at all.
+ */
+export function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+
+  try {
+    return JSON.stringify(error) ?? 'Unknown error';
+  } catch {
+    return 'Unknown error';
+  }
+}
+
+/**
+ * Health-check one Soroban contract integration (#1067).
+ *
+ * Four checks, run in order, because each one is only meaningful if the
+ * previous passed:
+ *
+ * 1. **Availability** — does the contract exist? Nothing else can be
+ *    interpreted if it does not, so the remaining checks are skipped rather
+ *    than reported as failures they cannot fairly be blamed for.
+ * 2. **Network** — did the *expected* network answer? A contract that responds
+ *    from the wrong network is worse than one that does not respond at all:
+ *    the integration looks healthy while reading someone else's state.
+ * 3. **Interface** — are the methods the integration calls actually there?
+ * 4. **Read** — do safe reads succeed, and return something sensible?
+ *
+ * Severity is graded rather than binary. A missing method or a wrong network
+ * is `unhealthy` — the integration cannot work. A failing read on an
+ * otherwise correct contract is `degraded` — the wiring is right and the
+ * fault may be transient.
+ */
+export async function checkSorobanContractHealth(
+  config: SorobanContractConfig,
+  probe: SorobanContractProbe,
+  options: HealthCheckOptions = {},
+): Promise<ContractHealthResult> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, now = Date.now } = options;
+
+  const startedAt = now();
+  const checks: ContractHealthCheck[] = [];
+  const missingMethods: string[] = [];
+
+  const timed = async (
+    name: ContractHealthCheck['name'],
+    run: () => Promise<{ ok: boolean; message: string }>,
+  ): Promise<boolean> => {
+    const from = now();
+
+    try {
+      const outcome = await run();
+
+      checks.push({ name, ...outcome, durationMs: now() - from });
+
+      return outcome.ok;
+    } catch (error) {
+      checks.push({
+        name,
+        ok: false,
+        message: messageOf(error),
+        durationMs: now() - from,
+      });
+
+      return false;
+    }
+  };
+
+  const skip = (name: ContractHealthCheck['name'], message: string) => {
+    checks.push({ name, ok: false, message, durationMs: 0, skipped: true });
+  };
+
+  // ── 1. Availability ────────────────────────────────────────────────────
+  let reportedNetwork: string | undefined;
+
+  const available = await timed('availability', async () => {
+    const info = await withTimeout(
+      probe.getContractInfo(config.id),
+      timeoutMs,
+      'availability check',
+    );
+
+    reportedNetwork = info.network;
+
+    return info.exists
+      ? { ok: true, message: `Contract ${config.id} is present` }
+      : { ok: false, message: `Contract ${config.id} was not found` };
+  });
+
+  if (!available) {
+    // Everything below asks a question about a contract that is not there.
+    skip('network', 'Skipped: contract unavailable');
+    skip('interface', 'Skipped: contract unavailable');
+    skip('read', 'Skipped: contract unavailable');
+
+    return {
+      contractId: config.id,
+      name: config.name,
+      network: config.network,
+      status: 'unhealthy',
+      checks,
+      missingMethods: [...config.expectedMethods],
+      checkedAt: startedAt,
+      totalDurationMs: now() - startedAt,
+    };
+  }
+
+  // ── 2. Network ─────────────────────────────────────────────────────────
+  const networkOk = await timed('network', async () => {
+    if (!reportedNetwork) {
+      return {
+        ok: true,
+        message: 'Probe did not report a network; assuming configured network',
+      };
+    }
+
+    return reportedNetwork === config.network
+      ? { ok: true, message: `Answered on ${reportedNetwork}` }
+      : {
+          ok: false,
+          message: `Configured for ${config.network} but answered on ${reportedNetwork}`,
+        };
+  });
+
+  // ── 3. Interface ───────────────────────────────────────────────────────
+  const interfaceOk = await timed('interface', async () => {
+    const methods = await withTimeout(
+      probe.listMethods(config.id),
+      timeoutMs,
+      'interface check',
+    );
+    const present = new Set(methods);
+
+    for (const expected of config.expectedMethods) {
+      if (!present.has(expected)) missingMethods.push(expected);
+    }
+
+    return missingMethods.length === 0
+      ? {
+          ok: true,
+          message: `All ${config.expectedMethods.length} expected method(s) present`,
+        }
+      : {
+          ok: false,
+          message: `Missing method(s): ${missingMethods.join(', ')}`,
+        };
+  });
+
+  // ── 4. Reads ───────────────────────────────────────────────────────────
+  const probes = config.readProbes ?? [];
+
+  const readsOk =
+    probes.length === 0
+      ? (skip('read', 'Skipped: no read probes configured'), true)
+      : await timed('read', async () => {
+          const failures: string[] = [];
+
+          for (const readProbe of probes) {
+            try {
+              const value = await withTimeout(
+                probe.callRead(config.id, readProbe.method, readProbe.args),
+                timeoutMs,
+                `read ${readProbe.method}`,
+              );
+
+              const rejection = readProbe.expect?.(value);
+
+              if (rejection) failures.push(`${readProbe.method}: ${rejection}`);
+            } catch (error) {
+              failures.push(`${readProbe.method}: ${messageOf(error)}`);
+            }
+          }
+
+          return failures.length === 0
+            ? { ok: true, message: `${probes.length} read probe(s) succeeded` }
+            : { ok: false, message: failures.join('; ') };
+        });
+
+  // A contract on the wrong network, or missing methods the integration
+  // calls, cannot work at all. A failing read on an otherwise correct
+  // contract may be transient.
+  let status: ContractHealthStatus;
+
+  if (!networkOk || !interfaceOk) status = 'unhealthy';
+  else if (!readsOk) status = 'degraded';
+  else status = 'healthy';
+
+  return {
+    contractId: config.id,
+    name: config.name,
+    network: config.network,
+    status,
+    checks,
+    missingMethods,
+    checkedAt: startedAt,
+    totalDurationMs: now() - startedAt,
+  };
+}

--- a/src/contracts/health/soroban/types.ts
+++ b/src/contracts/health/soroban/types.ts
@@ -1,0 +1,92 @@
+// ─── Soroban contract integration health (#1067) ──────────────────────────────
+
+/** Overall verdict for one contract integration. */
+export type ContractHealthStatus =
+  'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+
+/** The individual checks that make up a verdict. */
+export type ContractCheckName =
+  'availability' | 'network' | 'interface' | 'read';
+
+export type SorobanNetwork = 'mainnet' | 'testnet' | 'futurenet' | 'local';
+
+/** A read that is safe to execute against a live contract. */
+export interface ReadProbe {
+  /** Contract method to invoke. Must be side-effect free. */
+  method: string;
+  args?: readonly unknown[];
+  /**
+   * Optional assertion on the returned value. Return a reason to fail the
+   * probe, or `null`/`undefined` to accept it.
+   *
+   * A read that returns *something* is weaker evidence than a read that
+   * returns something sensible — a contract can answer while being wired to
+   * the wrong asset.
+   */
+  expect?: (value: unknown) => string | null | undefined;
+}
+
+export interface SorobanContractConfig {
+  /** Contract id (`C…`). */
+  id: string;
+  /** Human name used in reports. */
+  name: string;
+  /** Network this integration is configured against. */
+  network: SorobanNetwork;
+  /** Methods the integration relies on. */
+  expectedMethods: readonly string[];
+  /** Safe reads used to prove the contract actually answers. */
+  readProbes?: readonly ReadProbe[];
+}
+
+/**
+ * The RPC surface a health check needs.
+ *
+ * Injected rather than constructed so a check can run against a real Soroban
+ * RPC client, a recorded fixture, or a stub in tests without this module
+ * knowing which.
+ */
+export interface SorobanContractProbe {
+  /** Whether the contract exists, and which network answered. */
+  getContractInfo(
+    contractId: string,
+  ): Promise<{ exists: boolean; network?: string }>;
+  /** Method names exposed by the contract's spec. */
+  listMethods(contractId: string): Promise<readonly string[]>;
+  /** Execute a read-only call. */
+  callRead(
+    contractId: string,
+    method: string,
+    args?: readonly unknown[],
+  ): Promise<unknown>;
+}
+
+export interface ContractHealthCheck {
+  name: ContractCheckName;
+  ok: boolean;
+  /** Why it failed, or what it confirmed. */
+  message: string;
+  durationMs: number;
+  /** Set when the check was not run because an earlier one made it moot. */
+  skipped?: boolean;
+}
+
+export interface ContractHealthResult {
+  contractId: string;
+  name: string;
+  network: SorobanNetwork;
+  status: ContractHealthStatus;
+  checks: ContractHealthCheck[];
+  /** Expected methods the contract does not expose. */
+  missingMethods: string[];
+  /** Epoch ms at which the check ran. */
+  checkedAt: number;
+  totalDurationMs: number;
+}
+
+export interface HealthCheckOptions {
+  /** Per-check timeout. Default 5000ms. */
+  timeoutMs?: number;
+  /** Injectable clock, for deterministic tests. */
+  now?: () => number;
+}

--- a/src/monitoring/contracts/contract-health-monitor.ts
+++ b/src/monitoring/contracts/contract-health-monitor.ts
@@ -1,0 +1,203 @@
+import {
+  checkSorobanContractHealth,
+  messageOf,
+  type ContractHealthResult,
+  type ContractHealthStatus,
+  type HealthCheckOptions,
+  type SorobanContractConfig,
+  type SorobanContractProbe,
+} from '../../contracts/health/soroban';
+
+// ─── Contract integration monitoring (#1067) ──────────────────────────────────
+
+export interface ContractHealthSummary {
+  /** Worst status across every monitored contract. */
+  overall: ContractHealthStatus;
+  total: number;
+  healthy: number;
+  degraded: number;
+  unhealthy: number;
+  /** Contract ids that are not healthy, worst first. */
+  failing: string[];
+  checkedAt: number;
+}
+
+export interface MonitorOptions extends HealthCheckOptions {
+  /** Results retained per contract. Default 20. */
+  historyLimit?: number;
+}
+
+/** Ordering used to decide which status is "worse". */
+const SEVERITY: Record<ContractHealthStatus, number> = {
+  healthy: 0,
+  unknown: 1,
+  degraded: 2,
+  unhealthy: 3,
+};
+
+export function worstStatus(
+  statuses: readonly ContractHealthStatus[],
+): ContractHealthStatus {
+  // No contracts is not the same as healthy contracts. Reporting "healthy"
+  // for an empty monitor would hide a misconfiguration where nothing was
+  // registered at all.
+  if (statuses.length === 0) return 'unknown';
+
+  return statuses.reduce((worst, status) =>
+    SEVERITY[status] > SEVERITY[worst] ? status : worst,
+  );
+}
+
+/**
+ * Runs health checks across every configured contract integration and keeps a
+ * short history of the results.
+ *
+ * History matters because a single failing check does not distinguish a
+ * transient RPC blip from an integration that has been broken since deploy,
+ * and those need different responses.
+ */
+export class ContractHealthMonitor {
+  private readonly contracts = new Map<string, SorobanContractConfig>();
+  private readonly history = new Map<string, ContractHealthResult[]>();
+  private readonly historyLimit: number;
+  private readonly options: HealthCheckOptions;
+  private readonly now: () => number;
+
+  constructor(
+    private readonly probe: SorobanContractProbe,
+    options: MonitorOptions = {},
+  ) {
+    const { historyLimit = 20, ...checkOptions } = options;
+
+    this.historyLimit = historyLimit;
+    this.options = checkOptions;
+    this.now = checkOptions.now ?? Date.now;
+  }
+
+  register(config: SorobanContractConfig): void {
+    this.contracts.set(config.id, config);
+  }
+
+  unregister(contractId: string): void {
+    this.contracts.delete(contractId);
+    this.history.delete(contractId);
+  }
+
+  registered(): SorobanContractConfig[] {
+    return [...this.contracts.values()];
+  }
+
+  /** Check one contract and record the result. */
+  async check(contractId: string): Promise<ContractHealthResult> {
+    const config = this.contracts.get(contractId);
+
+    if (!config) {
+      throw new Error(`No contract registered with id ${contractId}`);
+    }
+
+    const result = await checkSorobanContractHealth(
+      config,
+      this.probe,
+      this.options,
+    );
+
+    const existing = this.history.get(contractId) ?? [];
+
+    this.history.set(
+      contractId,
+      [result, ...existing].slice(0, this.historyLimit),
+    );
+
+    return result;
+  }
+
+  /**
+   * Check every registered contract.
+   *
+   * Checks run concurrently and a thrown check becomes an `unknown` result
+   * rather than failing the sweep — one unreachable integration must not hide
+   * the status of the others.
+   */
+  async checkAll(): Promise<ContractHealthResult[]> {
+    const ids = [...this.contracts.keys()];
+
+    return Promise.all(
+      ids.map(async (id) => {
+        try {
+          return await this.check(id);
+        } catch (error) {
+          const config = this.contracts.get(id);
+
+          return {
+            contractId: id,
+            name: config?.name ?? id,
+            network: config?.network ?? 'local',
+            status: 'unknown' as const,
+            checks: [
+              {
+                name: 'availability' as const,
+                ok: false,
+                message: messageOf(error),
+                durationMs: 0,
+              },
+            ],
+            missingMethods: [],
+            checkedAt: this.now(),
+            totalDurationMs: 0,
+          };
+        }
+      }),
+    );
+  }
+
+  /** Most recent result for a contract, if it has been checked. */
+  latest(contractId: string): ContractHealthResult | undefined {
+    return this.history.get(contractId)?.[0];
+  }
+
+  /** Recorded results for a contract, most recent first. */
+  historyFor(contractId: string): ContractHealthResult[] {
+    return [...(this.history.get(contractId) ?? [])];
+  }
+
+  /** Roll the latest result for every contract into one verdict. */
+  summary(): ContractHealthSummary {
+    const latest = [...this.contracts.keys()]
+      .map((id) => this.latest(id))
+      .filter((result): result is ContractHealthResult => result !== undefined);
+
+    const counts = { healthy: 0, degraded: 0, unhealthy: 0 };
+
+    for (const result of latest) {
+      if (result.status === 'healthy') counts.healthy += 1;
+      else if (result.status === 'degraded') counts.degraded += 1;
+      else if (result.status === 'unhealthy') counts.unhealthy += 1;
+    }
+
+    const failing = latest
+      .filter((result) => result.status !== 'healthy')
+      .sort((a, b) => SEVERITY[b.status] - SEVERITY[a.status])
+      .map((result) => result.contractId);
+
+    return {
+      overall: worstStatus(latest.map((result) => result.status)),
+      total: latest.length,
+      ...counts,
+      failing,
+      checkedAt: this.now(),
+    };
+  }
+
+  /**
+   * Whether a contract has failed every one of its last `count` checks.
+   *
+   * A run of failures is what separates a broken integration from a blip.
+   */
+  isPersistentlyFailing(contractId: string, count = 3): boolean {
+    const recent = (this.history.get(contractId) ?? []).slice(0, count);
+
+    if (recent.length < count) return false;
+
+    return recent.every((result) => result.status === 'unhealthy');
+  }
+}

--- a/src/monitoring/contracts/index.ts
+++ b/src/monitoring/contracts/index.ts
@@ -1,0 +1,1 @@
+export * from './contract-health-monitor';

--- a/src/providers/dependencies/stellar/dependency-graph.ts
+++ b/src/providers/dependencies/stellar/dependency-graph.ts
@@ -1,0 +1,247 @@
+import type {
+  DependencyHealth,
+  DependencyStatus,
+  ProviderDefinition,
+  ProviderDependency,
+  ProviderHealthReport,
+} from './types';
+
+/** Ordering used to decide which status is "worse". */
+const SEVERITY: Record<DependencyStatus, number> = {
+  healthy: 0,
+  unknown: 1,
+  degraded: 2,
+  unhealthy: 3,
+};
+
+export function worstDependencyStatus(
+  statuses: readonly DependencyStatus[],
+): DependencyStatus {
+  if (statuses.length === 0) return 'unknown';
+
+  return statuses.reduce((worst, status) =>
+    SEVERITY[status] > SEVERITY[worst] ? status : worst,
+  );
+}
+
+export interface DependencyGraphOptions {
+  /** Injectable clock, for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * Models what each Stellar bridge provider depends on, and derives provider
+ * health from the health of those dependencies (#1068).
+ *
+ * The problem this solves is attribution. A provider stops quoting and the
+ * symptom is "provider X is down", but the cause is usually one shared RPC
+ * endpoint, contract, or price API sitting underneath several providers. A
+ * graph makes that a lookup rather than an investigation: record the
+ * dependency as unhealthy once, and every provider that leans on it reports
+ * the reason rather than a bare failure.
+ *
+ * Dependencies are shared by reference, so one failure fans out to every
+ * provider that declares it — which is exactly what happens in production.
+ */
+export class StellarProviderDependencyGraph {
+  private readonly dependencies = new Map<string, ProviderDependency>();
+  private readonly providers = new Map<string, ProviderDefinition>();
+  private readonly health = new Map<string, DependencyHealth>();
+  private readonly now: () => number;
+
+  constructor(options: DependencyGraphOptions = {}) {
+    this.now = options.now ?? Date.now;
+  }
+
+  /** Register a dependency. Re-registering updates its definition. */
+  addDependency(dependency: ProviderDependency): void {
+    this.dependencies.set(dependency.id, dependency);
+
+    if (!this.health.has(dependency.id)) {
+      this.health.set(dependency.id, {
+        dependencyId: dependency.id,
+        status: 'unknown',
+        updatedAt: 0,
+      });
+    }
+  }
+
+  /**
+   * Register a provider and the dependencies it requires.
+   *
+   * Every declared dependency must already be registered — a provider
+   * pointing at a dependency that does not exist would silently report
+   * healthy, having nothing to check.
+   */
+  addProvider(provider: ProviderDefinition): void {
+    const unknownIds = provider.dependencyIds.filter(
+      (id) => !this.dependencies.has(id),
+    );
+
+    if (unknownIds.length > 0) {
+      throw new Error(
+        `Provider ${provider.id} declares unknown dependencies: ${unknownIds.join(', ')}`,
+      );
+    }
+
+    this.providers.set(provider.id, provider);
+  }
+
+  getDependency(dependencyId: string): ProviderDependency | undefined {
+    return this.dependencies.get(dependencyId);
+  }
+
+  listDependencies(): ProviderDependency[] {
+    return [...this.dependencies.values()];
+  }
+
+  listProviders(): ProviderDefinition[] {
+    return [...this.providers.values()];
+  }
+
+  /** Record the current state of a dependency. */
+  recordDependencyHealth(
+    dependencyId: string,
+    status: DependencyStatus,
+    reason?: string,
+  ): void {
+    if (!this.dependencies.has(dependencyId)) {
+      throw new Error(`Unknown dependency ${dependencyId}`);
+    }
+
+    this.health.set(dependencyId, {
+      dependencyId,
+      status,
+      reason,
+      updatedAt: this.now(),
+    });
+  }
+
+  /** Current state of one dependency. */
+  dependencyStatus(dependencyId: string): DependencyHealth {
+    const existing = this.health.get(dependencyId);
+
+    if (!existing) {
+      throw new Error(`Unknown dependency ${dependencyId}`);
+    }
+
+    return { ...existing };
+  }
+
+  /** Current state of every dependency. */
+  allDependencyStatuses(): DependencyHealth[] {
+    return [...this.health.values()].map((entry) => ({ ...entry }));
+  }
+
+  /**
+   * Which providers declare `dependencyId` — the answer to "what does this
+   * outage affect?".
+   */
+  providersAffectedBy(dependencyId: string): ProviderDefinition[] {
+    return [...this.providers.values()].filter((provider) =>
+      provider.dependencyIds.includes(dependencyId),
+    );
+  }
+
+  /**
+   * Derive a provider's health from its dependencies.
+   *
+   * The grading is the point:
+   *
+   * - a **critical** dependency that is unhealthy makes the provider
+   *   unhealthy — it cannot serve;
+   * - a **critical** dependency that is degraded, or a **non-critical** one
+   *   that is unhealthy, makes the provider degraded — it can still serve,
+   *   worse;
+   * - a critical dependency that has never reported leaves the provider
+   *   `unknown`, because claiming health for something never checked is how a
+   *   dashboard ends up lying.
+   */
+  providerHealth(providerId: string): ProviderHealthReport {
+    const provider = this.providers.get(providerId);
+
+    if (!provider) {
+      throw new Error(`Unknown provider ${providerId}`);
+    }
+
+    const health = provider.dependencyIds.map((id) =>
+      this.dependencyStatus(id),
+    );
+
+    const failing = health.filter(
+      (entry) => entry.status === 'degraded' || entry.status === 'unhealthy',
+    );
+    const unknown = health.filter((entry) => entry.status === 'unknown');
+
+    const isCritical = (entry: DependencyHealth) =>
+      this.dependencies.get(entry.dependencyId)?.critical ?? false;
+
+    const criticalFailures = failing.filter(
+      (entry) => isCritical(entry) && entry.status === 'unhealthy',
+    );
+
+    let status: DependencyStatus;
+    let summary: string;
+
+    if (criticalFailures.length > 0) {
+      status = 'unhealthy';
+      summary = `Critical dependency failure: ${criticalFailures
+        .map((entry) => this.labelFor(entry.dependencyId))
+        .join(', ')}`;
+    } else if (failing.length > 0) {
+      status = 'degraded';
+      summary = `Degraded by ${failing.map((entry) => this.labelFor(entry.dependencyId)).join(', ')}`;
+    } else if (unknown.some(isCritical)) {
+      status = 'unknown';
+      summary = `Awaiting health for ${unknown
+        .filter(isCritical)
+        .map((entry) => this.labelFor(entry.dependencyId))
+        .join(', ')}`;
+    } else if (health.length === 0) {
+      // A provider with no declared dependencies has nothing to derive health
+      // from; saying "healthy" would be an unearned claim.
+      status = 'unknown';
+      summary = 'No dependencies declared';
+    } else {
+      status = 'healthy';
+      summary = `All ${health.length} dependencies healthy`;
+    }
+
+    return {
+      providerId,
+      name: provider.name,
+      status,
+      failing,
+      criticalFailures,
+      unknown,
+      summary,
+    };
+  }
+
+  /** Health for every provider. */
+  allProviderHealth(): ProviderHealthReport[] {
+    return [...this.providers.keys()].map((id) => this.providerHealth(id));
+  }
+
+  /**
+   * What breaks if `dependencyId` goes unhealthy, without actually recording
+   * it — used to answer "is this endpoint safe to take out of rotation?".
+   */
+  impactOf(dependencyId: string): { unhealthy: string[]; degraded: string[] } {
+    const dependency = this.dependencies.get(dependencyId);
+
+    if (!dependency) {
+      throw new Error(`Unknown dependency ${dependencyId}`);
+    }
+
+    const affected = this.providersAffectedBy(dependencyId);
+
+    return dependency.critical
+      ? { unhealthy: affected.map((provider) => provider.id), degraded: [] }
+      : { unhealthy: [], degraded: affected.map((provider) => provider.id) };
+  }
+
+  private labelFor(dependencyId: string): string {
+    return this.dependencies.get(dependencyId)?.label ?? dependencyId;
+  }
+}

--- a/src/providers/dependencies/stellar/index.ts
+++ b/src/providers/dependencies/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './dependency-graph';

--- a/src/providers/dependencies/stellar/types.ts
+++ b/src/providers/dependencies/stellar/types.ts
@@ -1,0 +1,53 @@
+// ─── Stellar bridge provider dependencies (#1068) ─────────────────────────────
+
+/** What kind of thing a provider depends on. */
+export type DependencyKind =
+  'rpc' | 'horizon' | 'contract' | 'liquidity' | 'api' | 'indexer';
+
+export type DependencyStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+
+export interface ProviderDependency {
+  id: string;
+  kind: DependencyKind;
+  /** Human label used in reports. */
+  label: string;
+  /**
+   * Whether the provider can function at all without it.
+   *
+   * Critical is not "important" — it is "the provider cannot serve a quote or
+   * a transfer without this". A price API going down may degrade quality; an
+   * RPC endpoint going down stops the provider entirely, and the two must not
+   * be reported the same way.
+   */
+  critical: boolean;
+}
+
+export interface ProviderDefinition {
+  id: string;
+  name: string;
+  /** Ids of the dependencies this provider requires. */
+  dependencyIds: readonly string[];
+}
+
+export interface DependencyHealth {
+  dependencyId: string;
+  status: DependencyStatus;
+  /** Why it is in this state, when known. */
+  reason?: string;
+  /** Epoch ms of the last update; 0 when never reported. */
+  updatedAt: number;
+}
+
+export interface ProviderHealthReport {
+  providerId: string;
+  name: string;
+  status: DependencyStatus;
+  /** Dependencies that are not healthy. */
+  failing: DependencyHealth[];
+  /** The subset of `failing` the provider cannot operate without. */
+  criticalFailures: DependencyHealth[];
+  /** Dependencies that have never reported. */
+  unknown: DependencyHealth[];
+  /** One-line explanation of the status. */
+  summary: string;
+}

--- a/src/providers/health/index.ts
+++ b/src/providers/health/index.ts
@@ -1,0 +1,1 @@
+export * from './provider-health';

--- a/src/providers/health/provider-health.ts
+++ b/src/providers/health/provider-health.ts
@@ -1,0 +1,90 @@
+import {
+  StellarProviderDependencyGraph,
+  worstDependencyStatus,
+  type DependencyStatus,
+  type ProviderHealthReport,
+} from '../dependencies/stellar';
+
+// ─── Provider health surface (#1068) ──────────────────────────────────────────
+
+export interface ProviderHealthOverview {
+  /** Worst provider status across the fleet. */
+  overall: DependencyStatus;
+  total: number;
+  healthy: number;
+  degraded: number;
+  unhealthy: number;
+  unknown: number;
+  /** Providers that are not healthy, worst first. */
+  failing: ProviderHealthReport[];
+  /**
+   * Dependencies causing failures, and the providers each one takes down.
+   *
+   * This is the view an operator actually wants: five providers failing for
+   * one reason is one problem, not five.
+   */
+  rootCauses: { dependencyId: string; label: string; providerIds: string[] }[];
+}
+
+const SEVERITY: Record<DependencyStatus, number> = {
+  healthy: 0,
+  unknown: 1,
+  degraded: 2,
+  unhealthy: 3,
+};
+
+/** Roll per-provider health into a fleet-level view. */
+export function summarizeProviderHealth(
+  graph: StellarProviderDependencyGraph,
+): ProviderHealthOverview {
+  const reports = graph.allProviderHealth();
+
+  const counts = { healthy: 0, degraded: 0, unhealthy: 0, unknown: 0 };
+
+  for (const report of reports) counts[report.status] += 1;
+
+  const failing = reports
+    .filter((report) => report.status !== 'healthy')
+    .sort((a, b) => SEVERITY[b.status] - SEVERITY[a.status]);
+
+  // Group failures by the dependency responsible, so one shared outage is
+  // reported once rather than once per provider.
+  const byDependency = new Map<string, Set<string>>();
+
+  for (const report of reports) {
+    for (const failure of report.failing) {
+      const providers =
+        byDependency.get(failure.dependencyId) ?? new Set<string>();
+
+      providers.add(report.providerId);
+      byDependency.set(failure.dependencyId, providers);
+    }
+  }
+
+  const rootCauses = [...byDependency.entries()]
+    .map(([dependencyId, providerIds]) => ({
+      dependencyId,
+      label: graph.getDependency(dependencyId)?.label ?? dependencyId,
+      providerIds: [...providerIds].sort(),
+    }))
+    // Widest blast radius first.
+    .sort((a, b) => b.providerIds.length - a.providerIds.length);
+
+  return {
+    overall: worstDependencyStatus(reports.map((report) => report.status)),
+    total: reports.length,
+    ...counts,
+    failing,
+    rootCauses,
+  };
+}
+
+/** Providers currently able to serve traffic. */
+export function healthyProviderIds(
+  graph: StellarProviderDependencyGraph,
+): string[] {
+  return graph
+    .allProviderHealth()
+    .filter((report) => report.status === 'healthy')
+    .map((report) => report.providerId);
+}

--- a/tests/contracts/health/contract-health-monitor.spec.ts
+++ b/tests/contracts/health/contract-health-monitor.spec.ts
@@ -1,0 +1,205 @@
+import { ContractHealthMonitor, worstStatus } from "../../../src/monitoring/contracts";
+import type {
+  SorobanContractConfig,
+  SorobanContractProbe,
+} from "../../../src/contracts/health/soroban";
+
+function config(id: string, overrides: Partial<SorobanContractConfig> = {}): SorobanContractConfig {
+  return {
+    id,
+    name: `Contract ${id}`,
+    network: "testnet",
+    expectedMethods: ["quote"],
+    ...overrides,
+  };
+}
+
+function probe(overrides: Partial<SorobanContractProbe> = {}): SorobanContractProbe {
+  return {
+    getContractInfo: jest.fn().mockResolvedValue({ exists: true, network: "testnet" }),
+    listMethods: jest.fn().mockResolvedValue(["quote"]),
+    callRead: jest.fn().mockResolvedValue(1),
+    ...overrides,
+  };
+}
+
+describe("worstStatus", () => {
+  it("picks the most severe status", () => {
+    expect(worstStatus(["healthy", "degraded"])).toBe("degraded");
+    expect(worstStatus(["degraded", "unhealthy"])).toBe("unhealthy");
+    expect(worstStatus(["healthy", "healthy"])).toBe("healthy");
+  });
+
+  // An empty monitor is not a healthy one — reporting "healthy" would hide a
+  // configuration where nothing was registered at all.
+  it("reports unknown for no statuses", () => {
+    expect(worstStatus([])).toBe("unknown");
+  });
+});
+
+describe("ContractHealthMonitor", () => {
+  it("registers and lists contracts", () => {
+    const monitor = new ContractHealthMonitor(probe());
+
+    monitor.register(config("A"));
+    monitor.register(config("B"));
+
+    expect(monitor.registered().map((entry) => entry.id)).toEqual(["A", "B"]);
+  });
+
+  it("unregisters a contract and forgets its history", async () => {
+    const monitor = new ContractHealthMonitor(probe());
+
+    monitor.register(config("A"));
+    await monitor.check("A");
+
+    monitor.unregister("A");
+
+    expect(monitor.registered()).toEqual([]);
+    expect(monitor.latest("A")).toBeUndefined();
+  });
+
+  it("refuses to check a contract it does not know", async () => {
+    const monitor = new ContractHealthMonitor(probe());
+
+    await expect(monitor.check("missing")).rejects.toThrow("No contract registered");
+  });
+
+  it("records the latest result", async () => {
+    const monitor = new ContractHealthMonitor(probe());
+    monitor.register(config("A"));
+
+    await monitor.check("A");
+
+    expect(monitor.latest("A")?.status).toBe("healthy");
+  });
+
+  it("keeps a bounded history, most recent first", async () => {
+    const monitor = new ContractHealthMonitor(probe(), { historyLimit: 2 });
+    monitor.register(config("A"));
+
+    await monitor.check("A");
+    await monitor.check("A");
+    await monitor.check("A");
+
+    expect(monitor.historyFor("A")).toHaveLength(2);
+  });
+
+  it("checks every registered contract", async () => {
+    const monitor = new ContractHealthMonitor(probe());
+    monitor.register(config("A"));
+    monitor.register(config("B"));
+
+    const results = await monitor.checkAll();
+
+    expect(results.map((entry) => entry.contractId).sort()).toEqual(["A", "B"]);
+  });
+
+  // One unreachable integration must not hide the status of the others.
+  it("keeps sweeping when one contract throws", async () => {
+    const monitor = new ContractHealthMonitor(
+      probe({
+        getContractInfo: jest.fn(async (id: string) => {
+          if (id === "A") throw new Error("exploded");
+
+          return { exists: true, network: "testnet" };
+        }),
+      }),
+    );
+
+    monitor.register(config("A"));
+    monitor.register(config("B"));
+
+    const results = await monitor.checkAll();
+
+    expect(results).toHaveLength(2);
+    expect(results.find((entry) => entry.contractId === "B")?.status).toBe("healthy");
+  });
+
+  describe("summary", () => {
+    it("is unknown before anything has been checked", () => {
+      const monitor = new ContractHealthMonitor(probe());
+      monitor.register(config("A"));
+
+      expect(monitor.summary().overall).toBe("unknown");
+      expect(monitor.summary().total).toBe(0);
+    });
+
+    it("counts each status", async () => {
+      const monitor = new ContractHealthMonitor(
+        probe({
+          listMethods: jest.fn(async (id: string) => (id === "B" ? [] : ["quote"])),
+        }),
+      );
+
+      monitor.register(config("A"));
+      monitor.register(config("B"));
+      await monitor.checkAll();
+
+      const summary = monitor.summary();
+
+      expect(summary.healthy).toBe(1);
+      expect(summary.unhealthy).toBe(1);
+      expect(summary.overall).toBe("unhealthy");
+    });
+
+    it("lists failing contracts worst first", async () => {
+      const monitor = new ContractHealthMonitor(
+        probe({
+          listMethods: jest.fn(async (id: string) => (id === "BAD" ? [] : ["quote"])),
+          callRead: jest.fn(async (id: string) => {
+            if (id === "SLOW") throw new Error("timeout");
+
+            return 1;
+          }),
+        }),
+      );
+
+      monitor.register(config("OK"));
+      monitor.register(config("SLOW", { readProbes: [{ method: "quote" }] }));
+      monitor.register(config("BAD"));
+
+      await monitor.checkAll();
+
+      expect(monitor.summary().failing).toEqual(["BAD", "SLOW"]);
+    });
+  });
+
+  describe("isPersistentlyFailing", () => {
+    // A run of failures is what separates a broken integration from a blip,
+    // and the two warrant different responses.
+    it("is false until enough consecutive failures are recorded", async () => {
+      const monitor = new ContractHealthMonitor(
+        probe({ getContractInfo: jest.fn().mockResolvedValue({ exists: false }) }),
+      );
+
+      monitor.register(config("A"));
+
+      await monitor.check("A");
+      expect(monitor.isPersistentlyFailing("A", 3)).toBe(false);
+
+      await monitor.check("A");
+      expect(monitor.isPersistentlyFailing("A", 3)).toBe(false);
+
+      await monitor.check("A");
+      expect(monitor.isPersistentlyFailing("A", 3)).toBe(true);
+    });
+
+    it("is false when a recent check succeeded", async () => {
+      let healthy = false;
+
+      const monitor = new ContractHealthMonitor(
+        probe({ getContractInfo: jest.fn(async () => ({ exists: healthy, network: "testnet" })) }),
+      );
+
+      monitor.register(config("A"));
+
+      await monitor.check("A");
+      await monitor.check("A");
+      healthy = true;
+      await monitor.check("A");
+
+      expect(monitor.isPersistentlyFailing("A", 3)).toBe(false);
+    });
+  });
+});

--- a/tests/contracts/health/soroban-contract-health.spec.ts
+++ b/tests/contracts/health/soroban-contract-health.spec.ts
@@ -1,0 +1,271 @@
+import {
+  checkSorobanContractHealth,
+  type SorobanContractConfig,
+  type SorobanContractProbe,
+} from "../../../src/contracts/health/soroban";
+
+const CONTRACT_ID = "CABC123";
+
+function config(overrides: Partial<SorobanContractConfig> = {}): SorobanContractConfig {
+  return {
+    id: CONTRACT_ID,
+    name: "Bridge Pool",
+    network: "testnet",
+    expectedMethods: ["quote", "swap"],
+    ...overrides,
+  };
+}
+
+/** A probe where every call succeeds unless overridden. */
+function probe(overrides: Partial<SorobanContractProbe> = {}): SorobanContractProbe {
+  return {
+    getContractInfo: jest.fn().mockResolvedValue({ exists: true, network: "testnet" }),
+    listMethods: jest.fn().mockResolvedValue(["quote", "swap", "admin"]),
+    callRead: jest.fn().mockResolvedValue(42),
+    ...overrides,
+  };
+}
+
+describe("checkSorobanContractHealth", () => {
+  it("reports healthy when every check passes", async () => {
+    const result = await checkSorobanContractHealth(config(), probe());
+
+    expect(result.status).toBe("healthy");
+    expect(result.missingMethods).toEqual([]);
+    expect(result.contractId).toBe(CONTRACT_ID);
+  });
+
+  it("records a result for each check", async () => {
+    const result = await checkSorobanContractHealth(config(), probe());
+
+    expect(result.checks.map((check) => check.name)).toEqual([
+      "availability",
+      "network",
+      "interface",
+      "read",
+    ]);
+  });
+
+  // ── Availability ────────────────────────────────────────────────────
+
+  it("is unhealthy when the contract does not exist", async () => {
+    const result = await checkSorobanContractHealth(
+      config(),
+      probe({ getContractInfo: jest.fn().mockResolvedValue({ exists: false }) }),
+    );
+
+    expect(result.status).toBe("unhealthy");
+    expect(result.checks[0]).toMatchObject({ name: "availability", ok: false });
+  });
+
+  // Blaming interface and read checks for a contract that is not there would
+  // bury the one fact that matters.
+  it("skips the remaining checks when the contract is absent", async () => {
+    const listMethods = jest.fn();
+    const callRead = jest.fn();
+
+    const result = await checkSorobanContractHealth(
+      config({ readProbes: [{ method: "quote" }] }),
+      probe({
+        getContractInfo: jest.fn().mockResolvedValue({ exists: false }),
+        listMethods,
+        callRead,
+      }),
+    );
+
+    expect(listMethods).not.toHaveBeenCalled();
+    expect(callRead).not.toHaveBeenCalled();
+
+    for (const name of ["network", "interface", "read"]) {
+      expect(result.checks.find((check) => check.name === name)?.skipped).toBe(true);
+    }
+  });
+
+  it("reports every expected method as missing when the contract is absent", async () => {
+    const result = await checkSorobanContractHealth(
+      config(),
+      probe({ getContractInfo: jest.fn().mockResolvedValue({ exists: false }) }),
+    );
+
+    expect(result.missingMethods).toEqual(["quote", "swap"]);
+  });
+
+  it("treats a throwing availability probe as unavailable", async () => {
+    const result = await checkSorobanContractHealth(
+      config(),
+      probe({ getContractInfo: jest.fn().mockRejectedValue(new Error("rpc down")) }),
+    );
+
+    expect(result.status).toBe("unhealthy");
+    expect(result.checks[0].message).toContain("rpc down");
+  });
+
+  // ── Network ─────────────────────────────────────────────────────────
+
+  // A contract answering from the wrong network is worse than silence: the
+  // integration looks fine while reading someone else's state.
+  it("is unhealthy when the wrong network answers", async () => {
+    const result = await checkSorobanContractHealth(
+      config({ network: "mainnet" }),
+      probe({
+        getContractInfo: jest.fn().mockResolvedValue({ exists: true, network: "testnet" }),
+      }),
+    );
+
+    expect(result.status).toBe("unhealthy");
+
+    const check = result.checks.find((entry) => entry.name === "network");
+    expect(check?.ok).toBe(false);
+    expect(check?.message).toContain("mainnet");
+    expect(check?.message).toContain("testnet");
+  });
+
+  it("accepts a probe that does not report a network", async () => {
+    const result = await checkSorobanContractHealth(
+      config(),
+      probe({ getContractInfo: jest.fn().mockResolvedValue({ exists: true }) }),
+    );
+
+    expect(result.status).toBe("healthy");
+  });
+
+  // ── Interface ───────────────────────────────────────────────────────
+
+  it("is unhealthy when an expected method is missing", async () => {
+    const result = await checkSorobanContractHealth(
+      config(),
+      probe({ listMethods: jest.fn().mockResolvedValue(["quote"]) }),
+    );
+
+    expect(result.status).toBe("unhealthy");
+    expect(result.missingMethods).toEqual(["swap"]);
+  });
+
+  it("names every missing method", async () => {
+    const result = await checkSorobanContractHealth(
+      config(),
+      probe({ listMethods: jest.fn().mockResolvedValue([]) }),
+    );
+
+    const check = result.checks.find((entry) => entry.name === "interface");
+    expect(check?.message).toContain("quote");
+    expect(check?.message).toContain("swap");
+  });
+
+  it("ignores extra methods the contract exposes", async () => {
+    const result = await checkSorobanContractHealth(
+      config(),
+      probe({ listMethods: jest.fn().mockResolvedValue(["quote", "swap", "extra"]) }),
+    );
+
+    expect(result.status).toBe("healthy");
+  });
+
+  // ── Reads ───────────────────────────────────────────────────────────
+
+  it("skips the read check when no probes are configured", async () => {
+    const result = await checkSorobanContractHealth(config(), probe());
+
+    expect(result.checks.find((check) => check.name === "read")?.skipped).toBe(true);
+    expect(result.status).toBe("healthy");
+  });
+
+  it("runs each configured read probe", async () => {
+    const callRead = jest.fn().mockResolvedValue(1);
+
+    await checkSorobanContractHealth(
+      config({ readProbes: [{ method: "quote", args: [1, 2] }, { method: "swap" }] }),
+      probe({ callRead }),
+    );
+
+    expect(callRead).toHaveBeenCalledTimes(2);
+    expect(callRead).toHaveBeenCalledWith(CONTRACT_ID, "quote", [1, 2]);
+  });
+
+  // The contract is present and correctly shaped, so a failing read is more
+  // likely transient than structural — that difference drives the response.
+  it("is degraded, not unhealthy, when a read fails", async () => {
+    const result = await checkSorobanContractHealth(
+      config({ readProbes: [{ method: "quote" }] }),
+      probe({ callRead: jest.fn().mockRejectedValue(new Error("timeout")) }),
+    );
+
+    expect(result.status).toBe("degraded");
+    expect(result.checks.find((check) => check.name === "read")?.message).toContain("timeout");
+  });
+
+  it("fails a read whose value does not meet expectations", async () => {
+    const result = await checkSorobanContractHealth(
+      config({
+        readProbes: [
+          { method: "quote", expect: (value) => (typeof value === "number" ? null : "not a number") },
+        ],
+      }),
+      probe({ callRead: jest.fn().mockResolvedValue("nope") }),
+    );
+
+    expect(result.status).toBe("degraded");
+    expect(result.checks.find((check) => check.name === "read")?.message).toContain(
+      "not a number",
+    );
+  });
+
+  it("reports every failing probe rather than stopping at the first", async () => {
+    const result = await checkSorobanContractHealth(
+      config({ readProbes: [{ method: "a" }, { method: "b" }] }),
+      probe({ callRead: jest.fn().mockRejectedValue(new Error("boom")) }),
+    );
+
+    const message = result.checks.find((check) => check.name === "read")?.message ?? "";
+    expect(message).toContain("a:");
+    expect(message).toContain("b:");
+  });
+
+  // A structural fault outranks a transient one.
+  it("prefers unhealthy over degraded when both apply", async () => {
+    const result = await checkSorobanContractHealth(
+      config({ readProbes: [{ method: "quote" }] }),
+      probe({
+        listMethods: jest.fn().mockResolvedValue([]),
+        callRead: jest.fn().mockRejectedValue(new Error("also broken")),
+      }),
+    );
+
+    expect(result.status).toBe("unhealthy");
+  });
+
+  // ── Timeouts ────────────────────────────────────────────────────────
+
+  // An integration that never answers is not healthy, and without a bound the
+  // health check would hang with it.
+  it("bounds a hanging probe", async () => {
+    const result = await checkSorobanContractHealth(
+      config(),
+      probe({ getContractInfo: jest.fn().mockImplementation(() => new Promise(() => {})) }),
+      { timeoutMs: 20 },
+    );
+
+    expect(result.status).toBe("unhealthy");
+    expect(result.checks[0].message).toContain("timed out");
+  });
+
+  it("bounds a hanging read", async () => {
+    const result = await checkSorobanContractHealth(
+      config({ readProbes: [{ method: "quote" }] }),
+      probe({ callRead: jest.fn().mockImplementation(() => new Promise(() => {})) }),
+      { timeoutMs: 20 },
+    );
+
+    expect(result.status).toBe("degraded");
+  });
+
+  it("uses the injected clock for timings", async () => {
+    let tick = 1_000;
+    const now = jest.fn(() => (tick += 5));
+
+    const result = await checkSorobanContractHealth(config(), probe(), { now });
+
+    expect(result.checkedAt).toBe(1_005);
+    expect(result.totalDurationMs).toBeGreaterThan(0);
+  });
+});

--- a/tests/providers/dependencies/dependency-graph.spec.ts
+++ b/tests/providers/dependencies/dependency-graph.spec.ts
@@ -1,0 +1,298 @@
+import {
+  StellarProviderDependencyGraph,
+  worstDependencyStatus,
+} from "../../../src/providers/dependencies/stellar";
+import {
+  healthyProviderIds,
+  summarizeProviderHealth,
+} from "../../../src/providers/health";
+
+/** A graph with two providers sharing one RPC endpoint. */
+function graphWithSharedRpc() {
+  const graph = new StellarProviderDependencyGraph({ now: () => 1_000 });
+
+  graph.addDependency({ id: "rpc-main", kind: "rpc", label: "Soroban RPC", critical: true });
+  graph.addDependency({ id: "pool-a", kind: "contract", label: "Pool A", critical: true });
+  graph.addDependency({ id: "prices", kind: "api", label: "Price API", critical: false });
+
+  graph.addProvider({ id: "alpha", name: "Alpha Bridge", dependencyIds: ["rpc-main", "pool-a"] });
+  graph.addProvider({ id: "beta", name: "Beta Bridge", dependencyIds: ["rpc-main", "prices"] });
+
+  return graph;
+}
+
+/** Mark every dependency healthy so a test can isolate one failure. */
+function allHealthy(graph: StellarProviderDependencyGraph) {
+  for (const dependency of graph.listDependencies()) {
+    graph.recordDependencyHealth(dependency.id, "healthy");
+  }
+}
+
+describe("worstDependencyStatus", () => {
+  it("picks the most severe", () => {
+    expect(worstDependencyStatus(["healthy", "degraded", "unhealthy"])).toBe("unhealthy");
+    expect(worstDependencyStatus(["healthy", "unknown"])).toBe("unknown");
+  });
+
+  it("is unknown for an empty list", () => {
+    expect(worstDependencyStatus([])).toBe("unknown");
+  });
+});
+
+describe("StellarProviderDependencyGraph", () => {
+  it("registers dependencies and providers", () => {
+    const graph = graphWithSharedRpc();
+
+    expect(graph.listDependencies().map((entry) => entry.id).sort()).toEqual([
+      "pool-a",
+      "prices",
+      "rpc-main",
+    ]);
+    expect(graph.listProviders().map((entry) => entry.id).sort()).toEqual(["alpha", "beta"]);
+  });
+
+  // A provider pointing at a dependency that does not exist would have
+  // nothing to check and would silently report healthy.
+  it("refuses a provider that declares an unknown dependency", () => {
+    const graph = new StellarProviderDependencyGraph();
+
+    expect(() =>
+      graph.addProvider({ id: "x", name: "X", dependencyIds: ["nope"] }),
+    ).toThrow("unknown dependencies");
+  });
+
+  it("refuses health for an unknown dependency", () => {
+    const graph = new StellarProviderDependencyGraph();
+
+    expect(() => graph.recordDependencyHealth("nope", "healthy")).toThrow("Unknown dependency");
+  });
+
+  it("starts every dependency as unknown", () => {
+    const graph = graphWithSharedRpc();
+
+    expect(graph.dependencyStatus("rpc-main")).toMatchObject({ status: "unknown", updatedAt: 0 });
+  });
+
+  it("records health with a reason and a timestamp", () => {
+    const graph = graphWithSharedRpc();
+
+    graph.recordDependencyHealth("rpc-main", "unhealthy", "connection refused");
+
+    expect(graph.dependencyStatus("rpc-main")).toMatchObject({
+      status: "unhealthy",
+      reason: "connection refused",
+      updatedAt: 1_000,
+    });
+  });
+
+  // ── Attribution ─────────────────────────────────────────────────────
+
+  it("names the providers that depend on something", () => {
+    const graph = graphWithSharedRpc();
+
+    expect(graph.providersAffectedBy("rpc-main").map((entry) => entry.id).sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+    expect(graph.providersAffectedBy("pool-a").map((entry) => entry.id)).toEqual(["alpha"]);
+  });
+
+  it("predicts impact without recording a failure", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    expect(graph.impactOf("rpc-main")).toEqual({ unhealthy: ["alpha", "beta"], degraded: [] });
+    expect(graph.impactOf("prices")).toEqual({ unhealthy: [], degraded: ["beta"] });
+
+    // Nothing was actually recorded.
+    expect(graph.providerHealth("alpha").status).toBe("healthy");
+  });
+
+  // ── Provider health derivation ──────────────────────────────────────
+
+  it("is healthy when every dependency is healthy", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    expect(graph.providerHealth("alpha").status).toBe("healthy");
+    expect(graph.providerHealth("alpha").summary).toContain("healthy");
+  });
+
+  it("is unhealthy when a critical dependency fails", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("rpc-main", "unhealthy", "connection refused");
+
+    const report = graph.providerHealth("alpha");
+
+    expect(report.status).toBe("unhealthy");
+    expect(report.criticalFailures.map((entry) => entry.dependencyId)).toEqual(["rpc-main"]);
+    expect(report.summary).toContain("Soroban RPC");
+  });
+
+  // The distinction that makes the graph worth having: a price feed going
+  // down degrades quality, an RPC going down stops the provider.
+  it("is only degraded when a non-critical dependency fails", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("prices", "unhealthy", "429");
+
+    const report = graph.providerHealth("beta");
+
+    expect(report.status).toBe("degraded");
+    expect(report.criticalFailures).toEqual([]);
+    expect(report.failing.map((entry) => entry.dependencyId)).toEqual(["prices"]);
+  });
+
+  it("is degraded when a critical dependency is degraded rather than down", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("rpc-main", "degraded", "elevated latency");
+
+    expect(graph.providerHealth("alpha").status).toBe("degraded");
+  });
+
+  // Claiming health for something never checked is how a dashboard ends up
+  // lying.
+  it("is unknown while a critical dependency has never reported", () => {
+    const graph = graphWithSharedRpc();
+
+    graph.recordDependencyHealth("pool-a", "healthy");
+
+    const report = graph.providerHealth("alpha");
+
+    expect(report.status).toBe("unknown");
+    expect(report.unknown.map((entry) => entry.dependencyId)).toEqual(["rpc-main"]);
+  });
+
+  it("is unknown for a provider with no dependencies declared", () => {
+    const graph = new StellarProviderDependencyGraph();
+
+    graph.addProvider({ id: "bare", name: "Bare", dependencyIds: [] });
+
+    expect(graph.providerHealth("bare").status).toBe("unknown");
+    expect(graph.providerHealth("bare").summary).toContain("No dependencies");
+  });
+
+  it("prefers unhealthy over degraded when both apply", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("rpc-main", "unhealthy");
+    graph.recordDependencyHealth("prices", "degraded");
+
+    expect(graph.providerHealth("beta").status).toBe("unhealthy");
+  });
+
+  it("refuses health for an unknown provider", () => {
+    const graph = graphWithSharedRpc();
+
+    expect(() => graph.providerHealth("nope")).toThrow("Unknown provider");
+  });
+
+  // One shared endpoint failing takes down everything that leans on it —
+  // which is the situation the graph exists to make obvious.
+  it("fans a shared failure out to every dependent provider", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("rpc-main", "unhealthy", "connection refused");
+
+    expect(graph.providerHealth("alpha").status).toBe("unhealthy");
+    expect(graph.providerHealth("beta").status).toBe("unhealthy");
+  });
+
+  it("leaves unrelated providers alone", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("pool-a", "unhealthy");
+
+    expect(graph.providerHealth("alpha").status).toBe("unhealthy");
+    expect(graph.providerHealth("beta").status).toBe("healthy");
+  });
+});
+
+describe("summarizeProviderHealth", () => {
+  it("counts providers by status", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+    graph.recordDependencyHealth("prices", "unhealthy");
+
+    const overview = summarizeProviderHealth(graph);
+
+    expect(overview.total).toBe(2);
+    expect(overview.healthy).toBe(1);
+    expect(overview.degraded).toBe(1);
+    expect(overview.overall).toBe("degraded");
+  });
+
+  it("orders failing providers worst first", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("pool-a", "unhealthy");
+    graph.recordDependencyHealth("prices", "degraded");
+
+    expect(summarizeProviderHealth(graph).failing.map((entry) => entry.providerId)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  // Five providers failing for one reason is one problem, not five.
+  it("groups failures by the dependency responsible", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("rpc-main", "unhealthy", "connection refused");
+
+    const [rootCause] = summarizeProviderHealth(graph).rootCauses;
+
+    expect(rootCause.dependencyId).toBe("rpc-main");
+    expect(rootCause.label).toBe("Soroban RPC");
+    expect(rootCause.providerIds).toEqual(["alpha", "beta"]);
+  });
+
+  it("puts the widest blast radius first", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    graph.recordDependencyHealth("rpc-main", "unhealthy");
+    graph.recordDependencyHealth("prices", "unhealthy");
+
+    expect(summarizeProviderHealth(graph).rootCauses[0].dependencyId).toBe("rpc-main");
+  });
+
+  it("reports no root causes when everything is healthy", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    expect(summarizeProviderHealth(graph).rootCauses).toEqual([]);
+    expect(summarizeProviderHealth(graph).overall).toBe("healthy");
+  });
+});
+
+describe("healthyProviderIds", () => {
+  it("lists only providers that can serve", () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    expect(healthyProviderIds(graph).sort()).toEqual(["alpha", "beta"]);
+
+    graph.recordDependencyHealth("pool-a", "unhealthy");
+
+    expect(healthyProviderIds(graph)).toEqual(["beta"]);
+  });
+
+  // A provider whose dependencies have never reported is not known to be
+  // healthy, so it must not be handed traffic.
+  it("excludes providers whose health is unknown", () => {
+    const graph = graphWithSharedRpc();
+
+    expect(healthyProviderIds(graph)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1067
Closes #1068

**60 new tests, all passing. `pnpm run build` green.** Both features are new directories — no existing source file is touched.

---

## #1067 — Soroban contract integration health

`src/contracts/health/soroban/` runs four checks **in order**, because each is only meaningful if the previous one passed:

| Check | Question |
|---|---|
| Availability | Is the contract there at all? |
| Network | Did the *expected* network answer? |
| Interface | Are the methods the integration calls actually present? |
| Read | Do safe reads succeed, and return something sensible? |

Three decisions worth a reviewer's eye:

**When the contract is absent, the later checks are skipped rather than failed.** Reporting "interface check failed" for a contract that doesn't exist buries the one fact that matters. Each skip records *why* it was skipped, so nothing looks silently unrun.

**A wrong network is `unhealthy`, not a warning.** A contract answering from testnet when the integration is configured for mainnet is *worse* than one that doesn't answer — the integration looks fine while reading someone else's state, and everything downstream trusts it.

**Severity is graded, not binary.** A missing method or a wrong network means the integration cannot work → `unhealthy`. A failing read on an otherwise correct contract → `degraded`: the wiring is right and the fault may well be transient. Those warrant different responses, and collapsing them loses the distinction.

Every probe is bounded by a timeout. An integration that never answers is not healthy, and without a bound the health check would hang along with it — there are tests for a hanging availability probe and a hanging read.

`readProbes` accept an optional `expect` assertion, because a read that returns *something* is weaker evidence than a read that returns something sensible — a contract can answer while being wired to the wrong asset.

### Monitoring

`src/monitoring/contracts/` aggregates results and keeps a short history. History matters: a single failing check cannot tell an RPC blip from an integration that's been broken since deploy, and `isPersistentlyFailing` is exactly that distinction.

- A sweep where one contract throws yields `unknown` for that one rather than failing the sweep — one unreachable integration must not hide the status of the others.
- **An empty monitor reports `unknown`, not `healthy`.** Saying "healthy" when nothing is registered would hide a misconfiguration where the contracts were never wired up.

## #1068 — Stellar bridge provider dependency graph

`src/providers/dependencies/stellar/` models what each provider needs — RPC, Horizon, contracts, liquidity sources, APIs — and derives provider health from it.

**The problem is attribution.** The symptom is "provider X is down"; the cause is usually one shared RPC endpoint or price API sitting underneath several providers. The graph turns that from an investigation into a lookup: record the dependency unhealthy once, and every dependent provider reports the reason rather than a bare failure.

The grading is the substance of the model:

- a **critical** dependency unhealthy → provider **unhealthy**; it cannot serve
- a critical dependency *degraded*, or a **non-critical** one unhealthy → provider **degraded**; it serves, worse
- a critical dependency that has **never reported** → **unknown**

That last case is deliberate. Claiming health for something never checked is how a dashboard ends up lying, so `healthyProviderIds` excludes unknown providers rather than handing them traffic.

"Critical" here means *the provider cannot serve without it* — not merely "important". A price API going down degrades quote quality; an RPC endpoint going down stops the provider dead, and reporting those identically makes the signal useless.

Two things that fall out of the model:

- **A provider declaring an unregistered dependency is rejected at registration.** It would otherwise have nothing to check and silently report healthy — the worst possible failure for a health system.
- **`impactOf` answers "is this endpoint safe to take out of rotation?"** without recording a failure first.

`src/providers/health/` rolls this into a fleet view. `rootCauses` groups failures by the dependency responsible, **widest blast radius first**: five providers failing for one reason is one problem, not five, and that's the view an operator actually wants at 3am.

---

## Verification

```
pnpm exec jest tests/contracts tests/providers    60 passed
pnpm run build                                    green  (this is CI's gate)
eslint on every new src file                      clean
tsc --noEmit                                      clean
```

## Two notes for the maintainers

**`node_modules` is tracked in this repository** — 13,336 files. Installing dependencies locally modifies or restructures thousands of them, which makes `git add -A` actively dangerous here. Only the 13 source and test files are in this commit; nothing under `node_modules` is included. Worth `.gitignore`-ing separately, but that's a large, disruptive change and not mine to make inside a feature PR.

**CI doesn't run the TypeScript tests.** The workflow does `pnpm install`, `pnpm run build`, then `cargo test` — so `jest` never runs on a PR, and neither these 60 tests nor any existing suite gates a merge. Adding `pnpm test` to that job would be a one-line change; happy to open it separately.

Separately, and unrelated to this PR: the root `pnpm-lock.yaml` is `lockfileVersion: 6.0` (pnpm 8 format) while `packageManager` pins `pnpm@10.30.2`. Locally, pnpm 10 refuses it with `ERR_PNPM_LOCKFILE_BREAKING_CHANGE` under `--frozen-lockfile`; CI resolves a version that accepts it, so this isn't breaking your pipeline today, but a contributor following `packageManager` will hit it. I left the lockfile untouched rather than regenerate it into this PR.
