### PR TITLE
feat(security): Soroban deployment fingerprinting and contract upgrade detection

### DIFF
--- a/src/contracts/monitoring/contract-upgrade-monitor.ts
+++ b/src/contracts/monitoring/contract-upgrade-monitor.ts
@@ -1,0 +1,318 @@
+import { EventEmitter } from 'events';
+import { SorobanDeploymentVerifier } from '../verification/soroban-deployment-verifier';
+import { contractKey } from '../../security/contracts/fingerprints/deployment-fingerprint';
+import {
+  DeploymentObservation,
+  FingerprintNetwork,
+  VerificationResult,
+  VerificationStatus,
+} from '../../security/contracts/fingerprints/types';
+import { SorobanUpgradeDetector } from '../../security/contracts/upgrades/soroban/soroban-upgrade-detector';
+import { severityRank } from '../../security/contracts/upgrades/soroban/soroban-upgrade-detector';
+import {
+  IntegrationReviewFlag,
+  UpgradeEvent,
+  UpgradeSeverity,
+} from '../../security/contracts/upgrades/soroban/types';
+
+/** Reads the current on-chain state of one contract. */
+export type DeploymentProbe = () => Promise<DeploymentObservation>;
+
+export interface MonitoredContractInput {
+  contractAddress: string;
+  network: FingerprintNetwork;
+  probe: DeploymentProbe;
+  integrations?: string[];
+  label?: string;
+  baseline?: DeploymentObservation;
+}
+
+/** A monitoring sink — PagerDuty, a webhook, an internal alert bus. */
+export type UpgradeNotifier = (
+  notification: UpgradeNotification,
+) => void | Promise<void>;
+
+export interface UpgradeNotification {
+  event: UpgradeEvent;
+  verification?: VerificationResult;
+  affectedIntegrations: string[];
+  message: string;
+}
+
+export interface ContractUpgradeMonitorConfig {
+  checkIntervalMs?: number;
+  /** Probes slower than this are treated as failures. Default 10s. */
+  probeTimeoutMs?: number;
+  /** Severity at or above which `severe-upgrade` fires. Default MAJOR. */
+  alertSeverity?: UpgradeSeverity;
+}
+
+export interface CheckResult {
+  contractAddress: string;
+  network: FingerprintNetwork;
+  observed?: DeploymentObservation;
+  upgrade: UpgradeEvent | null;
+  verification?: VerificationResult;
+  error?: string;
+}
+
+/**
+ * Watches configured Soroban contracts for upgrades and tells the monitoring
+ * services about them.
+ *
+ * The monitor owns scheduling and fan-out only; what counts as an upgrade
+ * lives in `SorobanUpgradeDetector`, and what counts as approved lives in the
+ * fingerprint store.
+ */
+export class ContractUpgradeMonitor extends EventEmitter {
+  private readonly probes = new Map<string, MonitoredContractInput>();
+  private readonly notifiers: UpgradeNotifier[] = [];
+  private readonly config: Required<ContractUpgradeMonitorConfig>;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly detector: SorobanUpgradeDetector = new SorobanUpgradeDetector(),
+    private readonly verifier?: SorobanDeploymentVerifier,
+    config: ContractUpgradeMonitorConfig = {},
+  ) {
+    super();
+    this.config = {
+      checkIntervalMs: config.checkIntervalMs ?? 60_000,
+      probeTimeoutMs: config.probeTimeoutMs ?? 10_000,
+      alertSeverity: config.alertSeverity ?? UpgradeSeverity.MAJOR,
+    };
+  }
+
+  registerContract(input: MonitoredContractInput): void {
+    this.probes.set(contractKey(input.contractAddress, input.network), input);
+    this.detector.register({
+      contractAddress: input.contractAddress,
+      network: input.network,
+      integrations: input.integrations,
+      label: input.label,
+      baseline: input.baseline,
+    });
+  }
+
+  unregisterContract(
+    contractAddress: string,
+    network: FingerprintNetwork,
+  ): boolean {
+    return this.probes.delete(contractKey(contractAddress, network));
+  }
+
+  addNotifier(notifier: UpgradeNotifier): void {
+    this.notifiers.push(notifier);
+  }
+
+  getMonitoredContracts(): MonitoredContractInput[] {
+    return [...this.probes.values()];
+  }
+
+  async check(
+    contractAddress: string,
+    network: FingerprintNetwork,
+    now: number = Date.now(),
+  ): Promise<CheckResult> {
+    const monitored = this.probes.get(contractKey(contractAddress, network));
+
+    if (!monitored) {
+      throw new Error(
+        `Contract ${contractAddress} on ${network} is not monitored`,
+      );
+    }
+
+    return this.runProbe(monitored, now);
+  }
+
+  async checkAll(now: number = Date.now()): Promise<CheckResult[]> {
+    const results = await Promise.all(
+      [...this.probes.values()].map((monitored) =>
+        this.runProbe(monitored, now),
+      ),
+    );
+
+    this.emit('check-complete', results);
+
+    return results;
+  }
+
+  private async runProbe(
+    monitored: MonitoredContractInput,
+    now: number,
+  ): Promise<CheckResult> {
+    let observation: DeploymentObservation;
+
+    try {
+      observation = await this.withTimeout(monitored.probe(), monitored);
+    } catch (error) {
+      const message = messageOf(error);
+
+      // A probe failure is not an upgrade: leaving the tracked state alone
+      // means an unreachable node cannot look like a rollback.
+      this.emit('probe-error', {
+        contractAddress: monitored.contractAddress,
+        network: monitored.network,
+        error: message,
+      });
+
+      return {
+        contractAddress: monitored.contractAddress,
+        network: monitored.network,
+        upgrade: null,
+        error: message,
+      };
+    }
+
+    const verification = this.verifier?.verify(observation, now);
+
+    if (verification && verification.status !== VerificationStatus.APPROVED) {
+      this.emit('unapproved-deployment', verification);
+    }
+
+    const upgrade = this.detector.observe(observation, now);
+
+    if (upgrade) {
+      this.emit('upgrade', upgrade);
+
+      if (
+        severityRank(upgrade.severity) >=
+        severityRank(this.config.alertSeverity)
+      ) {
+        this.emit('severe-upgrade', upgrade);
+      }
+
+      await this.notify(upgrade, verification);
+    }
+
+    return {
+      contractAddress: monitored.contractAddress,
+      network: monitored.network,
+      observed: observation,
+      upgrade,
+      verification,
+    };
+  }
+
+  /**
+   * A hung probe would otherwise stall every later check on the interval, so
+   * the wait is bounded and a timeout is reported as a probe failure.
+   */
+  private withTimeout(
+    promise: Promise<DeploymentObservation>,
+    monitored: MonitoredContractInput,
+  ): Promise<DeploymentObservation> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(
+          new Error(
+            `Probe for ${monitored.contractAddress} timed out after ${this.config.probeTimeoutMs}ms`,
+          ),
+        );
+      }, this.config.probeTimeoutMs);
+
+      promise
+        .then((value) => {
+          clearTimeout(timer);
+          resolve(value);
+        })
+        .catch((error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+    });
+  }
+
+  /**
+   * Fan the upgrade out to the monitoring sinks.
+   *
+   * One sink throwing must not stop the others, and must not stop the check
+   * loop — a broken webhook is the worst possible reason to stop noticing
+   * contract upgrades.
+   */
+  private async notify(
+    event: UpgradeEvent,
+    verification?: VerificationResult,
+  ): Promise<void> {
+    const notification: UpgradeNotification = {
+      event,
+      verification,
+      affectedIntegrations: event.affectedIntegrations,
+      message: describeUpgrade(event),
+    };
+
+    for (const notifier of this.notifiers) {
+      try {
+        await notifier(notification);
+      } catch (error) {
+        this.emit('notifier-error', { error: messageOf(error), event });
+      }
+    }
+  }
+
+  start(intervalMs: number = this.config.checkIntervalMs): void {
+    if (this.timer) return;
+
+    this.timer = setInterval(() => {
+      void this.checkAll().catch((error) => {
+        this.emit('probe-error', { error: messageOf(error) });
+      });
+    }, intervalMs);
+
+    // Never hold the process open for a monitoring interval.
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  isRunning(): boolean {
+    return this.timer !== null;
+  }
+
+  getReviewFlags(integrationId?: string): IntegrationReviewFlag[] {
+    return this.detector.getReviewFlags(integrationId);
+  }
+
+  getUpgradeHistory(
+    contractAddress?: string,
+    network?: FingerprintNetwork,
+  ): UpgradeEvent[] {
+    return this.detector.getHistory(contractAddress, network);
+  }
+
+  destroy(): void {
+    this.stop();
+    this.probes.clear();
+    this.notifiers.length = 0;
+    this.removeAllListeners();
+  }
+}
+
+export function describeUpgrade(event: UpgradeEvent): string {
+  const affected =
+    event.affectedIntegrations.length > 0
+      ? ` Affected integrations: ${event.affectedIntegrations.join(', ')}.`
+      : '';
+
+  return `[${event.severity}] Contract ${event.contractAddress} on ${event.network} changed: ${event.details.join('; ')}.${affected}`;
+}
+
+/**
+ * `String(error)` on a plain object yields "[object Object]", which is worse
+ * than useless in an alert.
+ */
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+
+  try {
+    return JSON.stringify(error) ?? 'Unknown error';
+  } catch {
+    return 'Unknown error';
+  }
+}

--- a/src/contracts/monitoring/index.ts
+++ b/src/contracts/monitoring/index.ts
@@ -1,0 +1,1 @@
+export * from './contract-upgrade-monitor';

--- a/src/contracts/verification/index.ts
+++ b/src/contracts/verification/index.ts
@@ -1,0 +1,1 @@
+export * from './soroban-deployment-verifier';

--- a/src/contracts/verification/soroban-deployment-verifier.ts
+++ b/src/contracts/verification/soroban-deployment-verifier.ts
@@ -1,0 +1,168 @@
+import { ApprovedFingerprintStore } from '../../security/contracts/fingerprints/approved-fingerprint-store';
+import {
+  computeDeploymentFingerprint,
+  shortFingerprint,
+} from '../../security/contracts/fingerprints/deployment-fingerprint';
+import {
+  ApprovedFingerprint,
+  DeploymentFingerprint,
+  DeploymentObservation,
+  MismatchReason,
+  VerificationResult,
+  VerificationStatus,
+} from '../../security/contracts/fingerprints/types';
+
+/**
+ * Checks an observed Soroban deployment against the approved fingerprints.
+ *
+ * The three failure modes are kept distinct because they call for different
+ * responses: an unknown contract needs an approval decision, a mismatch needs
+ * investigation, and a revoked deployment needs the integration stopped.
+ */
+export class SorobanDeploymentVerifier {
+  constructor(private readonly store: ApprovedFingerprintStore) {}
+
+  verify(
+    observation: DeploymentObservation,
+    now: number = Date.now(),
+  ): VerificationResult {
+    const observed = computeDeploymentFingerprint(observation, now);
+    const { contractAddress, network } = observed;
+
+    const match = this.store.find(
+      contractAddress,
+      network,
+      observed.fingerprint,
+    );
+
+    if (match && !match.revokedAt) {
+      return {
+        contractAddress,
+        network,
+        status: VerificationStatus.APPROVED,
+        observed,
+        matched: match,
+        reasons: [],
+        differences: [],
+        verifiedAt: now,
+      };
+    }
+
+    if (match?.revokedAt) {
+      return {
+        contractAddress,
+        network,
+        status: VerificationStatus.REVOKED,
+        observed,
+        matched: match,
+        reasons: [MismatchReason.FINGERPRINT_REVOKED],
+        differences: [
+          match.revokedReason
+            ? `Deployment was revoked: ${match.revokedReason}`
+            : 'Deployment was revoked',
+        ],
+        verifiedAt: now,
+      };
+    }
+
+    const comparedAgainst = this.store.latestActive(contractAddress, network);
+
+    if (!comparedAgainst) {
+      return {
+        contractAddress,
+        network,
+        status: VerificationStatus.UNKNOWN,
+        observed,
+        reasons: [MismatchReason.NO_APPROVED_FINGERPRINT],
+        differences: [
+          `No approved fingerprint recorded for ${contractAddress} on ${network}`,
+        ],
+        verifiedAt: now,
+      };
+    }
+
+    const { reasons, differences } = diffFingerprints(
+      comparedAgainst.details,
+      observed,
+    );
+
+    return {
+      contractAddress,
+      network,
+      status: VerificationStatus.MISMATCH,
+      observed,
+      comparedAgainst,
+      reasons,
+      differences,
+      verifiedAt: now,
+    };
+  }
+
+  verifyMany(
+    observations: DeploymentObservation[],
+    now: number = Date.now(),
+  ): VerificationResult[] {
+    return observations.map((observation) => this.verify(observation, now));
+  }
+
+  /** True only for an active, matching approval. */
+  isVerified(
+    observation: DeploymentObservation,
+    now: number = Date.now(),
+  ): boolean {
+    return this.verify(observation, now).status === VerificationStatus.APPROVED;
+  }
+
+  /** Record the observed deployment as the approved one. */
+  approve(
+    observation: DeploymentObservation,
+    options: {
+      label?: string;
+      approvedBy?: string;
+      notes?: string;
+      now?: number;
+    } = {},
+  ): ApprovedFingerprint {
+    const now = options.now ?? Date.now();
+
+    return this.store.approve({
+      details: computeDeploymentFingerprint(observation, now),
+      label: options.label,
+      approvedBy: options.approvedBy,
+      notes: options.notes,
+      approvedAt: now,
+    });
+  }
+}
+
+/** Why two fingerprints differ, in terms an operator can act on. */
+export function diffFingerprints(
+  approved: DeploymentFingerprint,
+  observed: DeploymentFingerprint,
+): { reasons: MismatchReason[]; differences: string[] } {
+  const reasons: MismatchReason[] = [];
+  const differences: string[] = [];
+
+  if (approved.wasmHash !== observed.wasmHash) {
+    reasons.push(MismatchReason.WASM_HASH_CHANGED);
+    differences.push(
+      `Wasm hash ${shortFingerprint(approved.wasmHash)} → ${shortFingerprint(observed.wasmHash)}`,
+    );
+  }
+
+  if (approved.interfaceDigest !== observed.interfaceDigest) {
+    reasons.push(MismatchReason.INTERFACE_CHANGED);
+    differences.push(
+      `Interface digest ${shortFingerprint(approved.interfaceDigest)} → ${shortFingerprint(observed.interfaceDigest)}`,
+    );
+  }
+
+  if ((approved.specVersion ?? '') !== (observed.specVersion ?? '')) {
+    reasons.push(MismatchReason.SPEC_VERSION_CHANGED);
+    differences.push(
+      `Spec version ${approved.specVersion ?? 'none'} → ${observed.specVersion ?? 'none'}`,
+    );
+  }
+
+  return { reasons, differences };
+}

--- a/src/security/contracts/fingerprints/approved-fingerprint-store.ts
+++ b/src/security/contracts/fingerprints/approved-fingerprint-store.ts
@@ -1,0 +1,187 @@
+import { contractKey } from './deployment-fingerprint';
+import {
+  ApproveFingerprintInput,
+  ApprovedFingerprint,
+  FingerprintNetwork,
+} from './types';
+
+/**
+ * Storage for the deployments an operator has approved.
+ *
+ * In memory by design — persistence differs per deployment target, so the
+ * store exposes `snapshot()` / `restore()` and leaves the medium to the
+ * caller rather than assuming a database.
+ */
+export class ApprovedFingerprintStore {
+  private readonly byContract = new Map<string, ApprovedFingerprint[]>();
+
+  /**
+   * Approve a deployment.
+   *
+   * Re-approving the same fingerprint updates the existing record instead of
+   * adding a duplicate — and un-revokes it, since approving something that was
+   * revoked is an explicit decision to trust it again.
+   */
+  approve(input: ApproveFingerprintInput): ApprovedFingerprint {
+    const { details } = input;
+    const key = contractKey(details.contractAddress, details.network);
+    const existing = this.byContract.get(key) ?? [];
+    const previous = existing.find(
+      (entry) => entry.fingerprint === details.fingerprint,
+    );
+
+    const record: ApprovedFingerprint = {
+      fingerprint: details.fingerprint,
+      contractAddress: details.contractAddress,
+      network: details.network,
+      details,
+      label: input.label ?? previous?.label,
+      approvedAt: input.approvedAt ?? Date.now(),
+      approvedBy: input.approvedBy ?? previous?.approvedBy,
+      notes: input.notes ?? previous?.notes,
+    };
+
+    this.byContract.set(
+      key,
+      previous
+        ? existing.map((entry) =>
+            entry.fingerprint === record.fingerprint ? record : entry,
+          )
+        : [...existing, record],
+    );
+
+    return record;
+  }
+
+  /** Every approval recorded for a contract, revoked ones included. */
+  listForContract(
+    contractAddress: string,
+    network: FingerprintNetwork,
+  ): ApprovedFingerprint[] {
+    return [
+      ...(this.byContract.get(contractKey(contractAddress, network)) ?? []),
+    ];
+  }
+
+  listActiveForContract(
+    contractAddress: string,
+    network: FingerprintNetwork,
+  ): ApprovedFingerprint[] {
+    return this.listForContract(contractAddress, network).filter(
+      (entry) => !entry.revokedAt,
+    );
+  }
+
+  find(
+    contractAddress: string,
+    network: FingerprintNetwork,
+    fingerprint: string,
+  ): ApprovedFingerprint | undefined {
+    return this.listForContract(contractAddress, network).find(
+      (entry) => entry.fingerprint === fingerprint,
+    );
+  }
+
+  isApproved(
+    contractAddress: string,
+    network: FingerprintNetwork,
+    fingerprint: string,
+  ): boolean {
+    const entry = this.find(contractAddress, network, fingerprint);
+
+    return Boolean(entry && !entry.revokedAt);
+  }
+
+  /** The approval to compare a mismatch against — the most recently approved active one. */
+  latestActive(
+    contractAddress: string,
+    network: FingerprintNetwork,
+  ): ApprovedFingerprint | undefined {
+    return this.listActiveForContract(contractAddress, network).sort(
+      (a, b) => b.approvedAt - a.approvedAt,
+    )[0];
+  }
+
+  /**
+   * Withdraw trust from a deployment.
+   *
+   * The record is kept rather than deleted: "this was approved and then
+   * revoked" is a different, more useful answer than "never heard of it".
+   */
+  revoke(
+    contractAddress: string,
+    network: FingerprintNetwork,
+    fingerprint: string,
+    reason?: string,
+    revokedAt: number = Date.now(),
+  ): ApprovedFingerprint | undefined {
+    const entry = this.find(contractAddress, network, fingerprint);
+
+    if (!entry) return undefined;
+
+    const revoked: ApprovedFingerprint = {
+      ...entry,
+      revokedAt,
+      revokedReason: reason,
+    };
+    const key = contractKey(contractAddress, network);
+
+    this.byContract.set(
+      key,
+      (this.byContract.get(key) ?? []).map((item) =>
+        item.fingerprint === fingerprint ? revoked : item,
+      ),
+    );
+
+    return revoked;
+  }
+
+  remove(
+    contractAddress: string,
+    network: FingerprintNetwork,
+    fingerprint: string,
+  ): boolean {
+    const key = contractKey(contractAddress, network);
+    const existing = this.byContract.get(key) ?? [];
+    const remaining = existing.filter(
+      (entry) => entry.fingerprint !== fingerprint,
+    );
+
+    if (remaining.length === existing.length) return false;
+
+    if (remaining.length === 0) {
+      this.byContract.delete(key);
+    } else {
+      this.byContract.set(key, remaining);
+    }
+
+    return true;
+  }
+
+  size(): number {
+    return [...this.byContract.values()].reduce(
+      (total, list) => total + list.length,
+      0,
+    );
+  }
+
+  clear(): void {
+    this.byContract.clear();
+  }
+
+  /** Flat list for persistence. */
+  snapshot(): ApprovedFingerprint[] {
+    return [...this.byContract.values()].flat();
+  }
+
+  /** Replace the contents from a previous snapshot. */
+  restore(entries: ApprovedFingerprint[]): void {
+    this.byContract.clear();
+
+    for (const entry of entries) {
+      const key = contractKey(entry.contractAddress, entry.network);
+
+      this.byContract.set(key, [...(this.byContract.get(key) ?? []), entry]);
+    }
+  }
+}

--- a/src/security/contracts/fingerprints/deployment-fingerprint.ts
+++ b/src/security/contracts/fingerprints/deployment-fingerprint.ts
@@ -1,0 +1,159 @@
+import { createHash } from 'crypto';
+import {
+  ContractInterfaceSurface,
+  DeploymentFingerprint,
+  DeploymentObservation,
+  EMPTY_INTERFACE,
+  FingerprintNetwork,
+} from './types';
+
+/**
+ * Deterministic fingerprinting of Soroban deployments.
+ *
+ * Determinism is the whole point: the same deployment observed from two
+ * different nodes, at different times, in a different field order, must
+ * produce the same string — otherwise every comparison is a false alarm.
+ */
+
+function sha256(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+/** Contract addresses are upper-case base32; normalize so case cannot fork identity. */
+export function normalizeContractAddress(address: string): string {
+  const normalized = address?.trim().toUpperCase();
+
+  if (!normalized) {
+    throw new Error('Contract address is required to fingerprint a deployment');
+  }
+
+  return normalized;
+}
+
+/**
+ * Wasm hashes are hex. A non-hex value (a base64 hash, a truncated log line)
+ * would still fingerprint cleanly and then never match anything, so it is
+ * rejected at the door rather than becoming a silent permanent mismatch.
+ */
+export function normalizeWasmHash(wasmHash: string): string {
+  const normalized = wasmHash?.trim().toLowerCase().replace(/^0x/, '');
+
+  if (!normalized) {
+    throw new Error('Wasm hash is required to fingerprint a deployment');
+  }
+
+  if (!/^[0-9a-f]+$/.test(normalized)) {
+    throw new Error(`Wasm hash must be hex encoded, received: ${wasmHash}`);
+  }
+
+  return normalized;
+}
+
+/**
+ * Sort and de-duplicate the interface surface.
+ *
+ * Two nodes can enumerate a contract spec in different orders; that is not an
+ * interface change and must not read as one.
+ */
+export function canonicalizeInterface(
+  surface: ContractInterfaceSurface = EMPTY_INTERFACE,
+): ContractInterfaceSurface {
+  const unique = (values: string[] = []) =>
+    [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort();
+
+  return {
+    functions: unique(surface.functions),
+    events: unique(surface.events),
+    errors: [...new Set(surface.errors ?? [])].sort((a, b) => a - b),
+  };
+}
+
+export function computeInterfaceDigest(
+  surface?: ContractInterfaceSurface,
+): string {
+  const canonical = canonicalizeInterface(surface);
+
+  return sha256(
+    JSON.stringify([canonical.functions, canonical.events, canonical.errors]),
+  );
+}
+
+/** Digest of an empty surface — what a deployment with no known spec fingerprints as. */
+export const EMPTY_INTERFACE_DIGEST = computeInterfaceDigest(EMPTY_INTERFACE);
+
+/**
+ * The identity payload.
+ *
+ * An array rather than a delimited string: with `address|network|hash`, an
+ * address containing the delimiter could impersonate another deployment.
+ * JSON of a fixed-length array has no such ambiguity.
+ */
+function identityPayload(
+  contractAddress: string,
+  network: FingerprintNetwork,
+  wasmHash: string,
+  specVersion: string,
+  interfaceDigest: string,
+): string {
+  return JSON.stringify([
+    contractAddress,
+    network,
+    wasmHash,
+    specVersion,
+    interfaceDigest,
+  ]);
+}
+
+export function computeDeploymentFingerprint(
+  observation: DeploymentObservation,
+  now: number = Date.now(),
+): DeploymentFingerprint {
+  const contractAddress = normalizeContractAddress(observation.contractAddress);
+  const wasmHash = normalizeWasmHash(observation.wasmHash);
+  const network = observation.network;
+
+  if (!network) {
+    throw new Error('Network is required to fingerprint a deployment');
+  }
+
+  const specVersion = observation.specVersion?.trim() ?? '';
+  const interfaceDigest = computeInterfaceDigest(observation.interface);
+
+  return {
+    fingerprint: sha256(
+      identityPayload(
+        contractAddress,
+        network,
+        wasmHash,
+        specVersion,
+        interfaceDigest,
+      ),
+    ),
+    contractAddress,
+    network,
+    wasmHash,
+    specVersion: specVersion || undefined,
+    interfaceDigest,
+    computedAt: now,
+  };
+}
+
+export function fingerprintsMatch(
+  left: DeploymentFingerprint,
+  right: DeploymentFingerprint,
+): boolean {
+  return left.fingerprint === right.fingerprint;
+}
+
+/** Key under which a contract's approvals are grouped — network-scoped by design. */
+export function contractKey(
+  contractAddress: string,
+  network: FingerprintNetwork,
+): string {
+  return `${network}:${normalizeContractAddress(contractAddress)}`;
+}
+
+/** Short form for log lines and alert messages. */
+export function shortFingerprint(fingerprint: string, length = 12): string {
+  return fingerprint.slice(0, length);
+}

--- a/src/security/contracts/fingerprints/index.ts
+++ b/src/security/contracts/fingerprints/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './deployment-fingerprint';
+export * from './approved-fingerprint-store';

--- a/src/security/contracts/fingerprints/types.ts
+++ b/src/security/contracts/fingerprints/types.ts
@@ -1,0 +1,118 @@
+/**
+ * Soroban deployment fingerprinting types.
+ *
+ * A fingerprint answers one question: is the contract we are talking to right
+ * now the same deployment we approved? It therefore covers only the fields
+ * that define a deployment's identity — never when or how we observed it.
+ */
+
+/** Stellar network a deployment lives on. */
+export enum FingerprintNetwork {
+  TESTNET = 'testnet',
+  PUBLIC = 'public',
+  FUTURENET = 'futurenet',
+  STANDALONE = 'standalone',
+}
+
+/**
+ * The interface surface of a deployment.
+ *
+ * Function entries are canonical signatures (`transfer(from:address,to:address,amount:i128):bool`)
+ * rather than bare names, so a changed parameter list is visible in the digest.
+ */
+export interface ContractInterfaceSurface {
+  functions: string[];
+  events: string[];
+  errors: number[];
+}
+
+/** A deployment as observed on-chain or read from a registry. */
+export interface DeploymentObservation {
+  contractAddress: string;
+  network: FingerprintNetwork;
+  /** Hex hash of the deployed wasm. */
+  wasmHash: string;
+  specVersion?: string;
+  interface?: ContractInterfaceSurface;
+  /** Observation-time context. Deliberately excluded from the fingerprint. */
+  observedAt?: number;
+  deployedAt?: number;
+  deployerAddress?: string;
+  txHash?: string;
+}
+
+/** Deterministic identity of a deployment. */
+export interface DeploymentFingerprint {
+  /** sha256 over the canonical identity payload, hex encoded. */
+  fingerprint: string;
+  contractAddress: string;
+  network: FingerprintNetwork;
+  wasmHash: string;
+  specVersion?: string;
+  /** sha256 over the canonical interface surface. */
+  interfaceDigest: string;
+  computedAt: number;
+}
+
+/** An operator-approved deployment. */
+export interface ApprovedFingerprint {
+  fingerprint: string;
+  contractAddress: string;
+  network: FingerprintNetwork;
+  /** Full detail of what was approved, so a mismatch can say what differs. */
+  details: DeploymentFingerprint;
+  label?: string;
+  approvedAt: number;
+  approvedBy?: string;
+  notes?: string;
+  revokedAt?: number;
+  revokedReason?: string;
+}
+
+export interface ApproveFingerprintInput {
+  details: DeploymentFingerprint;
+  label?: string;
+  approvedBy?: string;
+  notes?: string;
+  approvedAt?: number;
+}
+
+export enum VerificationStatus {
+  /** Matches an active approved fingerprint. */
+  APPROVED = 'approved',
+  /** The contract has approvals, but this deployment is not one of them. */
+  MISMATCH = 'mismatch',
+  /** Matches an approval that has since been revoked. */
+  REVOKED = 'revoked',
+  /** Nothing has ever been approved for this contract on this network. */
+  UNKNOWN = 'unknown',
+}
+
+export enum MismatchReason {
+  WASM_HASH_CHANGED = 'wasm_hash_changed',
+  INTERFACE_CHANGED = 'interface_changed',
+  SPEC_VERSION_CHANGED = 'spec_version_changed',
+  NO_APPROVED_FINGERPRINT = 'no_approved_fingerprint',
+  FINGERPRINT_REVOKED = 'fingerprint_revoked',
+}
+
+export interface VerificationResult {
+  contractAddress: string;
+  network: FingerprintNetwork;
+  status: VerificationStatus;
+  observed: DeploymentFingerprint;
+  /** The approval this deployment matched, when it matched one. */
+  matched?: ApprovedFingerprint;
+  /** The approval a mismatch was compared against — the most recent active one. */
+  comparedAgainst?: ApprovedFingerprint;
+  reasons: MismatchReason[];
+  /** Human-readable differences, for logs and alerts. */
+  differences: string[];
+  verifiedAt: number;
+}
+
+export const EMPTY_INTERFACE: ContractInterfaceSurface = {
+  functions: [],
+  events: [],
+  errors: [],
+};

--- a/src/security/contracts/upgrades/soroban/index.ts
+++ b/src/security/contracts/upgrades/soroban/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './soroban-upgrade-detector';

--- a/src/security/contracts/upgrades/soroban/soroban-upgrade-detector.ts
+++ b/src/security/contracts/upgrades/soroban/soroban-upgrade-detector.ts
@@ -1,0 +1,470 @@
+import {
+  canonicalizeInterface,
+  computeDeploymentFingerprint,
+  contractKey,
+  normalizeContractAddress,
+  shortFingerprint,
+} from '../../fingerprints/deployment-fingerprint';
+import {
+  ContractInterfaceSurface,
+  DeploymentFingerprint,
+  DeploymentObservation,
+  FingerprintNetwork,
+} from '../../fingerprints/types';
+import {
+  IntegrationReviewFlag,
+  RegisterContractInput,
+  TrackedContractState,
+  UpgradeDetectorConfig,
+  UpgradeEvent,
+  UpgradeIndicator,
+  UpgradeSeverity,
+} from './types';
+
+const DEFAULT_MAX_HISTORY = 500;
+
+/**
+ * Tracks configured Soroban contracts and detects upgrades behind their
+ * addresses.
+ *
+ * State is compared by deployment fingerprint rather than by any single
+ * field, so an upgrade that keeps the interface identical — the case most
+ * likely to go unnoticed — is still caught.
+ */
+export class SorobanUpgradeDetector {
+  private readonly states = new Map<string, TrackedContractState>();
+  private readonly history: UpgradeEvent[] = [];
+  private readonly flags: IntegrationReviewFlag[] = [];
+  /** Integrations and labels configured before the first observation arrived. */
+  private readonly pending = new Map<
+    string,
+    { integrations: string[]; label?: string }
+  >();
+  private readonly config: Required<UpgradeDetectorConfig>;
+  private eventCounter = 0;
+
+  constructor(config: UpgradeDetectorConfig = {}) {
+    this.config = {
+      maxHistory: config.maxHistory ?? DEFAULT_MAX_HISTORY,
+      treatRedeployAsUpgrade: config.treatRedeployAsUpgrade ?? true,
+    };
+  }
+
+  /**
+   * Configure a contract to track.
+   *
+   * Registering again keeps the tracked state and merges the integration list,
+   * so re-reading config at startup cannot erase what is already known.
+   */
+  register(
+    input: RegisterContractInput,
+    now: number = Date.now(),
+  ): TrackedContractState | null {
+    const key = contractKey(input.contractAddress, input.network);
+    const existing = this.states.get(key);
+
+    if (existing) {
+      const merged = [
+        ...new Set([...existing.integrations, ...(input.integrations ?? [])]),
+      ];
+
+      this.states.set(key, {
+        ...existing,
+        integrations: merged,
+        label: input.label ?? existing.label,
+      });
+
+      return this.states.get(key) ?? null;
+    }
+
+    if (!input.baseline) {
+      // Nothing to compare yet; the first observation becomes the baseline.
+      this.pending.set(key, {
+        integrations: [...new Set(input.integrations ?? [])],
+        label: input.label,
+      });
+
+      return null;
+    }
+
+    const fingerprint = computeDeploymentFingerprint(input.baseline, now);
+    const state: TrackedContractState = {
+      contractAddress: fingerprint.contractAddress,
+      network: fingerprint.network,
+      fingerprint,
+      interfaceSurface: canonicalizeInterface(input.baseline.interface),
+      integrations: [...new Set(input.integrations ?? [])],
+      label: input.label,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      lastTxHash: input.baseline.txHash,
+      upgradeCount: 0,
+    };
+
+    this.states.set(key, state);
+
+    return state;
+  }
+
+  /**
+   * Record an observation.
+   *
+   * Returns the upgrade event when the deployment changed, and `null` when it
+   * is unchanged or is the first thing seen for this contract.
+   */
+  observe(
+    observation: DeploymentObservation,
+    now: number = Date.now(),
+  ): UpgradeEvent | null {
+    const fingerprint = computeDeploymentFingerprint(observation, now);
+    const key = contractKey(fingerprint.contractAddress, fingerprint.network);
+    const previous = this.states.get(key);
+    const surface = canonicalizeInterface(observation.interface);
+
+    if (!previous) {
+      const configured = this.pending.get(key);
+
+      this.pending.delete(key);
+      this.states.set(key, {
+        contractAddress: fingerprint.contractAddress,
+        network: fingerprint.network,
+        fingerprint,
+        interfaceSurface: surface,
+        integrations: configured?.integrations ?? [],
+        label: configured?.label,
+        firstSeenAt: now,
+        lastSeenAt: now,
+        lastTxHash: observation.txHash,
+        upgradeCount: 0,
+      });
+
+      return null;
+    }
+
+    const redeployed =
+      Boolean(observation.txHash) &&
+      Boolean(previous.lastTxHash) &&
+      observation.txHash !== previous.lastTxHash;
+
+    const changed =
+      previous.fingerprint.fingerprint !== fingerprint.fingerprint;
+
+    if (!changed && !(redeployed && this.config.treatRedeployAsUpgrade)) {
+      this.states.set(key, {
+        ...previous,
+        lastSeenAt: now,
+        lastTxHash: observation.txHash ?? previous.lastTxHash,
+      });
+
+      return null;
+    }
+
+    const event = this.buildEvent(
+      previous,
+      fingerprint,
+      surface,
+      observation,
+      redeployed,
+      now,
+    );
+
+    this.states.set(key, {
+      ...previous,
+      fingerprint,
+      interfaceSurface: surface,
+      lastSeenAt: now,
+      lastTxHash: observation.txHash ?? previous.lastTxHash,
+      upgradeCount: previous.upgradeCount + 1,
+    });
+
+    this.recordEvent(event);
+    this.flagIntegrations(event, now);
+
+    return event;
+  }
+
+  private buildEvent(
+    previous: TrackedContractState,
+    current: DeploymentFingerprint,
+    surface: ContractInterfaceSurface,
+    observation: DeploymentObservation,
+    redeployed: boolean,
+    now: number,
+  ): UpgradeEvent {
+    const indicators: UpgradeIndicator[] = [];
+    const details: string[] = [];
+    const before = previous.interfaceSurface ?? canonicalizeInterface();
+
+    if (previous.fingerprint.wasmHash !== current.wasmHash) {
+      indicators.push(UpgradeIndicator.WASM_HASH_CHANGED);
+      details.push(
+        `Wasm hash ${shortFingerprint(previous.fingerprint.wasmHash)} → ${shortFingerprint(current.wasmHash)}`,
+      );
+    }
+
+    if (
+      (previous.fingerprint.specVersion ?? '') !== (current.specVersion ?? '')
+    ) {
+      indicators.push(UpgradeIndicator.SPEC_VERSION_CHANGED);
+      details.push(
+        `Spec version ${previous.fingerprint.specVersion ?? 'none'} → ${current.specVersion ?? 'none'}`,
+      );
+    }
+
+    const addedFunctions = surface.functions.filter(
+      (fn) => !before.functions.includes(fn),
+    );
+    const removedFunctions = before.functions.filter(
+      (fn) => !surface.functions.includes(fn),
+    );
+
+    if (addedFunctions.length > 0) {
+      indicators.push(UpgradeIndicator.INTERFACE_FUNCTIONS_ADDED);
+      details.push(`Functions added: ${addedFunctions.join(', ')}`);
+    }
+
+    if (removedFunctions.length > 0) {
+      indicators.push(UpgradeIndicator.INTERFACE_FUNCTIONS_REMOVED);
+      details.push(`Functions removed: ${removedFunctions.join(', ')}`);
+    }
+
+    if (!sameStrings(before.events, surface.events)) {
+      indicators.push(UpgradeIndicator.INTERFACE_EVENTS_CHANGED);
+      details.push('Contract events changed');
+    }
+
+    if (!sameNumbers(before.errors, surface.errors)) {
+      indicators.push(UpgradeIndicator.INTERFACE_ERRORS_CHANGED);
+      details.push('Contract error codes changed');
+    }
+
+    if (redeployed) {
+      indicators.push(UpgradeIndicator.REDEPLOYED);
+      details.push(`Redeployed in transaction ${observation.txHash}`);
+    }
+
+    this.eventCounter += 1;
+
+    return {
+      id: `upgrade-${current.network}-${current.contractAddress}-${this.eventCounter}`,
+      contractAddress: current.contractAddress,
+      network: current.network,
+      previousFingerprint: previous.fingerprint,
+      currentFingerprint: current,
+      indicators,
+      severity: classifySeverity(indicators, removedFunctions),
+      details,
+      addedFunctions,
+      removedFunctions,
+      affectedIntegrations: [...previous.integrations],
+      detectedAt: now,
+      txHash: observation.txHash,
+    };
+  }
+
+  private recordEvent(event: UpgradeEvent): void {
+    this.history.push(event);
+
+    if (this.history.length > this.config.maxHistory) {
+      this.history.splice(0, this.history.length - this.config.maxHistory);
+    }
+  }
+
+  /**
+   * Mark every integration that depended on the old deployment for review.
+   *
+   * An integration already flagged for an earlier upgrade is not flagged
+   * twice; the open flag is what matters, not how many upgrades produced it.
+   */
+  private flagIntegrations(event: UpgradeEvent, now: number): void {
+    for (const integrationId of event.affectedIntegrations) {
+      const open = this.flags.find(
+        (flag) =>
+          flag.integrationId === integrationId &&
+          flag.contractAddress === event.contractAddress &&
+          flag.network === event.network &&
+          !flag.clearedAt,
+      );
+
+      if (open) {
+        // Keep the worst severity seen while the flag is open.
+        if (severityRank(event.severity) > severityRank(open.severity)) {
+          open.severity = event.severity;
+          open.reason = summarize(event);
+          open.upgradeEventId = event.id;
+        }
+
+        continue;
+      }
+
+      this.flags.push({
+        integrationId,
+        contractAddress: event.contractAddress,
+        network: event.network,
+        upgradeEventId: event.id,
+        severity: event.severity,
+        reason: summarize(event),
+        flaggedAt: now,
+      });
+    }
+  }
+
+  addIntegration(
+    contractAddress: string,
+    network: FingerprintNetwork,
+    integrationId: string,
+  ): void {
+    const key = contractKey(contractAddress, network);
+    const state = this.states.get(key);
+
+    if (state) {
+      state.integrations = [...new Set([...state.integrations, integrationId])];
+
+      return;
+    }
+
+    const configured = this.pending.get(key) ?? {
+      integrations: [] as string[],
+    };
+
+    this.pending.set(key, {
+      ...configured,
+      integrations: [...new Set([...configured.integrations, integrationId])],
+    });
+  }
+
+  getState(
+    contractAddress: string,
+    network: FingerprintNetwork,
+  ): TrackedContractState | undefined {
+    return this.states.get(contractKey(contractAddress, network));
+  }
+
+  getTrackedContracts(): TrackedContractState[] {
+    return [...this.states.values()];
+  }
+
+  isTracked(contractAddress: string, network: FingerprintNetwork): boolean {
+    return this.states.has(contractKey(contractAddress, network));
+  }
+
+  getHistory(
+    contractAddress?: string,
+    network?: FingerprintNetwork,
+  ): UpgradeEvent[] {
+    if (!contractAddress) return [...this.history];
+
+    const address = normalizeContractAddress(contractAddress);
+
+    return this.history.filter(
+      (event) =>
+        event.contractAddress === address &&
+        (!network || event.network === network),
+    );
+  }
+
+  /** Open review flags, optionally for one integration. */
+  getReviewFlags(integrationId?: string): IntegrationReviewFlag[] {
+    return this.flags.filter(
+      (flag) =>
+        !flag.clearedAt &&
+        (!integrationId || flag.integrationId === integrationId),
+    );
+  }
+
+  getAllReviewFlags(): IntegrationReviewFlag[] {
+    return [...this.flags];
+  }
+
+  needsReview(integrationId: string): boolean {
+    return this.getReviewFlags(integrationId).length > 0;
+  }
+
+  /** Close a review flag once an operator has re-approved the integration. */
+  clearReviewFlag(
+    integrationId: string,
+    contractAddress: string,
+    network: FingerprintNetwork,
+    clearedBy?: string,
+    clearedAt: number = Date.now(),
+  ): boolean {
+    const address = normalizeContractAddress(contractAddress);
+    const flag = this.flags.find(
+      (candidate) =>
+        candidate.integrationId === integrationId &&
+        candidate.contractAddress === address &&
+        candidate.network === network &&
+        !candidate.clearedAt,
+    );
+
+    if (!flag) return false;
+
+    flag.clearedAt = clearedAt;
+    flag.clearedBy = clearedBy;
+
+    return true;
+  }
+
+  reset(): void {
+    this.states.clear();
+    this.pending.clear();
+    this.history.length = 0;
+    this.flags.length = 0;
+    this.eventCounter = 0;
+  }
+}
+
+function sameStrings(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function sameNumbers(left: number[], right: number[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+export function severityRank(severity: UpgradeSeverity): number {
+  return [
+    UpgradeSeverity.INFO,
+    UpgradeSeverity.MINOR,
+    UpgradeSeverity.MAJOR,
+    UpgradeSeverity.CRITICAL,
+  ].indexOf(severity);
+}
+
+/**
+ * How badly an upgrade undermines what BridgeWise assumed.
+ *
+ * A removed function breaks calls outright, so it is critical. New code with
+ * an unchanged interface is only one step below: nothing visible changed,
+ * which is precisely why it would otherwise keep being trusted.
+ */
+export function classifySeverity(
+  indicators: UpgradeIndicator[],
+  removedFunctions: string[],
+): UpgradeSeverity {
+  if (removedFunctions.length > 0) return UpgradeSeverity.CRITICAL;
+
+  if (indicators.includes(UpgradeIndicator.WASM_HASH_CHANGED))
+    return UpgradeSeverity.MAJOR;
+
+  if (
+    indicators.includes(UpgradeIndicator.SPEC_VERSION_CHANGED) ||
+    indicators.includes(UpgradeIndicator.INTERFACE_FUNCTIONS_ADDED) ||
+    indicators.includes(UpgradeIndicator.INTERFACE_EVENTS_CHANGED) ||
+    indicators.includes(UpgradeIndicator.INTERFACE_ERRORS_CHANGED)
+  ) {
+    return UpgradeSeverity.MINOR;
+  }
+
+  return UpgradeSeverity.INFO;
+}
+
+function summarize(event: UpgradeEvent): string {
+  return `Contract ${event.contractAddress} upgraded (${event.indicators.join(', ')})`;
+}

--- a/src/security/contracts/upgrades/soroban/types.ts
+++ b/src/security/contracts/upgrades/soroban/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Soroban contract upgrade detection types.
+ *
+ * An upgrade is not inherently a problem — it is a withdrawal of the evidence
+ * that made the contract trusted. These types describe what changed, how
+ * badly, and which BridgeWise integrations relied on the old behaviour.
+ */
+
+import {
+  ContractInterfaceSurface,
+  DeploymentFingerprint,
+  DeploymentObservation,
+  FingerprintNetwork,
+} from '../../fingerprints/types';
+
+export enum UpgradeIndicator {
+  /** New code behind the same address. */
+  WASM_HASH_CHANGED = 'wasm_hash_changed',
+  SPEC_VERSION_CHANGED = 'spec_version_changed',
+  INTERFACE_FUNCTIONS_ADDED = 'interface_functions_added',
+  INTERFACE_FUNCTIONS_REMOVED = 'interface_functions_removed',
+  INTERFACE_EVENTS_CHANGED = 'interface_events_changed',
+  INTERFACE_ERRORS_CHANGED = 'interface_errors_changed',
+  /** Same code, new deployment transaction. */
+  REDEPLOYED = 'redeployed',
+}
+
+export enum UpgradeSeverity {
+  INFO = 'info',
+  MINOR = 'minor',
+  MAJOR = 'major',
+  CRITICAL = 'critical',
+}
+
+export interface TrackedContractState {
+  contractAddress: string;
+  network: FingerprintNetwork;
+  fingerprint: DeploymentFingerprint;
+  /** Last observed interface surface, kept so a diff can name the functions. */
+  interfaceSurface?: ContractInterfaceSurface;
+  /** Integration ids that depend on this contract. */
+  integrations: string[];
+  label?: string;
+  firstSeenAt: number;
+  lastSeenAt: number;
+  lastTxHash?: string;
+  upgradeCount: number;
+}
+
+export interface UpgradeEvent {
+  id: string;
+  contractAddress: string;
+  network: FingerprintNetwork;
+  previousFingerprint: DeploymentFingerprint;
+  currentFingerprint: DeploymentFingerprint;
+  indicators: UpgradeIndicator[];
+  severity: UpgradeSeverity;
+  /** Human-readable summary lines, one per indicator. */
+  details: string[];
+  addedFunctions: string[];
+  removedFunctions: string[];
+  affectedIntegrations: string[];
+  detectedAt: number;
+  txHash?: string;
+}
+
+export interface IntegrationReviewFlag {
+  integrationId: string;
+  contractAddress: string;
+  network: FingerprintNetwork;
+  upgradeEventId: string;
+  severity: UpgradeSeverity;
+  reason: string;
+  flaggedAt: number;
+  clearedAt?: number;
+  clearedBy?: string;
+}
+
+export interface RegisterContractInput {
+  contractAddress: string;
+  network: FingerprintNetwork;
+  integrations?: string[];
+  label?: string;
+  /** Known-good baseline, so the first observation can already be judged. */
+  baseline?: DeploymentObservation;
+}
+
+export interface UpgradeDetectorConfig {
+  /** Cap on retained upgrade events. Default 500. */
+  maxHistory?: number;
+  /**
+   * Treat a redeploy of identical code as an upgrade. Default true: the
+   * address' code is unchanged but its storage and admin may not be.
+   */
+  treatRedeployAsUpgrade?: boolean;
+}

--- a/tests/security/contracts/fingerprints/approved-fingerprint-store.spec.ts
+++ b/tests/security/contracts/fingerprints/approved-fingerprint-store.spec.ts
@@ -1,0 +1,279 @@
+import { ApprovedFingerprintStore } from '../../../../src/security/contracts/fingerprints/approved-fingerprint-store';
+import { computeDeploymentFingerprint } from '../../../../src/security/contracts/fingerprints/deployment-fingerprint';
+import {
+  DeploymentObservation,
+  FingerprintNetwork,
+} from '../../../../src/security/contracts/fingerprints/types';
+
+const ADDRESS = 'CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K';
+
+function fingerprintFor(overrides: Partial<DeploymentObservation> = {}) {
+  const observation: DeploymentObservation = {
+    contractAddress: ADDRESS,
+    network: FingerprintNetwork.TESTNET,
+    wasmHash: 'a'.repeat(64),
+    specVersion: '1.0.0',
+    ...overrides,
+  };
+
+  return computeDeploymentFingerprint(observation, 1_000);
+}
+
+describe('ApprovedFingerprintStore', () => {
+  let store: ApprovedFingerprintStore;
+
+  beforeEach(() => {
+    store = new ApprovedFingerprintStore();
+  });
+
+  it('approves and finds a deployment', () => {
+    const details = fingerprintFor();
+
+    store.approve({
+      details,
+      label: 'bridge v1',
+      approvedBy: 'ops',
+      approvedAt: 5,
+    });
+
+    expect(
+      store.isApproved(
+        ADDRESS,
+        FingerprintNetwork.TESTNET,
+        details.fingerprint,
+      ),
+    ).toBe(true);
+    expect(
+      store.find(ADDRESS, FingerprintNetwork.TESTNET, details.fingerprint)
+        ?.label,
+    ).toBe('bridge v1');
+    expect(store.size()).toBe(1);
+  });
+
+  it('does not approve a deployment it has never seen', () => {
+    expect(
+      store.isApproved(ADDRESS, FingerprintNetwork.TESTNET, 'unknown'),
+    ).toBe(false);
+  });
+
+  it('normalizes the address on lookup', () => {
+    const details = fingerprintFor();
+
+    store.approve({ details });
+
+    expect(
+      store.isApproved(
+        ADDRESS.toLowerCase(),
+        FingerprintNetwork.TESTNET,
+        details.fingerprint,
+      ),
+    ).toBe(true);
+  });
+
+  // An approval on testnet says nothing about the same id on mainnet.
+  it('keeps networks separate', () => {
+    const details = fingerprintFor();
+
+    store.approve({ details });
+
+    expect(
+      store.isApproved(ADDRESS, FingerprintNetwork.PUBLIC, details.fingerprint),
+    ).toBe(false);
+  });
+
+  it('updates rather than duplicating a re-approval', () => {
+    const details = fingerprintFor();
+
+    store.approve({ details, label: 'first', approvedAt: 1 });
+    store.approve({ details, label: 'second', approvedAt: 2 });
+
+    expect(store.size()).toBe(1);
+    expect(
+      store.find(ADDRESS, FingerprintNetwork.TESTNET, details.fingerprint)
+        ?.label,
+    ).toBe('second');
+  });
+
+  it('holds several approved deployments for one contract', () => {
+    store.approve({ details: fingerprintFor() });
+    store.approve({ details: fingerprintFor({ wasmHash: 'b'.repeat(64) }) });
+
+    expect(
+      store.listActiveForContract(ADDRESS, FingerprintNetwork.TESTNET),
+    ).toHaveLength(2);
+  });
+
+  describe('revocation', () => {
+    it('stops treating a revoked deployment as approved', () => {
+      const details = fingerprintFor();
+
+      store.approve({ details });
+      store.revoke(
+        ADDRESS,
+        FingerprintNetwork.TESTNET,
+        details.fingerprint,
+        'key leak',
+        77,
+      );
+
+      expect(
+        store.isApproved(
+          ADDRESS,
+          FingerprintNetwork.TESTNET,
+          details.fingerprint,
+        ),
+      ).toBe(false);
+    });
+
+    // "Approved and then revoked" is a more useful answer than "never seen".
+    it('keeps the revoked record for audit', () => {
+      const details = fingerprintFor();
+
+      store.approve({ details });
+      store.revoke(
+        ADDRESS,
+        FingerprintNetwork.TESTNET,
+        details.fingerprint,
+        'key leak',
+        77,
+      );
+
+      const record = store.find(
+        ADDRESS,
+        FingerprintNetwork.TESTNET,
+        details.fingerprint,
+      );
+
+      expect(record?.revokedAt).toBe(77);
+      expect(record?.revokedReason).toBe('key leak');
+      expect(
+        store.listForContract(ADDRESS, FingerprintNetwork.TESTNET),
+      ).toHaveLength(1);
+      expect(
+        store.listActiveForContract(ADDRESS, FingerprintNetwork.TESTNET),
+      ).toHaveLength(0);
+    });
+
+    it('returns undefined revoking something unknown', () => {
+      expect(
+        store.revoke(ADDRESS, FingerprintNetwork.TESTNET, 'nope'),
+      ).toBeUndefined();
+    });
+
+    // Re-approving is an explicit decision to trust the deployment again.
+    it('clears the revocation on re-approval', () => {
+      const details = fingerprintFor();
+
+      store.approve({ details });
+      store.revoke(
+        ADDRESS,
+        FingerprintNetwork.TESTNET,
+        details.fingerprint,
+        'precaution',
+      );
+      store.approve({ details, approvedBy: 'ops' });
+
+      expect(
+        store.isApproved(
+          ADDRESS,
+          FingerprintNetwork.TESTNET,
+          details.fingerprint,
+        ),
+      ).toBe(true);
+      expect(
+        store.find(ADDRESS, FingerprintNetwork.TESTNET, details.fingerprint)
+          ?.revokedAt,
+      ).toBeUndefined();
+    });
+  });
+
+  describe('latestActive', () => {
+    it('returns the most recently approved active deployment', () => {
+      store.approve({ details: fingerprintFor(), label: 'old', approvedAt: 1 });
+      store.approve({
+        details: fingerprintFor({ wasmHash: 'b'.repeat(64) }),
+        label: 'new',
+        approvedAt: 9,
+      });
+
+      expect(
+        store.latestActive(ADDRESS, FingerprintNetwork.TESTNET)?.label,
+      ).toBe('new');
+    });
+
+    it('skips revoked approvals', () => {
+      const revoked = fingerprintFor({ wasmHash: 'b'.repeat(64) });
+
+      store.approve({ details: fingerprintFor(), label: 'old', approvedAt: 1 });
+      store.approve({ details: revoked, label: 'new', approvedAt: 9 });
+      store.revoke(ADDRESS, FingerprintNetwork.TESTNET, revoked.fingerprint);
+
+      expect(
+        store.latestActive(ADDRESS, FingerprintNetwork.TESTNET)?.label,
+      ).toBe('old');
+    });
+
+    it('returns undefined for an unknown contract', () => {
+      expect(
+        store.latestActive(ADDRESS, FingerprintNetwork.TESTNET),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('removal', () => {
+    it('removes an approval', () => {
+      const details = fingerprintFor();
+
+      store.approve({ details });
+
+      expect(
+        store.remove(ADDRESS, FingerprintNetwork.TESTNET, details.fingerprint),
+      ).toBe(true);
+      expect(store.size()).toBe(0);
+    });
+
+    it('reports nothing removed for an unknown fingerprint', () => {
+      expect(store.remove(ADDRESS, FingerprintNetwork.TESTNET, 'nope')).toBe(
+        false,
+      );
+    });
+
+    it('clears everything', () => {
+      store.approve({ details: fingerprintFor() });
+      store.clear();
+
+      expect(store.size()).toBe(0);
+    });
+  });
+
+  describe('persistence', () => {
+    it('round-trips through a snapshot', () => {
+      const details = fingerprintFor();
+
+      store.approve({ details, label: 'bridge v1', approvedAt: 3 });
+
+      const restored = new ApprovedFingerprintStore();
+
+      restored.restore(store.snapshot());
+
+      expect(
+        restored.isApproved(
+          ADDRESS,
+          FingerprintNetwork.TESTNET,
+          details.fingerprint,
+        ),
+      ).toBe(true);
+      expect(
+        restored.find(ADDRESS, FingerprintNetwork.TESTNET, details.fingerprint)
+          ?.label,
+      ).toBe('bridge v1');
+    });
+
+    it('replaces existing contents on restore', () => {
+      store.approve({ details: fingerprintFor() });
+      store.restore([]);
+
+      expect(store.size()).toBe(0);
+    });
+  });
+});

--- a/tests/security/contracts/fingerprints/deployment-fingerprint.spec.ts
+++ b/tests/security/contracts/fingerprints/deployment-fingerprint.spec.ts
@@ -1,0 +1,298 @@
+import {
+  EMPTY_INTERFACE_DIGEST,
+  canonicalizeInterface,
+  computeDeploymentFingerprint,
+  computeInterfaceDigest,
+  contractKey,
+  fingerprintsMatch,
+  normalizeContractAddress,
+  normalizeWasmHash,
+  shortFingerprint,
+} from '../../../../src/security/contracts/fingerprints/deployment-fingerprint';
+import {
+  DeploymentObservation,
+  FingerprintNetwork,
+} from '../../../../src/security/contracts/fingerprints/types';
+
+const ADDRESS = 'CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K';
+const WASM_HASH = 'a'.repeat(64);
+
+function observation(
+  overrides: Partial<DeploymentObservation> = {},
+): DeploymentObservation {
+  return {
+    contractAddress: ADDRESS,
+    network: FingerprintNetwork.TESTNET,
+    wasmHash: WASM_HASH,
+    specVersion: '1.2.0',
+    interface: {
+      functions: [
+        'transfer(from:address,to:address,amount:i128):bool',
+        'balance(id:address):i128',
+      ],
+      events: ['transfer'],
+      errors: [1, 2],
+    },
+    ...overrides,
+  };
+}
+
+describe('normalizeContractAddress', () => {
+  it('upper-cases and trims', () => {
+    expect(normalizeContractAddress(`  ${ADDRESS.toLowerCase()} `)).toBe(
+      ADDRESS,
+    );
+  });
+
+  it('rejects an empty address', () => {
+    expect(() => normalizeContractAddress('  ')).toThrow(
+      /Contract address is required/,
+    );
+  });
+});
+
+describe('normalizeWasmHash', () => {
+  it('lower-cases, trims and drops an 0x prefix', () => {
+    expect(normalizeWasmHash(`0x${WASM_HASH.toUpperCase()}`)).toBe(WASM_HASH);
+  });
+
+  it('rejects an empty hash', () => {
+    expect(() => normalizeWasmHash('')).toThrow(/Wasm hash is required/);
+  });
+
+  // A base64 hash would fingerprint cleanly and then never match anything —
+  // a permanent silent mismatch is worse than a loud failure here.
+  it('rejects a non-hex hash', () => {
+    expect(() => normalizeWasmHash('bm90LWhleA==')).toThrow(
+      /must be hex encoded/,
+    );
+  });
+});
+
+describe('canonicalizeInterface', () => {
+  it('sorts and de-duplicates', () => {
+    const canonical = canonicalizeInterface({
+      functions: ['b()', 'a()', 'b()'],
+      events: ['z', 'y'],
+      errors: [5, 1, 5],
+    });
+
+    expect(canonical.functions).toEqual(['a()', 'b()']);
+    expect(canonical.events).toEqual(['y', 'z']);
+    expect(canonical.errors).toEqual([1, 5]);
+  });
+
+  it('tolerates a missing surface', () => {
+    expect(canonicalizeInterface()).toEqual({
+      functions: [],
+      events: [],
+      errors: [],
+    });
+  });
+
+  it('drops blank entries', () => {
+    expect(
+      canonicalizeInterface({
+        functions: ['  ', 'a()'],
+        events: [],
+        errors: [],
+      }).functions,
+    ).toEqual(['a()']);
+  });
+});
+
+describe('computeInterfaceDigest', () => {
+  // Two nodes can enumerate a spec in different orders; that is not a change.
+  it('does not depend on ordering', () => {
+    const first = computeInterfaceDigest({
+      functions: ['a()', 'b()'],
+      events: ['x'],
+      errors: [1, 2],
+    });
+    const second = computeInterfaceDigest({
+      functions: ['b()', 'a()'],
+      events: ['x'],
+      errors: [2, 1],
+    });
+
+    expect(first).toBe(second);
+  });
+
+  it('changes when a function is added', () => {
+    const before = computeInterfaceDigest({
+      functions: ['a()'],
+      events: [],
+      errors: [],
+    });
+    const after = computeInterfaceDigest({
+      functions: ['a()', 'b()'],
+      events: [],
+      errors: [],
+    });
+
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when a signature changes', () => {
+    const before = computeInterfaceDigest({
+      functions: ['transfer(amount:i128)'],
+      events: [],
+      errors: [],
+    });
+    const after = computeInterfaceDigest({
+      functions: ['transfer(amount:u64)'],
+      events: [],
+      errors: [],
+    });
+
+    expect(after).not.toBe(before);
+  });
+
+  it('gives a missing surface the empty digest', () => {
+    expect(computeInterfaceDigest(undefined)).toBe(EMPTY_INTERFACE_DIGEST);
+  });
+});
+
+describe('computeDeploymentFingerprint', () => {
+  it('is stable across repeated computation', () => {
+    expect(computeDeploymentFingerprint(observation(), 1).fingerprint).toBe(
+      computeDeploymentFingerprint(observation(), 2).fingerprint,
+    );
+  });
+
+  // The fingerprint answers "is this the deployment we approved", so when and
+  // how we observed it must not enter into it.
+  it('ignores observation-time context', () => {
+    const base = computeDeploymentFingerprint(observation());
+    const later = computeDeploymentFingerprint(
+      observation({
+        observedAt: 999,
+        deployedAt: 12345,
+        txHash: 'different-tx',
+        deployerAddress: 'GSOMEONEELSE',
+      }),
+    );
+
+    expect(later.fingerprint).toBe(base.fingerprint);
+  });
+
+  it('normalizes address and hash before hashing', () => {
+    const base = computeDeploymentFingerprint(observation());
+    const messy = computeDeploymentFingerprint(
+      observation({
+        contractAddress: ADDRESS.toLowerCase(),
+        wasmHash: `0x${WASM_HASH.toUpperCase()}`,
+      }),
+    );
+
+    expect(messy.fingerprint).toBe(base.fingerprint);
+  });
+
+  it('changes when the wasm hash changes', () => {
+    const base = computeDeploymentFingerprint(observation());
+    const upgraded = computeDeploymentFingerprint(
+      observation({ wasmHash: 'b'.repeat(64) }),
+    );
+
+    expect(upgraded.fingerprint).not.toBe(base.fingerprint);
+  });
+
+  it('changes when the interface changes', () => {
+    const base = computeDeploymentFingerprint(observation());
+    const changed = computeDeploymentFingerprint(
+      observation({
+        interface: { functions: ['burn(amount:i128)'], events: [], errors: [] },
+      }),
+    );
+
+    expect(changed.fingerprint).not.toBe(base.fingerprint);
+  });
+
+  it('changes when the spec version changes', () => {
+    const base = computeDeploymentFingerprint(observation());
+    const bumped = computeDeploymentFingerprint(
+      observation({ specVersion: '1.3.0' }),
+    );
+
+    expect(bumped.fingerprint).not.toBe(base.fingerprint);
+  });
+
+  // The same contract id can exist on testnet and public with different code;
+  // colliding them would let a testnet deployment pass a mainnet check.
+  it('separates networks', () => {
+    const testnet = computeDeploymentFingerprint(observation());
+    const publicNet = computeDeploymentFingerprint(
+      observation({ network: FingerprintNetwork.PUBLIC }),
+    );
+
+    expect(publicNet.fingerprint).not.toBe(testnet.fingerprint);
+  });
+
+  it('carries the normalized fields through', () => {
+    const result = computeDeploymentFingerprint(observation(), 42);
+
+    expect(result.contractAddress).toBe(ADDRESS);
+    expect(result.wasmHash).toBe(WASM_HASH);
+    expect(result.specVersion).toBe('1.2.0');
+    expect(result.computedAt).toBe(42);
+    expect(result.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('treats a missing spec version as absent rather than empty', () => {
+    expect(
+      computeDeploymentFingerprint(observation({ specVersion: '  ' }))
+        .specVersion,
+    ).toBeUndefined();
+  });
+
+  it('rejects an observation without a network', () => {
+    expect(() =>
+      computeDeploymentFingerprint(
+        observation({ network: undefined as never }),
+      ),
+    ).toThrow(/Network is required/);
+  });
+
+  it('fingerprints a deployment with no known interface', () => {
+    const result = computeDeploymentFingerprint(
+      observation({ interface: undefined }),
+    );
+
+    expect(result.interfaceDigest).toBe(EMPTY_INTERFACE_DIGEST);
+  });
+});
+
+describe('fingerprintsMatch', () => {
+  it('compares by fingerprint alone', () => {
+    const left = computeDeploymentFingerprint(observation(), 1);
+    const right = computeDeploymentFingerprint(observation(), 2);
+
+    expect(fingerprintsMatch(left, right)).toBe(true);
+    expect(
+      fingerprintsMatch(
+        left,
+        computeDeploymentFingerprint(observation({ wasmHash: 'c'.repeat(64) })),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('contractKey', () => {
+  it('scopes the key by network', () => {
+    expect(contractKey(ADDRESS, FingerprintNetwork.TESTNET)).not.toBe(
+      contractKey(ADDRESS, FingerprintNetwork.PUBLIC),
+    );
+  });
+
+  it('normalizes the address', () => {
+    expect(contractKey(ADDRESS.toLowerCase(), FingerprintNetwork.TESTNET)).toBe(
+      contractKey(ADDRESS, FingerprintNetwork.TESTNET),
+    );
+  });
+});
+
+describe('shortFingerprint', () => {
+  it('truncates for log lines', () => {
+    expect(shortFingerprint('abcdef1234567890', 6)).toBe('abcdef');
+  });
+});

--- a/tests/security/contracts/fingerprints/soroban-deployment-verifier.spec.ts
+++ b/tests/security/contracts/fingerprints/soroban-deployment-verifier.spec.ts
@@ -1,0 +1,210 @@
+import { ApprovedFingerprintStore } from '../../../../src/security/contracts/fingerprints/approved-fingerprint-store';
+import { computeDeploymentFingerprint } from '../../../../src/security/contracts/fingerprints/deployment-fingerprint';
+import {
+  DeploymentObservation,
+  FingerprintNetwork,
+  MismatchReason,
+  VerificationStatus,
+} from '../../../../src/security/contracts/fingerprints/types';
+import {
+  SorobanDeploymentVerifier,
+  diffFingerprints,
+} from '../../../../src/contracts/verification/soroban-deployment-verifier';
+
+const ADDRESS = 'CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K';
+
+function observation(
+  overrides: Partial<DeploymentObservation> = {},
+): DeploymentObservation {
+  return {
+    contractAddress: ADDRESS,
+    network: FingerprintNetwork.TESTNET,
+    wasmHash: 'a'.repeat(64),
+    specVersion: '1.0.0',
+    interface: {
+      functions: ['transfer(amount:i128)'],
+      events: ['transfer'],
+      errors: [1],
+    },
+    ...overrides,
+  };
+}
+
+describe('SorobanDeploymentVerifier', () => {
+  let store: ApprovedFingerprintStore;
+  let verifier: SorobanDeploymentVerifier;
+
+  beforeEach(() => {
+    store = new ApprovedFingerprintStore();
+    verifier = new SorobanDeploymentVerifier(store);
+  });
+
+  it('reports an approved deployment', () => {
+    verifier.approve(observation(), { label: 'bridge v1', now: 1 });
+
+    const result = verifier.verify(observation(), 2);
+
+    expect(result.status).toBe(VerificationStatus.APPROVED);
+    expect(result.matched?.label).toBe('bridge v1');
+    expect(result.reasons).toEqual([]);
+    expect(result.differences).toEqual([]);
+  });
+
+  it('approves regardless of when or how the deployment was observed', () => {
+    verifier.approve(observation({ txHash: 'tx-1', observedAt: 1 }), {
+      now: 1,
+    });
+
+    expect(
+      verifier.isVerified(observation({ txHash: 'tx-2', observedAt: 500 })),
+    ).toBe(true);
+  });
+
+  // Nothing approved is a different problem from something that changed: one
+  // needs an approval decision, the other needs investigation.
+  it('reports an unknown contract distinctly from a mismatch', () => {
+    const result = verifier.verify(observation(), 7);
+
+    expect(result.status).toBe(VerificationStatus.UNKNOWN);
+    expect(result.reasons).toEqual([MismatchReason.NO_APPROVED_FINGERPRINT]);
+    expect(result.comparedAgainst).toBeUndefined();
+  });
+
+  describe('mismatches', () => {
+    beforeEach(() => {
+      verifier.approve(observation(), { label: 'bridge v1', now: 1 });
+    });
+
+    it('detects a changed wasm hash', () => {
+      const result = verifier.verify(
+        observation({ wasmHash: 'b'.repeat(64) }),
+        3,
+      );
+
+      expect(result.status).toBe(VerificationStatus.MISMATCH);
+      expect(result.reasons).toContain(MismatchReason.WASM_HASH_CHANGED);
+      expect(result.comparedAgainst?.label).toBe('bridge v1');
+      expect(result.differences[0]).toMatch(/Wasm hash/);
+    });
+
+    it('detects a changed interface', () => {
+      const result = verifier.verify(
+        observation({
+          interface: {
+            functions: ['burn(amount:i128)'],
+            events: [],
+            errors: [],
+          },
+        }),
+      );
+
+      expect(result.reasons).toContain(MismatchReason.INTERFACE_CHANGED);
+    });
+
+    it('detects a changed spec version', () => {
+      const result = verifier.verify(observation({ specVersion: '2.0.0' }));
+
+      expect(result.reasons).toContain(MismatchReason.SPEC_VERSION_CHANGED);
+    });
+
+    it('lists every reason at once', () => {
+      const result = verifier.verify(
+        observation({
+          wasmHash: 'c'.repeat(64),
+          specVersion: '2.0.0',
+          interface: { functions: ['burn()'], events: [], errors: [] },
+        }),
+      );
+
+      expect(result.reasons).toEqual(
+        expect.arrayContaining([
+          MismatchReason.WASM_HASH_CHANGED,
+          MismatchReason.INTERFACE_CHANGED,
+          MismatchReason.SPEC_VERSION_CHANGED,
+        ]),
+      );
+      expect(result.differences).toHaveLength(3);
+    });
+
+    // A deployment on the wrong network has no approvals of its own; treating
+    // it as merely "unknown" is the honest answer, not "approved".
+    it('does not approve a deployment seen on another network', () => {
+      const result = verifier.verify(
+        observation({ network: FingerprintNetwork.PUBLIC }),
+      );
+
+      expect(result.status).toBe(VerificationStatus.UNKNOWN);
+    });
+
+    it('compares against the most recent approval when several exist', () => {
+      verifier.approve(observation({ wasmHash: 'd'.repeat(64) }), {
+        label: 'bridge v2',
+        now: 9,
+      });
+
+      const result = verifier.verify(observation({ wasmHash: 'e'.repeat(64) }));
+
+      expect(result.comparedAgainst?.label).toBe('bridge v2');
+    });
+  });
+
+  describe('revocation', () => {
+    it('reports a revoked deployment as revoked, not merely mismatched', () => {
+      const approved = verifier.approve(observation(), { now: 1 });
+
+      store.revoke(
+        ADDRESS,
+        FingerprintNetwork.TESTNET,
+        approved.fingerprint,
+        'compromised key',
+      );
+
+      const result = verifier.verify(observation(), 5);
+
+      expect(result.status).toBe(VerificationStatus.REVOKED);
+      expect(result.reasons).toEqual([MismatchReason.FINGERPRINT_REVOKED]);
+      expect(result.differences[0]).toContain('compromised key');
+      expect(verifier.isVerified(observation())).toBe(false);
+    });
+  });
+
+  it('verifies a batch', () => {
+    verifier.approve(observation(), { now: 1 });
+
+    const results = verifier.verifyMany([
+      observation(),
+      observation({ wasmHash: 'f'.repeat(64) }),
+    ]);
+
+    expect(results.map((result) => result.status)).toEqual([
+      VerificationStatus.APPROVED,
+      VerificationStatus.MISMATCH,
+    ]);
+  });
+});
+
+describe('diffFingerprints', () => {
+  it('finds nothing between identical fingerprints', () => {
+    const details = computeDeploymentFingerprint(observation(), 1);
+
+    expect(diffFingerprints(details, details)).toEqual({
+      reasons: [],
+      differences: [],
+    });
+  });
+
+  it('names a spec version that was added', () => {
+    const before = computeDeploymentFingerprint(
+      observation({ specVersion: undefined }),
+      1,
+    );
+    const after = computeDeploymentFingerprint(
+      observation({ specVersion: '2.0.0' }),
+      1,
+    );
+
+    expect(diffFingerprints(before, after).differences[0]).toBe(
+      'Spec version none → 2.0.0',
+    );
+  });
+});

--- a/tests/security/contracts/upgrades/contract-upgrade-monitor.spec.ts
+++ b/tests/security/contracts/upgrades/contract-upgrade-monitor.spec.ts
@@ -1,0 +1,537 @@
+import { ApprovedFingerprintStore } from '../../../../src/security/contracts/fingerprints/approved-fingerprint-store';
+import {
+  DeploymentObservation,
+  FingerprintNetwork,
+  VerificationStatus,
+} from '../../../../src/security/contracts/fingerprints/types';
+import { SorobanDeploymentVerifier } from '../../../../src/contracts/verification/soroban-deployment-verifier';
+import { SorobanUpgradeDetector } from '../../../../src/security/contracts/upgrades/soroban/soroban-upgrade-detector';
+import {
+  ContractUpgradeMonitor,
+  UpgradeNotification,
+  describeUpgrade,
+} from '../../../../src/contracts/monitoring/contract-upgrade-monitor';
+import {
+  UpgradeEvent,
+  UpgradeSeverity,
+} from '../../../../src/security/contracts/upgrades/soroban/types';
+
+const ADDRESS = 'CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K';
+const NETWORK = FingerprintNetwork.TESTNET;
+
+function observation(
+  overrides: Partial<DeploymentObservation> = {},
+): DeploymentObservation {
+  return {
+    contractAddress: ADDRESS,
+    network: NETWORK,
+    wasmHash: 'a'.repeat(64),
+    specVersion: '1.0.0',
+    interface: {
+      functions: ['transfer(amount:i128)'],
+      events: ['transfer'],
+      errors: [1],
+    },
+    txHash: 'tx-1',
+    ...overrides,
+  };
+}
+
+/** A probe that returns each queued observation in turn, repeating the last. */
+function scriptedProbe(observations: DeploymentObservation[]) {
+  let index = 0;
+
+  return jest.fn(async () => {
+    const next = observations[Math.min(index, observations.length - 1)];
+
+    index += 1;
+
+    return next;
+  });
+}
+
+describe('ContractUpgradeMonitor', () => {
+  let detector: SorobanUpgradeDetector;
+  let monitor: ContractUpgradeMonitor;
+
+  beforeEach(() => {
+    detector = new SorobanUpgradeDetector();
+    monitor = new ContractUpgradeMonitor(detector);
+  });
+
+  afterEach(() => {
+    monitor.destroy();
+  });
+
+  it('registers a contract for monitoring', () => {
+    monitor.registerContract({
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      probe: scriptedProbe([observation()]),
+      integrations: ['bridge-a'],
+    });
+
+    expect(monitor.getMonitoredContracts()).toHaveLength(1);
+  });
+
+  it('reports no upgrade on the first check', async () => {
+    monitor.registerContract({
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      probe: scriptedProbe([observation()]),
+    });
+
+    const [result] = await monitor.checkAll(10);
+
+    expect(result.upgrade).toBeNull();
+    expect(result.error).toBeUndefined();
+  });
+
+  it('emits an upgrade when the deployment changes', async () => {
+    const upgrades: UpgradeEvent[] = [];
+
+    monitor.on('upgrade', (event: UpgradeEvent) => upgrades.push(event));
+    monitor.registerContract({
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      probe: scriptedProbe([
+        observation(),
+        observation({ wasmHash: 'b'.repeat(64) }),
+      ]),
+      integrations: ['bridge-a'],
+    });
+
+    await monitor.checkAll(10);
+    await monitor.checkAll(20);
+
+    expect(upgrades).toHaveLength(1);
+    expect(upgrades[0].affectedIntegrations).toEqual(['bridge-a']);
+  });
+
+  it('judges the first check against a configured baseline', async () => {
+    const upgrades: UpgradeEvent[] = [];
+
+    monitor.on('upgrade', (event: UpgradeEvent) => upgrades.push(event));
+    monitor.registerContract({
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      baseline: observation(),
+      probe: scriptedProbe([observation({ wasmHash: 'b'.repeat(64) })]),
+    });
+
+    await monitor.checkAll(10);
+
+    expect(upgrades).toHaveLength(1);
+  });
+
+  it('emits severe-upgrade only at or above the alert severity', async () => {
+    const severe: UpgradeEvent[] = [];
+    const strict = new ContractUpgradeMonitor(detector, undefined, {
+      alertSeverity: UpgradeSeverity.CRITICAL,
+    });
+
+    strict.on('severe-upgrade', (event: UpgradeEvent) => severe.push(event));
+    strict.registerContract({
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      probe: scriptedProbe([
+        observation(),
+        observation({ wasmHash: 'b'.repeat(64) }),
+        observation({
+          wasmHash: 'c'.repeat(64),
+          interface: { functions: [], events: [], errors: [] },
+        }),
+      ]),
+    });
+
+    await strict.checkAll(10);
+    await strict.checkAll(20);
+    expect(severe).toHaveLength(0);
+
+    await strict.checkAll(30);
+    expect(severe).toHaveLength(1);
+
+    strict.destroy();
+  });
+
+  describe('notifying monitoring services', () => {
+    it('sends the upgrade to every notifier', async () => {
+      const received: UpgradeNotification[] = [];
+
+      monitor.addNotifier((notification) => {
+        received.push(notification);
+      });
+      monitor.addNotifier(async (notification) => {
+        received.push(notification);
+      });
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: scriptedProbe([
+          observation(),
+          observation({ wasmHash: 'b'.repeat(64) }),
+        ]),
+        integrations: ['bridge-a'],
+      });
+
+      await monitor.checkAll(10);
+      await monitor.checkAll(20);
+
+      expect(received).toHaveLength(2);
+      expect(received[0].message).toContain(ADDRESS);
+      expect(received[0].affectedIntegrations).toEqual(['bridge-a']);
+    });
+
+    it('does not notify when nothing changed', async () => {
+      const notifier = jest.fn();
+
+      monitor.addNotifier(notifier);
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: scriptedProbe([observation()]),
+      });
+
+      await monitor.checkAll(10);
+      await monitor.checkAll(20);
+
+      expect(notifier).not.toHaveBeenCalled();
+    });
+
+    // A broken webhook is the worst possible reason to stop noticing contract
+    // upgrades.
+    it('keeps notifying after one sink throws', async () => {
+      const errors: unknown[] = [];
+      const second = jest.fn();
+
+      monitor.on('notifier-error', (error) => errors.push(error));
+      monitor.addNotifier(() => {
+        throw new Error('pager down');
+      });
+      monitor.addNotifier(second);
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: scriptedProbe([
+          observation(),
+          observation({ wasmHash: 'b'.repeat(64) }),
+        ]),
+      });
+
+      await monitor.checkAll(10);
+      await expect(monitor.checkAll(20)).resolves.toHaveLength(1);
+
+      expect(second).toHaveBeenCalledTimes(1);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('reports a rejected async notifier without failing the check', async () => {
+      const errors: Array<{ error: string }> = [];
+
+      monitor.on('notifier-error', (payload) => errors.push(payload));
+      monitor.addNotifier(async () => {
+        throw new Error('webhook 500');
+      });
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: scriptedProbe([
+          observation(),
+          observation({ wasmHash: 'b'.repeat(64) }),
+        ]),
+      });
+
+      await monitor.checkAll(10);
+      await monitor.checkAll(20);
+
+      expect(errors[0].error).toBe('webhook 500');
+    });
+  });
+
+  describe('probe failures', () => {
+    // An unreachable node must not look like a rollback.
+    it('does not disturb tracked state when a probe fails', async () => {
+      const failures: Array<{ error: string }> = [];
+      const probe = jest
+        .fn<Promise<DeploymentObservation>, []>()
+        .mockResolvedValueOnce(observation())
+        .mockRejectedValueOnce(new Error('horizon unreachable'))
+        .mockResolvedValueOnce(observation());
+
+      monitor.on('probe-error', (payload) => failures.push(payload));
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe,
+      });
+
+      await monitor.checkAll(10);
+      const [failed] = await monitor.checkAll(20);
+      const [recovered] = await monitor.checkAll(30);
+
+      expect(failed.error).toBe('horizon unreachable');
+      expect(failures).toHaveLength(1);
+      expect(recovered.upgrade).toBeNull();
+      expect(monitor.getUpgradeHistory()).toHaveLength(0);
+    });
+
+    it('keeps checking the other contracts when one probe fails', async () => {
+      const other = 'CDIFFERENTCONTRACTADDRESSFORTESTINGPURPOSESONLY1234567890';
+
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: jest.fn().mockRejectedValue(new Error('down')),
+      });
+      monitor.registerContract({
+        contractAddress: other,
+        network: NETWORK,
+        probe: scriptedProbe([observation({ contractAddress: other })]),
+      });
+
+      const results = await monitor.checkAll(10);
+
+      expect(results).toHaveLength(2);
+      expect(results.filter((result) => result.error)).toHaveLength(1);
+    });
+
+    // A hung probe would otherwise stall every later check on the interval.
+    it('times a hung probe out', async () => {
+      const impatient = new ContractUpgradeMonitor(detector, undefined, {
+        probeTimeoutMs: 20,
+      });
+
+      impatient.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: () => new Promise(() => undefined),
+      });
+
+      const [result] = await impatient.checkAll(10);
+
+      expect(result.error).toMatch(/timed out after 20ms/);
+
+      impatient.destroy();
+    });
+
+    it('reports a non-Error rejection readably', async () => {
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: jest.fn().mockRejectedValue({ status: 503 }),
+      });
+
+      const [result] = await monitor.checkAll(10);
+
+      expect(result.error).toBe('{"status":503}');
+    });
+
+    it('rejects a check for a contract that is not monitored', async () => {
+      await expect(monitor.check(ADDRESS, NETWORK)).rejects.toThrow(
+        /is not monitored/,
+      );
+    });
+  });
+
+  describe('fingerprint verification', () => {
+    it('emits unapproved-deployment for a deployment that is not approved', async () => {
+      const store = new ApprovedFingerprintStore();
+      const verifier = new SorobanDeploymentVerifier(store);
+      const verified = new ContractUpgradeMonitor(detector, verifier);
+      const unapproved: Array<{ status: VerificationStatus }> = [];
+
+      verified.on('unapproved-deployment', (result) => unapproved.push(result));
+      verified.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: scriptedProbe([observation()]),
+      });
+
+      const [result] = await verified.checkAll(10);
+
+      expect(result.verification?.status).toBe(VerificationStatus.UNKNOWN);
+      expect(unapproved).toHaveLength(1);
+
+      verified.destroy();
+    });
+
+    it('stays quiet for an approved deployment', async () => {
+      const store = new ApprovedFingerprintStore();
+      const verifier = new SorobanDeploymentVerifier(store);
+
+      verifier.approve(observation(), { now: 1 });
+
+      const verified = new ContractUpgradeMonitor(detector, verifier);
+      const unapproved: unknown[] = [];
+
+      verified.on('unapproved-deployment', (result) => unapproved.push(result));
+      verified.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: scriptedProbe([observation()]),
+      });
+
+      const [result] = await verified.checkAll(10);
+
+      expect(result.verification?.status).toBe(VerificationStatus.APPROVED);
+      expect(unapproved).toHaveLength(0);
+
+      verified.destroy();
+    });
+
+    it('carries the verification into the notification', async () => {
+      const store = new ApprovedFingerprintStore();
+      const verifier = new SorobanDeploymentVerifier(store);
+
+      verifier.approve(observation(), { now: 1 });
+
+      const verified = new ContractUpgradeMonitor(detector, verifier);
+      const received: UpgradeNotification[] = [];
+
+      verified.addNotifier((notification) => received.push(notification));
+      verified.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe: scriptedProbe([
+          observation(),
+          observation({ wasmHash: 'b'.repeat(64) }),
+        ]),
+      });
+
+      await verified.checkAll(10);
+      await verified.checkAll(20);
+
+      expect(received[0].verification?.status).toBe(
+        VerificationStatus.MISMATCH,
+      );
+
+      verified.destroy();
+    });
+  });
+
+  describe('scheduling', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('checks on an interval until stopped', async () => {
+      const probe = scriptedProbe([observation()]);
+
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe,
+      });
+      monitor.start(1_000);
+
+      expect(monitor.isRunning()).toBe(true);
+
+      await jest.advanceTimersByTimeAsync(3_000);
+      expect(probe).toHaveBeenCalledTimes(3);
+
+      monitor.stop();
+      await jest.advanceTimersByTimeAsync(3_000);
+
+      expect(probe).toHaveBeenCalledTimes(3);
+      expect(monitor.isRunning()).toBe(false);
+    });
+
+    it('ignores a second start', async () => {
+      const probe = scriptedProbe([observation()]);
+
+      monitor.registerContract({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        probe,
+      });
+      monitor.start(1_000);
+      monitor.start(1_000);
+
+      await jest.advanceTimersByTimeAsync(1_000);
+
+      expect(probe).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops cleanly when it was never started', () => {
+      expect(() => monitor.stop()).not.toThrow();
+    });
+  });
+
+  it('exposes review flags raised by the detector', async () => {
+    monitor.registerContract({
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      probe: scriptedProbe([
+        observation(),
+        observation({ wasmHash: 'b'.repeat(64) }),
+      ]),
+      integrations: ['bridge-a'],
+    });
+
+    await monitor.checkAll(10);
+    await monitor.checkAll(20);
+
+    expect(monitor.getReviewFlags('bridge-a')).toHaveLength(1);
+    expect(monitor.getUpgradeHistory(ADDRESS, NETWORK)).toHaveLength(1);
+  });
+
+  it('unregisters a contract', () => {
+    monitor.registerContract({
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      probe: scriptedProbe([observation()]),
+    });
+
+    expect(monitor.unregisterContract(ADDRESS, NETWORK)).toBe(true);
+    expect(monitor.getMonitoredContracts()).toHaveLength(0);
+  });
+});
+
+describe('describeUpgrade', () => {
+  it('names the severity, contract and affected integrations', () => {
+    const event: UpgradeEvent = {
+      id: 'upgrade-1',
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      previousFingerprint: {} as never,
+      currentFingerprint: {} as never,
+      indicators: [],
+      severity: UpgradeSeverity.MAJOR,
+      details: ['Wasm hash aaa → bbb'],
+      addedFunctions: [],
+      removedFunctions: [],
+      affectedIntegrations: ['bridge-a'],
+      detectedAt: 1,
+    };
+
+    const message = describeUpgrade(event);
+
+    expect(message).toContain('[major]');
+    expect(message).toContain(ADDRESS);
+    expect(message).toContain('Wasm hash aaa → bbb');
+    expect(message).toContain('bridge-a');
+  });
+
+  it('omits the integration clause when nothing is affected', () => {
+    const message = describeUpgrade({
+      id: 'upgrade-1',
+      contractAddress: ADDRESS,
+      network: NETWORK,
+      previousFingerprint: {} as never,
+      currentFingerprint: {} as never,
+      indicators: [],
+      severity: UpgradeSeverity.INFO,
+      details: ['Redeployed'],
+      addedFunctions: [],
+      removedFunctions: [],
+      affectedIntegrations: [],
+      detectedAt: 1,
+    });
+
+    expect(message).not.toContain('Affected integrations');
+  });
+});

--- a/tests/security/contracts/upgrades/soroban-upgrade-detector.spec.ts
+++ b/tests/security/contracts/upgrades/soroban-upgrade-detector.spec.ts
@@ -1,0 +1,488 @@
+import {
+  DeploymentObservation,
+  FingerprintNetwork,
+} from '../../../../src/security/contracts/fingerprints/types';
+import {
+  SorobanUpgradeDetector,
+  classifySeverity,
+  severityRank,
+} from '../../../../src/security/contracts/upgrades/soroban/soroban-upgrade-detector';
+import {
+  UpgradeIndicator,
+  UpgradeSeverity,
+} from '../../../../src/security/contracts/upgrades/soroban/types';
+
+const ADDRESS = 'CBQHNAXSI55GX2GN6D67GK7BHVPSLJUGZQEU7WJ5LKR5PNUCGLIMAO4K';
+const NETWORK = FingerprintNetwork.TESTNET;
+
+function observation(
+  overrides: Partial<DeploymentObservation> = {},
+): DeploymentObservation {
+  return {
+    contractAddress: ADDRESS,
+    network: NETWORK,
+    wasmHash: 'a'.repeat(64),
+    specVersion: '1.0.0',
+    interface: {
+      functions: ['transfer(amount:i128)', 'balance(id:address):i128'],
+      events: ['transfer'],
+      errors: [1],
+    },
+    txHash: 'tx-1',
+    ...overrides,
+  };
+}
+
+describe('SorobanUpgradeDetector', () => {
+  let detector: SorobanUpgradeDetector;
+
+  beforeEach(() => {
+    detector = new SorobanUpgradeDetector();
+  });
+
+  describe('tracking state', () => {
+    it('takes the first observation as the baseline without reporting an upgrade', () => {
+      expect(detector.observe(observation(), 10)).toBeNull();
+      expect(detector.isTracked(ADDRESS, NETWORK)).toBe(true);
+      expect(detector.getState(ADDRESS, NETWORK)?.upgradeCount).toBe(0);
+    });
+
+    it('registers a contract with a known-good baseline', () => {
+      const state = detector.register(
+        {
+          contractAddress: ADDRESS,
+          network: NETWORK,
+          baseline: observation(),
+          integrations: ['bridge-a'],
+        },
+        5,
+      );
+
+      expect(state?.integrations).toEqual(['bridge-a']);
+      expect(detector.isTracked(ADDRESS, NETWORK)).toBe(true);
+    });
+
+    it('applies integrations configured before the first observation', () => {
+      detector.register({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        integrations: ['bridge-a'],
+      });
+      detector.observe(observation(), 10);
+
+      expect(detector.getState(ADDRESS, NETWORK)?.integrations).toEqual([
+        'bridge-a',
+      ]);
+    });
+
+    // Re-reading config at startup must not erase what is already tracked.
+    it('merges integrations when a tracked contract is registered again', () => {
+      detector.register({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        baseline: observation(),
+        integrations: ['a'],
+      });
+      detector.register({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        integrations: ['b', 'a'],
+      });
+
+      expect(detector.getState(ADDRESS, NETWORK)?.integrations).toEqual([
+        'a',
+        'b',
+      ]);
+    });
+
+    it('reports no upgrade when nothing changed', () => {
+      detector.observe(observation(), 10);
+
+      expect(detector.observe(observation(), 20)).toBeNull();
+      expect(detector.getState(ADDRESS, NETWORK)?.lastSeenAt).toBe(20);
+    });
+
+    it('tracks the same address on two networks separately', () => {
+      detector.observe(observation(), 10);
+      detector.observe(observation({ network: FingerprintNetwork.PUBLIC }), 11);
+
+      expect(detector.getTrackedContracts()).toHaveLength(2);
+    });
+  });
+
+  describe('detecting upgrades', () => {
+    beforeEach(() => {
+      detector.register({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        integrations: ['bridge-a', 'bridge-b'],
+      });
+      detector.observe(observation(), 10);
+    });
+
+    it('detects new code behind the same address', () => {
+      const event = detector.observe(
+        observation({ wasmHash: 'b'.repeat(64) }),
+        20,
+      );
+
+      expect(event?.indicators).toContain(UpgradeIndicator.WASM_HASH_CHANGED);
+      expect(event?.previousFingerprint.wasmHash).toBe('a'.repeat(64));
+      expect(event?.currentFingerprint.wasmHash).toBe('b'.repeat(64));
+      expect(event?.detectedAt).toBe(20);
+    });
+
+    it('names the functions that were added and removed', () => {
+      const event = detector.observe(
+        observation({
+          wasmHash: 'b'.repeat(64),
+          interface: {
+            functions: ['transfer(amount:i128)', 'burn(amount:i128)'],
+            events: ['transfer'],
+            errors: [1],
+          },
+        }),
+        20,
+      );
+
+      expect(event?.addedFunctions).toEqual(['burn(amount:i128)']);
+      expect(event?.removedFunctions).toEqual(['balance(id:address):i128']);
+    });
+
+    it('detects a changed spec version', () => {
+      const event = detector.observe(observation({ specVersion: '2.0.0' }), 20);
+
+      expect(event?.indicators).toContain(
+        UpgradeIndicator.SPEC_VERSION_CHANGED,
+      );
+    });
+
+    it('detects changed events and error codes', () => {
+      const event = detector.observe(
+        observation({
+          wasmHash: 'b'.repeat(64),
+          interface: {
+            functions: ['transfer(amount:i128)', 'balance(id:address):i128'],
+            events: ['transfer', 'burn'],
+            errors: [1, 2],
+          },
+        }),
+        20,
+      );
+
+      expect(event?.indicators).toContain(
+        UpgradeIndicator.INTERFACE_EVENTS_CHANGED,
+      );
+      expect(event?.indicators).toContain(
+        UpgradeIndicator.INTERFACE_ERRORS_CHANGED,
+      );
+    });
+
+    // Same code, new deployment: the wasm is unchanged but storage and admin
+    // need not be.
+    it('treats a redeploy of identical code as an upgrade', () => {
+      const event = detector.observe(observation({ txHash: 'tx-2' }), 20);
+
+      expect(event?.indicators).toEqual([UpgradeIndicator.REDEPLOYED]);
+      expect(event?.severity).toBe(UpgradeSeverity.INFO);
+    });
+
+    it('can be configured to ignore redeploys of identical code', () => {
+      const lenient = new SorobanUpgradeDetector({
+        treatRedeployAsUpgrade: false,
+      });
+
+      lenient.observe(observation(), 10);
+
+      expect(lenient.observe(observation({ txHash: 'tx-2' }), 20)).toBeNull();
+    });
+
+    it('does not report an upgrade twice for the same deployment', () => {
+      detector.observe(
+        observation({ wasmHash: 'b'.repeat(64), txHash: 'tx-2' }),
+        20,
+      );
+
+      expect(
+        detector.observe(
+          observation({ wasmHash: 'b'.repeat(64), txHash: 'tx-2' }),
+          30,
+        ),
+      ).toBeNull();
+      expect(detector.getHistory()).toHaveLength(1);
+    });
+
+    it('counts successive upgrades', () => {
+      detector.observe(
+        observation({ wasmHash: 'b'.repeat(64), txHash: 'tx-2' }),
+        20,
+      );
+      detector.observe(
+        observation({ wasmHash: 'c'.repeat(64), txHash: 'tx-3' }),
+        30,
+      );
+
+      expect(detector.getState(ADDRESS, NETWORK)?.upgradeCount).toBe(2);
+      expect(detector.getHistory()).toHaveLength(2);
+    });
+  });
+
+  describe('severity', () => {
+    beforeEach(() => {
+      detector.observe(observation(), 10);
+    });
+
+    it('calls a removed function critical', () => {
+      const event = detector.observe(
+        observation({
+          wasmHash: 'b'.repeat(64),
+          interface: {
+            functions: ['transfer(amount:i128)'],
+            events: ['transfer'],
+            errors: [1],
+          },
+        }),
+        20,
+      );
+
+      expect(event?.severity).toBe(UpgradeSeverity.CRITICAL);
+    });
+
+    // A changed signature reads as one function removed and another added,
+    // which is right: existing callers break.
+    it('calls a changed signature critical', () => {
+      const event = detector.observe(
+        observation({
+          wasmHash: 'b'.repeat(64),
+          interface: {
+            functions: ['transfer(amount:u64)', 'balance(id:address):i128'],
+            events: ['transfer'],
+            errors: [1],
+          },
+        }),
+        20,
+      );
+
+      expect(event?.severity).toBe(UpgradeSeverity.CRITICAL);
+      expect(event?.removedFunctions).toEqual(['transfer(amount:i128)']);
+    });
+
+    // Nothing visible changed — which is exactly why this deployment would
+    // otherwise keep being trusted.
+    it('calls new code behind an unchanged interface major', () => {
+      const event = detector.observe(
+        observation({ wasmHash: 'b'.repeat(64) }),
+        20,
+      );
+
+      expect(event?.severity).toBe(UpgradeSeverity.MAJOR);
+    });
+
+    it('calls a spec-version-only change minor', () => {
+      const event = detector.observe(observation({ specVersion: '1.1.0' }), 20);
+
+      expect(event?.severity).toBe(UpgradeSeverity.MINOR);
+    });
+
+    it('ranks severities in order', () => {
+      expect(severityRank(UpgradeSeverity.CRITICAL)).toBeGreaterThan(
+        severityRank(UpgradeSeverity.MAJOR),
+      );
+      expect(severityRank(UpgradeSeverity.MAJOR)).toBeGreaterThan(
+        severityRank(UpgradeSeverity.MINOR),
+      );
+      expect(severityRank(UpgradeSeverity.MINOR)).toBeGreaterThan(
+        severityRank(UpgradeSeverity.INFO),
+      );
+    });
+
+    it('classifies an empty change set as informational', () => {
+      expect(classifySeverity([], [])).toBe(UpgradeSeverity.INFO);
+    });
+  });
+
+  describe('integration review flags', () => {
+    beforeEach(() => {
+      detector.register({
+        contractAddress: ADDRESS,
+        network: NETWORK,
+        integrations: ['bridge-a', 'bridge-b'],
+      });
+      detector.observe(observation(), 10);
+    });
+
+    it('flags every integration that depended on the old deployment', () => {
+      const event = detector.observe(
+        observation({ wasmHash: 'b'.repeat(64) }),
+        20,
+      );
+
+      expect(event?.affectedIntegrations).toEqual(['bridge-a', 'bridge-b']);
+      expect(
+        detector.getReviewFlags().map((flag) => flag.integrationId),
+      ).toEqual(['bridge-a', 'bridge-b']);
+      expect(detector.needsReview('bridge-a')).toBe(true);
+    });
+
+    it('flags nothing when no integration is registered', () => {
+      const bare = new SorobanUpgradeDetector();
+
+      bare.observe(observation(), 10);
+      bare.observe(observation({ wasmHash: 'b'.repeat(64) }), 20);
+
+      expect(bare.getReviewFlags()).toHaveLength(0);
+    });
+
+    // The open flag is what matters, not how many upgrades produced it.
+    it('does not raise a second flag while one is open', () => {
+      detector.observe(
+        observation({ wasmHash: 'b'.repeat(64), txHash: 'tx-2' }),
+        20,
+      );
+      detector.observe(
+        observation({ wasmHash: 'c'.repeat(64), txHash: 'tx-3' }),
+        30,
+      );
+
+      expect(detector.getReviewFlags('bridge-a')).toHaveLength(1);
+    });
+
+    it('raises the open flag to the worst severity seen', () => {
+      detector.observe(observation({ specVersion: '1.1.0' }), 20);
+      expect(detector.getReviewFlags('bridge-a')[0].severity).toBe(
+        UpgradeSeverity.MINOR,
+      );
+
+      detector.observe(
+        observation({
+          specVersion: '1.1.0',
+          wasmHash: 'c'.repeat(64),
+          interface: {
+            functions: ['transfer(amount:i128)'],
+            events: ['transfer'],
+            errors: [1],
+          },
+        }),
+        30,
+      );
+
+      expect(detector.getReviewFlags('bridge-a')[0].severity).toBe(
+        UpgradeSeverity.CRITICAL,
+      );
+    });
+
+    it('does not lower an open flag when a later upgrade is milder', () => {
+      detector.observe(
+        observation({
+          wasmHash: 'b'.repeat(64),
+          interface: {
+            functions: ['transfer(amount:i128)'],
+            events: ['transfer'],
+            errors: [1],
+          },
+        }),
+        20,
+      );
+      detector.observe(
+        observation({
+          wasmHash: 'b'.repeat(64),
+          specVersion: '1.1.0',
+          interface: {
+            functions: ['transfer(amount:i128)'],
+            events: ['transfer'],
+            errors: [1],
+          },
+        }),
+        30,
+      );
+
+      expect(detector.getReviewFlags('bridge-a')[0].severity).toBe(
+        UpgradeSeverity.CRITICAL,
+      );
+    });
+
+    it('clears a flag once an operator re-approves', () => {
+      detector.observe(observation({ wasmHash: 'b'.repeat(64) }), 20);
+
+      expect(
+        detector.clearReviewFlag('bridge-a', ADDRESS, NETWORK, 'ops', 40),
+      ).toBe(true);
+      expect(detector.needsReview('bridge-a')).toBe(false);
+      expect(detector.needsReview('bridge-b')).toBe(true);
+    });
+
+    it('keeps a cleared flag in the audit list', () => {
+      detector.observe(observation({ wasmHash: 'b'.repeat(64) }), 20);
+      detector.clearReviewFlag('bridge-a', ADDRESS, NETWORK, 'ops', 40);
+
+      const cleared = detector
+        .getAllReviewFlags()
+        .find((flag) => flag.integrationId === 'bridge-a');
+
+      expect(cleared?.clearedAt).toBe(40);
+      expect(cleared?.clearedBy).toBe('ops');
+    });
+
+    it('reports nothing cleared for an unknown flag', () => {
+      expect(detector.clearReviewFlag('nobody', ADDRESS, NETWORK)).toBe(false);
+    });
+
+    it('flags an integration added after the contract was tracked', () => {
+      detector.addIntegration(ADDRESS, NETWORK, 'bridge-c');
+      detector.observe(observation({ wasmHash: 'b'.repeat(64) }), 20);
+
+      expect(detector.needsReview('bridge-c')).toBe(true);
+    });
+  });
+
+  describe('history', () => {
+    it('filters history by contract', () => {
+      detector.observe(observation(), 10);
+      detector.observe(observation({ wasmHash: 'b'.repeat(64) }), 20);
+
+      expect(detector.getHistory(ADDRESS, NETWORK)).toHaveLength(1);
+      expect(detector.getHistory('CSOMETHINGELSE')).toHaveLength(0);
+    });
+
+    it('accepts an un-normalized address', () => {
+      detector.observe(observation(), 10);
+      detector.observe(observation({ wasmHash: 'b'.repeat(64) }), 20);
+
+      expect(detector.getHistory(ADDRESS.toLowerCase())).toHaveLength(1);
+    });
+
+    // Unbounded history in a long-running monitor is a slow memory leak.
+    it('caps retained history', () => {
+      const capped = new SorobanUpgradeDetector({ maxHistory: 2 });
+
+      capped.observe(observation(), 1);
+      capped.observe(observation({ wasmHash: 'b'.repeat(64) }), 2);
+      capped.observe(observation({ wasmHash: 'c'.repeat(64) }), 3);
+      capped.observe(observation({ wasmHash: 'd'.repeat(64) }), 4);
+
+      const history = capped.getHistory();
+
+      expect(history).toHaveLength(2);
+      expect(history[1].currentFingerprint.wasmHash).toBe('d'.repeat(64));
+    });
+
+    it('gives each event a distinct id', () => {
+      detector.observe(observation(), 10);
+      detector.observe(observation({ wasmHash: 'b'.repeat(64) }), 20);
+      detector.observe(observation({ wasmHash: 'c'.repeat(64) }), 30);
+
+      const [first, second] = detector.getHistory();
+
+      expect(first.id).not.toBe(second.id);
+    });
+
+    it('resets everything', () => {
+      detector.observe(observation(), 10);
+      detector.observe(observation({ wasmHash: 'b'.repeat(64) }), 20);
+      detector.reset();
+
+      expect(detector.getHistory()).toHaveLength(0);
+      expect(detector.getTrackedContracts()).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Two closely related pieces of the same defence, so they ship together: fingerprinting establishes what an approved deployment *is*, and upgrade detection notices when a configured contract stops being it.

Closes #1066
Closes #1065

---

### #1066 — Deployment fingerprinting

`src/security/contracts/fingerprints/`, `src/contracts/verification/`

A fingerprint is a sha256 over exactly the fields that define a deployment's identity — contract address, network, wasm hash, spec version, and a canonical digest of the interface surface. Observation-time context (`observedAt`, `deployedAt`, `txHash`, deployer) is deliberately excluded: the same deployment read from two nodes at two times must fingerprint identically, or every comparison is a false alarm.

Determinism is enforced where it can quietly break:

- **Ordering.** The interface surface is sorted and de-duplicated before hashing. Two nodes can enumerate a contract spec in different orders; that is not an interface change and must not read as one.
- **Normalization.** Addresses are upper-cased (base32), wasm hashes lower-cased with an optional `0x` stripped.
- **Non-hex hashes are rejected.** A base64 hash would fingerprint perfectly cleanly and then never match anything — a permanent silent mismatch is worse than a loud failure at the door.
- **Delimiter safety.** The identity payload is a JSON array, not `address|network|hash`, so no field value can impersonate another deployment by containing the separator.
- **Networks are separate.** The same contract id exists on testnet and public with different code; colliding them would let a testnet deployment satisfy a mainnet check.

`ApprovedFingerprintStore` holds what an operator approved, scoped per contract and network. Re-approving updates rather than duplicating (and un-revokes, since that is an explicit decision to trust again); revoked records are retained rather than deleted, because "approved and then revoked" is a materially different answer from "never heard of it". Persistence is left to the caller via `snapshot()` / `restore()`.

`SorobanDeploymentVerifier` returns four distinct statuses rather than a boolean, because they call for different responses:

| Status | Means | Response |
|---|---|---|
| `approved` | matches an active approval | proceed |
| `mismatch` | contract has approvals, this deployment is not one | investigate — result names what differs |
| `revoked` | matches an approval since withdrawn | stop the integration |
| `unknown` | nothing ever approved here | make an approval decision |

### #1065 — Upgrade detection

`src/security/contracts/upgrades/soroban/`, `src/contracts/monitoring/`

`SorobanUpgradeDetector` tracks configured contracts and compares each observation by **fingerprint**, not by any single field — so an upgrade that keeps the interface identical, the case most likely to go unnoticed, is still caught.

Indicators: wasm hash changed, spec version changed, functions added, functions removed, events changed, error codes changed, redeployed. Severity:

- **critical** — a function was removed. A changed signature reads as one removed plus one added, which is correct: existing callers break.
- **major** — new code behind an unchanged interface. Nothing visible changed, which is precisely why it would otherwise keep being trusted.
- **minor** — spec version, additions, events or error codes only.
- **info** — same code redeployed. Still surfaced by default: the wasm is unchanged but storage and admin need not be.

Every integration that depended on the previous deployment is flagged for review. A second upgrade while a flag is open does not raise a duplicate — it raises the existing flag to the worst severity seen, and never lowers it. Flags clear only when an operator re-approves, and cleared flags stay in the audit list.

`ContractUpgradeMonitor` owns scheduling and fan-out only:

- Probes are injectable, so this is testable without a Horizon node.
- **A probe failure is not an upgrade.** Tracked state is left untouched on error, so an unreachable node cannot look like a rollback.
- Probe waits are bounded — a hung probe would otherwise stall every later check on the interval.
- **One notifier throwing does not stop the others, or the loop.** A broken webhook is the worst possible reason to stop noticing contract upgrades.
- When a fingerprint store is supplied, each observation is verified too and `unapproved-deployment` is emitted for anything not approved.

---

### Verification

```
jest tests/security/contracts   116 passed (5 suites)
tsc --noEmit --strict           clean over the new modules
eslint + prettier               clean
pnpm run build                  clean
```

One thing worth flagging, since it affects how much the green check above is worth: CI runs `pnpm run build` and `cargo test`, and that build is `nest build --path apps/api/tsconfig.json`, whose `include` is `./src/**/*.ts` and `packages/utils/src/**` — the repo-root `src/` tree, where this work and most other feature code lives, is never compiled by CI, and jest never runs at all. So CI would be green for this PR whether or not the code compiles. That is why the numbers above are from running the suite locally. Happy to add a `pnpm test` step and widen the build in a separate PR if you want it — it seemed wrong to slip a CI change into a feature branch.
