### PR TITLE
feat: implement Stellar route revalidation

### DIFF
--- a/src/execution/validation/index.ts
+++ b/src/execution/validation/index.ts
@@ -8,3 +8,14 @@ export {
   validateTransactionResources,
   validateContractCompatibility,
 } from './stellar-pre-execution-validators';
+export {
+  validateProviderAvailability,
+  validateRouteQuoteFreshness,
+  validateRouteLiquidity,
+  validateRouteDestinationCompatibility,
+  compareAmountStrings,
+} from './stellar-route-revalidation-validators';
+export {
+  validateRouteBeforeSigning,
+  type PreSigningRouteValidationResult,
+} from './stellar-pre-signing-validation';

--- a/src/execution/validation/stellar-pre-signing-validation.ts
+++ b/src/execution/validation/stellar-pre-signing-validation.ts
@@ -1,0 +1,23 @@
+import { StellarRouteRevalidationService } from '../../routing/revalidation/stellar';
+import type {
+  StellarRouteRevalidationContext,
+  StellarRouteRevalidationResult,
+} from '../../routing/revalidation/stellar/types';
+
+export interface PreSigningRouteValidationResult {
+  routeRevalidation: StellarRouteRevalidationResult;
+  blocked: boolean;
+  canProceedToSigning: boolean;
+}
+
+export function validateRouteBeforeSigning(
+  context: StellarRouteRevalidationContext,
+  service: StellarRouteRevalidationService,
+): PreSigningRouteValidationResult {
+  const routeRevalidation = service.revalidate(context);
+  return {
+    routeRevalidation,
+    blocked: routeRevalidation.blocked,
+    canProceedToSigning: !routeRevalidation.blocked,
+  };
+}

--- a/src/execution/validation/stellar-route-revalidation-validators.ts
+++ b/src/execution/validation/stellar-route-revalidation-validators.ts
@@ -1,0 +1,293 @@
+import type { StellarBridgeQuote } from '../../quotes/types/canonical-quote';
+import type { SupportedChain } from '../../validation/bridgeability/stellar/stellar-bridgeability.types';
+import { StellarBridgeabilityChecker } from '../../validation/bridgeability/stellar/stellar-bridgeability.checker';
+import type {
+  RevalidationCheckFailure,
+  RevalidationCheckResult,
+  StellarRouteRevalidationContext,
+  StellarRouteRevalidationDependencies,
+} from '../../routing/revalidation/stellar/types';
+import { validateQuoteFreshness } from './stellar-pre-execution-validators';
+import type { StellarPreExecutionSafetyContext } from './types';
+
+function fail(
+  check: RevalidationCheckResult['check'],
+  code: string,
+  reason: string,
+  action: string,
+  retryable = false,
+): RevalidationCheckFailure {
+  return { check, code, severity: 'error', reason, action, retryable };
+}
+
+function mapFreshnessFailures(
+  failures: Array<{ code: string; reason: string; action: string }>,
+): RevalidationCheckFailure[] {
+  return failures.map((failure) => ({
+    check: 'quote_freshness',
+    code: failure.code,
+    severity: 'error' as const,
+    reason: failure.reason,
+    action: failure.action,
+    retryable: false,
+  }));
+}
+
+function parseAssetIdentifier(
+  asset: string,
+  metadata: Record<string, unknown>,
+): { code: string; issuer?: string } {
+  const trimmed = asset.trim();
+  if (trimmed.includes(':')) {
+    const [code, issuer] = trimmed.split(':');
+    return { code: code.trim(), issuer: issuer?.trim() };
+  }
+  const issuer = metadata.sourceAssetIssuer;
+  if (typeof issuer === 'string' && issuer.trim()) {
+    return { code: trimmed, issuer: issuer.trim() };
+  }
+  return { code: trimmed };
+}
+
+/** Compare two non-negative decimal amount strings without floating-point loss. */
+export function compareAmountStrings(left: string, right: string): number {
+  const normalize = (value: string): bigint => {
+    const trimmed = value.trim();
+    if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+      throw new Error(`Invalid decimal amount: ${value}`);
+    }
+    const [whole, fraction = ''] = trimmed.split('.');
+    const scale = 18n;
+    const frac = fraction.padEnd(Number(scale), '0').slice(0, Number(scale));
+    return BigInt(whole) * 10n ** scale + BigInt(frac || '0');
+  };
+
+  const a = normalize(left);
+  const b = normalize(right);
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function requiredLiquidityAmount(ctx: StellarRouteRevalidationContext): string {
+  return ctx.requiredLiquidity ?? ctx.route.amount ?? ctx.quote.output.inputAmount;
+}
+
+export function validateProviderAvailability(
+  ctx: StellarRouteRevalidationContext,
+  deps: StellarRouteRevalidationDependencies,
+): RevalidationCheckResult {
+  const check = 'provider_availability' as const;
+  const failures: RevalidationCheckFailure[] = [];
+  const providerId = ctx.route.provider;
+
+  const provider = deps.registry.get(providerId);
+  if (!provider) {
+    failures.push(
+      fail(
+        check,
+        'PROVIDER_NOT_REGISTERED',
+        `Provider "${providerId}" is not registered.`,
+        'Select a route from a registered provider.',
+      ),
+    );
+    return { check, passed: false, failures };
+  }
+
+  if (provider.status !== 'active' && provider.status !== 'degraded') {
+    const retryable = provider.status === 'maintenance';
+    failures.push(
+      fail(
+        check,
+        'PROVIDER_UNAVAILABLE',
+        `Provider "${providerId}" is ${provider.status} and cannot execute routes.`,
+        retryable
+          ? 'Wait for maintenance to complete or select another provider.'
+          : 'Select a route from an active provider.',
+        retryable,
+      ),
+    );
+  }
+
+  if (deps.healthMonitor?.isRouteDisabled(ctx.route.id)) {
+    failures.push(
+      fail(
+        check,
+        'ROUTE_DISABLED',
+        `Route "${ctx.route.id}" is disabled by health monitoring.`,
+        'Select an alternative route.',
+      ),
+    );
+  }
+
+  if (deps.circuitBreaker && !deps.circuitBreaker.isAvailable(providerId)) {
+    failures.push(
+      fail(
+        check,
+        'PROVIDER_CIRCUIT_OPEN',
+        `Provider "${providerId}" circuit breaker is open.`,
+        'Retry after the provider cooldown or select another route.',
+        true,
+      ),
+    );
+  }
+
+  if (deps.maintenanceRegistry && !deps.maintenanceRegistry.isAvailable(providerId)) {
+    failures.push(
+      fail(
+        check,
+        'PROVIDER_UNAVAILABLE',
+        `Provider "${providerId}" is unavailable due to maintenance or outage.`,
+        'Retry later or select another provider.',
+        true,
+      ),
+    );
+  }
+
+  return { check, passed: failures.length === 0, failures };
+}
+
+export function validateRouteQuoteFreshness(
+  ctx: StellarRouteRevalidationContext,
+  now: number,
+): RevalidationCheckResult {
+  const check = 'quote_freshness' as const;
+  const failures: RevalidationCheckFailure[] = [];
+
+  const freshnessContext = {
+    quoteQuotedAt: ctx.quote.quotedAt,
+    quoteTtlMs: ctx.quoteTtlMs,
+  } as StellarPreExecutionSafetyContext;
+
+  const ttlResult = validateQuoteFreshness(freshnessContext, now);
+  failures.push(...mapFreshnessFailures(ttlResult.failures));
+
+  if (ctx.quote.expiresAt !== undefined && ctx.quote.expiresAt < now) {
+    failures.push(
+      fail(
+        check,
+        'QUOTE_EXPIRED',
+        'The selected quote has passed its provider expiration time.',
+        'Refresh the quote and lock the route again before signing.',
+      ),
+    );
+  }
+
+  return { check, passed: failures.length === 0, failures };
+}
+
+export function validateRouteLiquidity(
+  ctx: StellarRouteRevalidationContext,
+): RevalidationCheckResult {
+  const check = 'liquidity' as const;
+  const failures: RevalidationCheckFailure[] = [];
+
+  if (ctx.availableLiquidity === undefined) {
+    failures.push(
+      fail(
+        check,
+        'LIQUIDITY_UNVERIFIED',
+        'Liquidity could not be verified for the selected route.',
+        'Fetch a current liquidity snapshot or refresh the provider quote before signing.',
+        true,
+      ),
+    );
+    return { check, passed: false, failures };
+  }
+
+  const required = requiredLiquidityAmount(ctx);
+  try {
+    if (compareAmountStrings(ctx.availableLiquidity, required) < 0) {
+      failures.push(
+        fail(
+          check,
+          'INSUFFICIENT_LIQUIDITY',
+          `Available liquidity ${ctx.availableLiquidity} is below the required transfer amount ${required}.`,
+          'Reduce the transfer amount or select a route with more liquidity.',
+        ),
+      );
+    }
+  } catch (error) {
+    failures.push(
+      fail(
+        check,
+        'LIQUIDITY_UNVERIFIED',
+        error instanceof Error ? error.message : 'Liquidity amounts could not be compared.',
+        'Provide valid liquidity and transfer amount values before signing.',
+        true,
+      ),
+    );
+  }
+
+  return { check, passed: failures.length === 0, failures };
+}
+
+function providerSupportsDestination(
+  providerId: string,
+  quote: StellarBridgeQuote,
+  deps: StellarRouteRevalidationDependencies,
+): RevalidationCheckFailure | null {
+  const provider = deps.registry.get(providerId);
+  if (!provider) {
+    return null;
+  }
+
+  const destinationChain = quote.route.destinationChain.trim().toLowerCase();
+  const destinationAsset = quote.route.destinationAsset.trim().toUpperCase();
+  const supportsChain = provider.chains.some(
+    (chain) => chain.identifier.trim().toLowerCase() === destinationChain,
+  );
+  const supportsAsset = provider.assets.some(
+    (asset) => asset.code.trim().toUpperCase() === destinationAsset,
+  );
+
+  if (!supportsChain || !supportsAsset) {
+    return fail(
+      'destination_compatibility',
+      'PROVIDER_ROUTE_UNSUPPORTED',
+      `Provider "${providerId}" does not support ${destinationAsset} on ${quote.route.destinationChain}.`,
+      'Select a provider that supports the destination chain and asset.',
+    );
+  }
+
+  return null;
+}
+
+export function validateRouteDestinationCompatibility(
+  ctx: StellarRouteRevalidationContext,
+  deps: StellarRouteRevalidationDependencies,
+): RevalidationCheckResult {
+  const check = 'destination_compatibility' as const;
+  const failures: RevalidationCheckFailure[] = [];
+  const bridgeabilityChecker = deps.bridgeabilityChecker ?? new StellarBridgeabilityChecker();
+  const asset = parseAssetIdentifier(ctx.quote.route.sourceAsset, ctx.quote.metadata);
+  const sourceChain = ctx.quote.route.sourceChain.trim().toLowerCase() as SupportedChain;
+  const targetChain = ctx.quote.route.destinationChain.trim().toLowerCase() as SupportedChain;
+
+  const bridgeability = bridgeabilityChecker.check({
+    asset,
+    sourceChain,
+    targetChain,
+  });
+
+  if (!bridgeability.isBridgeable) {
+    failures.push(
+      fail(
+        check,
+        bridgeability.reason?.includes('target') ||
+          bridgeability.reason?.includes('not supported')
+          ? 'DESTINATION_CHAIN_UNSUPPORTED'
+          : 'DESTINATION_ASSET_UNSUPPORTED',
+        bridgeability.reason ?? 'Destination is not bridgeable for the selected asset.',
+        'Change the destination chain or asset before signing.',
+      ),
+    );
+  }
+
+  const providerFailure = providerSupportsDestination(ctx.route.provider, ctx.quote, deps);
+  if (providerFailure) {
+    failures.push(providerFailure);
+  }
+
+  return { check, passed: failures.length === 0, failures };
+}

--- a/src/routing/revalidation/stellar/index.ts
+++ b/src/routing/revalidation/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { StellarRouteRevalidationService } from './stellar-route-revalidation.service';

--- a/src/routing/revalidation/stellar/stellar-route-revalidation.service.ts
+++ b/src/routing/revalidation/stellar/stellar-route-revalidation.service.ts
@@ -1,0 +1,44 @@
+import {
+  validateProviderAvailability,
+  validateRouteDestinationCompatibility,
+  validateRouteLiquidity,
+  validateRouteQuoteFreshness,
+} from '../../../execution/validation/stellar-route-revalidation-validators';
+import type {
+  StellarRouteRevalidationConfig,
+  StellarRouteRevalidationContext,
+  StellarRouteRevalidationDependencies,
+  StellarRouteRevalidationResult,
+} from './types';
+
+
+export class StellarRouteRevalidationService {
+  private readonly now: () => number;
+
+  constructor(
+    private readonly deps: StellarRouteRevalidationDependencies,
+    config: StellarRouteRevalidationConfig = {},
+  ) {
+    this.now = config.now ?? (() => Date.now());
+  }
+
+  revalidate(context: StellarRouteRevalidationContext): StellarRouteRevalidationResult {
+    const checkedAt = this.now();
+    const checks = [
+      validateProviderAvailability(context, this.deps),
+      validateRouteQuoteFreshness(context, checkedAt),
+      validateRouteLiquidity(context),
+      validateRouteDestinationCompatibility(context, this.deps),
+    ];
+    const failures = checks.flatMap((result) => result.failures);
+    const blocked = failures.some((failure) => failure.severity === 'error');
+
+    return {
+      valid: !blocked,
+      blocked,
+      checkedAt,
+      checks,
+      failures,
+    };
+  }
+}

--- a/src/routing/revalidation/stellar/types.ts
+++ b/src/routing/revalidation/stellar/types.ts
@@ -1,0 +1,64 @@
+import type { StellarBridgeQuote } from '../../../quotes/types/canonical-quote';
+import type { StellarBridgeProviderRegistry } from '../../../providers/stellar/registry/stellar-bridge-provider-registry';
+import type { StellarProviderCircuitBreakerRegistry } from '../../../providers/circuit-breaker/stellar/stellar-provider-circuit-breaker';
+import type { StellarMaintenanceRegistry } from '../../../providers/maintenance/stellar/stellar-maintenance-registry';
+import type { StellarRouteHealthMonitor } from '../../../monitoring/routes/stellar/stellar-route-health-monitor';
+import type { StellarBridgeabilityChecker } from '../../../validation/bridgeability/stellar/stellar-bridgeability.checker';
+import type { BridgeRoute } from '../../../services/route-ranker';
+
+export type RevalidationCheckName =
+  | 'provider_availability'
+  | 'quote_freshness'
+  | 'liquidity'
+  | 'destination_compatibility';
+
+export type RevalidationSeverity = 'error' | 'warning';
+
+export interface RevalidationCheckFailure {
+  check: RevalidationCheckName;
+  code: string;
+  severity: RevalidationSeverity;
+  reason: string;
+  action: string;
+  retryable?: boolean;
+}
+
+export interface RevalidationCheckResult {
+  check: RevalidationCheckName;
+  passed: boolean;
+  failures: RevalidationCheckFailure[];
+}
+
+export interface StellarRouteRevalidationContext {
+  route: BridgeRoute;
+  quote: StellarBridgeQuote;
+  /** Caller-supplied quote TTL; no repository default is applied. */
+  quoteTtlMs: number;
+  /**
+   * Available liquidity in the same asset/unit as the transfer amount.
+   * When omitted the liquidity check returns LIQUIDITY_UNVERIFIED.
+   */
+  availableLiquidity?: string;
+  /** Defaults to route.amount, then quote.output.inputAmount. */
+  requiredLiquidity?: string;
+}
+
+export interface StellarRouteRevalidationResult {
+  valid: boolean;
+  blocked: boolean;
+  checkedAt: number;
+  checks: RevalidationCheckResult[];
+  failures: RevalidationCheckFailure[];
+}
+
+export interface StellarRouteRevalidationConfig {
+  now?: () => number;
+}
+
+export interface StellarRouteRevalidationDependencies {
+  registry: StellarBridgeProviderRegistry;
+  bridgeabilityChecker?: StellarBridgeabilityChecker;
+  healthMonitor?: StellarRouteHealthMonitor;
+  circuitBreaker?: StellarProviderCircuitBreakerRegistry;
+  maintenanceRegistry?: StellarMaintenanceRegistry;
+}

--- a/tests/routing/revalidation/stellar-route-revalidation.service.spec.ts
+++ b/tests/routing/revalidation/stellar-route-revalidation.service.spec.ts
@@ -1,0 +1,377 @@
+import { StellarProviderCircuitBreakerRegistry } from '../../../src/providers/circuit-breaker/stellar';
+import { StellarBridgeProviderRegistry } from '../../../src/providers/stellar/registry/stellar-bridge-provider-registry';
+import type { RegisterStellarProviderInput } from '../../../src/providers/stellar/registry/types';
+import { StellarRouteHealthMonitor } from '../../../src/monitoring/routes/stellar/stellar-route-health-monitor';
+import { StellarRouteRevalidationService } from '../../../src/routing/revalidation/stellar';
+import type {
+  StellarRouteRevalidationContext,
+  StellarRouteRevalidationDependencies,
+} from '../../../src/routing/revalidation/stellar/types';
+import type { StellarBridgeQuote } from '../../../src/quotes/types/canonical-quote';
+import type { BridgeRoute } from '../../../src/services/route-ranker';
+import {
+  compareAmountStrings,
+  validateRouteBeforeSigning,
+} from '../../../src/execution/validation';
+import { StellarBridgeabilityChecker } from '../../../src/validation/bridgeability/stellar/stellar-bridgeability.checker';
+
+const FIXED_NOW = 1_700_000_000_000;
+const SAMPLE_NETWORK = 'Public Global Stellar Network ; September 2015';
+
+const baseProviderInput = (
+  id = 'allbridge',
+  overrides: Partial<RegisterStellarProviderInput> = {},
+): RegisterStellarProviderInput => ({
+  id,
+  name: `Provider ${id}`,
+  kind: 'soroban',
+  endpoint: `https://${id}.example.com`,
+  networks: [SAMPLE_NETWORK],
+  chains: [
+    { identifier: 'stellar', assetCode: 'XLM' },
+    { identifier: 'ethereum', assetCode: 'XLM' },
+  ],
+  assets: [{ code: 'XLM' }],
+  feeModel: 'bps',
+  feeBps: 30,
+  ...overrides,
+});
+
+const baseRoute = (overrides: Partial<BridgeRoute> = {}): BridgeRoute => ({
+  id: 'route-1',
+  fromChain: 'stellar',
+  toChain: 'ethereum',
+  fromToken: 'XLM',
+  toToken: 'XLM',
+  amount: '100',
+  fee: { amount: '0.1', token: 'XLM' },
+  estimatedTime: 5,
+  successRate: 0.98,
+  provider: 'allbridge',
+  ...overrides,
+});
+
+const baseQuote = (overrides: Partial<StellarBridgeQuote> = {}): StellarBridgeQuote => ({
+  id: 'quote-1',
+  providerId: 'allbridge',
+  providerName: 'AllBridge',
+  route: {
+    sourceChain: 'stellar',
+    destinationChain: 'ethereum',
+    sourceAsset: 'XLM',
+    destinationAsset: 'XLM',
+    hops: 1,
+  },
+  fees: {
+    networkFeeUsdCents: 10,
+    totalFeeUsdCents: 10,
+    feeToken: 'XLM',
+  },
+  execution: {
+    estimatedTimeSeconds: 60,
+    successRate: 0.98,
+  },
+  output: {
+    inputAmount: '100',
+    outputAmount: '99.5',
+    netOutputAmount: '99.0',
+    minOutputAmount: '98.0',
+  },
+  metadata: {},
+  quotedAt: FIXED_NOW,
+  ...overrides,
+});
+
+function validContext(
+  overrides: Partial<StellarRouteRevalidationContext> = {},
+): StellarRouteRevalidationContext {
+  return {
+    route: baseRoute(),
+    quote: baseQuote(),
+    quoteTtlMs: 60_000,
+    availableLiquidity: '1000',
+    ...overrides,
+  };
+}
+
+function createService(
+  deps: Partial<StellarRouteRevalidationDependencies> = {},
+  now = () => FIXED_NOW,
+): StellarRouteRevalidationService {
+  const registry = deps.registry ?? new StellarBridgeProviderRegistry({ now: () => FIXED_NOW });
+  if (!deps.registry) {
+    registry.register(baseProviderInput());
+  }
+  return new StellarRouteRevalidationService(
+    {
+      registry,
+      bridgeabilityChecker: deps.bridgeabilityChecker ?? new StellarBridgeabilityChecker(),
+      healthMonitor: deps.healthMonitor,
+      circuitBreaker: deps.circuitBreaker,
+      maintenanceRegistry: deps.maintenanceRegistry,
+    },
+    { now },
+  );
+}
+
+describe('StellarRouteRevalidationService (#1064)', () => {
+  describe('provider availability', () => {
+    it('passes for a valid active provider', () => {
+      const service = createService();
+      const result = service.revalidate(validContext());
+      expect(result.valid).toBe(true);
+      expect(result.checks.find((c) => c.check === 'provider_availability')?.passed).toBe(true);
+    });
+
+    it('fails when the provider is not registered', () => {
+      const registry = new StellarBridgeProviderRegistry();
+      const service = createService({ registry });
+      const result = service.revalidate(validContext());
+      expect(result.failures.some((f) => f.code === 'PROVIDER_NOT_REGISTERED')).toBe(true);
+      expect(result.blocked).toBe(true);
+    });
+
+    it('fails when the provider is inactive', () => {
+      const registry = new StellarBridgeProviderRegistry();
+      registry.register(baseProviderInput('allbridge', { status: 'inactive' }));
+      const service = createService({ registry });
+      const result = service.revalidate(validContext());
+      expect(result.failures.some((f) => f.code === 'PROVIDER_UNAVAILABLE')).toBe(true);
+      expect(result.failures.find((f) => f.code === 'PROVIDER_UNAVAILABLE')?.retryable).toBe(false);
+    });
+
+    it('fails with a retryable error when the circuit breaker is open', () => {
+      const registry = new StellarBridgeProviderRegistry();
+      registry.register(baseProviderInput());
+      const circuitBreaker = new StellarProviderCircuitBreakerRegistry({
+        failureThreshold: 1,
+        now: () => 0,
+      });
+      circuitBreaker.reportFailure('allbridge');
+      const service = createService({ registry, circuitBreaker });
+      const result = service.revalidate(validContext());
+      expect(result.failures.some((f) => f.code === 'PROVIDER_CIRCUIT_OPEN')).toBe(true);
+      expect(result.failures.find((f) => f.code === 'PROVIDER_CIRCUIT_OPEN')?.retryable).toBe(true);
+    });
+
+    it('fails when the route is disabled by the health monitor', async () => {
+      const registry = new StellarBridgeProviderRegistry();
+      registry.register(baseProviderInput());
+      const healthMonitor = new StellarRouteHealthMonitor({
+        timeoutMs: 10,
+        unhealthyThreshold: 1,
+      });
+      healthMonitor.registerRoute('route-1', async () => ({
+        available: false,
+        errorMessage: 'route unreachable',
+      }));
+      await healthMonitor.checkAll();
+      const service = createService({ registry, healthMonitor });
+      const result = service.revalidate(validContext());
+      expect(result.failures.some((f) => f.code === 'ROUTE_DISABLED')).toBe(true);
+    });
+  });
+
+  describe('quote freshness', () => {
+    it('passes for a fresh quote', () => {
+      const service = createService();
+      const result = service.revalidate(validContext());
+      expect(result.checks.find((c) => c.check === 'quote_freshness')?.passed).toBe(true);
+    });
+
+    it('fails when quoteTtlMs is exceeded', () => {
+      const service = createService();
+      const result = service.revalidate(
+        validContext({
+          quote: baseQuote({ quotedAt: FIXED_NOW - 120_000 }),
+          quoteTtlMs: 60_000,
+        }),
+      );
+      expect(result.failures.some((f) => f.code === 'QUOTE_STALE')).toBe(true);
+    });
+
+    it('fails when expiresAt is in the past', () => {
+      const service = createService();
+      const result = service.revalidate(
+        validContext({
+          quote: baseQuote({ expiresAt: FIXED_NOW - 1 }),
+        }),
+      );
+      expect(result.failures.some((f) => f.code === 'QUOTE_EXPIRED')).toBe(true);
+    });
+
+    it('does not invent a default quoteTtlMs', () => {
+      const service = createService();
+      const result = service.revalidate(
+        validContext({
+          quote: baseQuote({ quotedAt: FIXED_NOW - 1 }),
+          quoteTtlMs: 0,
+        }),
+      );
+      expect(result.failures.some((f) => f.code === 'QUOTE_TTL_INVALID')).toBe(true);
+    });
+  });
+
+  describe('liquidity', () => {
+    it('passes when available liquidity covers the transfer amount', () => {
+      const service = createService();
+      const result = service.revalidate(validContext({ availableLiquidity: '1000' }));
+      expect(result.checks.find((c) => c.check === 'liquidity')?.passed).toBe(true);
+    });
+
+    it('fails when available liquidity is insufficient', () => {
+      const service = createService();
+      const result = service.revalidate(validContext({ availableLiquidity: '10' }));
+      expect(result.failures.some((f) => f.code === 'INSUFFICIENT_LIQUIDITY')).toBe(true);
+    });
+
+    it('fails with LIQUIDITY_UNVERIFIED when liquidity data is missing', () => {
+      const service = createService();
+      const result = service.revalidate(validContext({ availableLiquidity: undefined }));
+      expect(result.failures.some((f) => f.code === 'LIQUIDITY_UNVERIFIED')).toBe(true);
+      expect(result.failures.find((f) => f.code === 'LIQUIDITY_UNVERIFIED')?.retryable).toBe(true);
+    });
+
+    it('does not use networkMetrics liquidityUsd as a transfer-amount gate', () => {
+      const service = createService();
+      const result = service.revalidate(
+        validContext({
+          route: baseRoute({
+            networkMetrics: { liquidityUsd: 10_000_000 },
+          }),
+          availableLiquidity: undefined,
+        }),
+      );
+      expect(result.failures.some((f) => f.code === 'LIQUIDITY_UNVERIFIED')).toBe(true);
+      expect(result.failures.some((f) => f.code === 'INSUFFICIENT_LIQUIDITY')).toBe(false);
+    });
+
+    it('compares decimal amounts without using floating-point equality', () => {
+      expect(compareAmountStrings('1000.50', '1000.5')).toBe(0);
+      expect(compareAmountStrings('99.99', '100')).toBe(-1);
+    });
+  });
+
+  describe('destination compatibility', () => {
+    it('passes for a supported destination chain and provider route', () => {
+      const service = createService();
+      const result = service.revalidate(validContext());
+      expect(result.checks.find((c) => c.check === 'destination_compatibility')?.passed).toBe(true);
+    });
+
+    it('fails for an unsupported destination chain', () => {
+      const service = createService();
+      const result = service.revalidate(
+        validContext({
+          quote: baseQuote({
+            route: {
+              sourceChain: 'stellar',
+              destinationChain: 'avalanche',
+              sourceAsset: 'XLM',
+              destinationAsset: 'XLM',
+              hops: 1,
+            },
+          }),
+        }),
+      );
+      expect(result.failures.some((f) => f.code === 'DESTINATION_CHAIN_UNSUPPORTED')).toBe(
+        true,
+      );
+    });
+
+    it('fails when the provider does not support the destination chain/asset', () => {
+      const registry = new StellarBridgeProviderRegistry();
+      registry.register(
+        baseProviderInput('allbridge', {
+          chains: [{ identifier: 'stellar', assetCode: 'XLM' }],
+          assets: [{ code: 'XLM' }],
+        }),
+      );
+      const service = createService({ registry });
+      const result = service.revalidate(validContext());
+      expect(result.failures.some((f) => f.code === 'PROVIDER_ROUTE_UNSUPPORTED')).toBe(true);
+    });
+
+    it('fails for an unsupported destination asset via bridgeability', () => {
+      const service = createService();
+      const result = service.revalidate(
+        validContext({
+          quote: baseQuote({
+            route: {
+              sourceChain: 'stellar',
+              destinationChain: 'ethereum',
+              sourceAsset: 'USDC',
+              destinationAsset: 'USDC',
+              hops: 1,
+            },
+          }),
+        }),
+      );
+      expect(result.failures.some((f) => f.code === 'DESTINATION_ASSET_UNSUPPORTED')).toBe(true);
+    });
+  });
+
+  describe('aggregation', () => {
+    it('returns valid when all four checks pass', () => {
+      const service = createService();
+      const result = service.revalidate(validContext());
+      expect(result.valid).toBe(true);
+      expect(result.blocked).toBe(false);
+      expect(result.checks).toHaveLength(4);
+      expect(result.failures).toEqual([]);
+    });
+
+    it('reports multiple failures without stopping early', () => {
+      const registry = new StellarBridgeProviderRegistry();
+      registry.register(baseProviderInput('allbridge', { status: 'inactive' }));
+      const service = createService({ registry });
+      const result = service.revalidate(
+        validContext({
+          quote: baseQuote({ quotedAt: FIXED_NOW - 120_000, expiresAt: FIXED_NOW - 1 }),
+          availableLiquidity: undefined,
+        }),
+      );
+      expect(result.valid).toBe(false);
+      expect(result.blocked).toBe(true);
+      expect(result.failures.map((f) => f.code)).toEqual(
+        expect.arrayContaining(['PROVIDER_UNAVAILABLE', 'QUOTE_STALE', 'QUOTE_EXPIRED', 'LIQUIDITY_UNVERIFIED']),
+      );
+      expect(result.checks).toHaveLength(4);
+    });
+  });
+
+  describe('pre-signing exposure', () => {
+    it('returns the revalidation result before signing', () => {
+      const service = createService();
+      const sign = jest.fn();
+      const gate = validateRouteBeforeSigning(validContext(), service);
+      expect(gate.routeRevalidation.valid).toBe(true);
+      expect(gate.canProceedToSigning).toBe(true);
+      if (!gate.blocked) {
+        sign();
+      }
+      expect(sign).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks signing when the route is invalid', () => {
+      const registry = new StellarBridgeProviderRegistry();
+      const service = createService({ registry });
+      const sign = jest.fn();
+      const gate = validateRouteBeforeSigning(validContext(), service);
+      expect(gate.routeRevalidation.valid).toBe(false);
+      expect(gate.blocked).toBe(true);
+      expect(gate.canProceedToSigning).toBe(false);
+      if (!gate.blocked) {
+        sign();
+      }
+      expect(sign).not.toHaveBeenCalled();
+    });
+
+    it('allows the caller to proceed when revalidation passes', () => {
+      const service = createService();
+      const gate = validateRouteBeforeSigning(validContext(), service);
+      expect(gate.routeRevalidation.checkedAt).toBe(FIXED_NOW);
+      expect(gate.canProceedToSigning).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Implements Stellar route revalidation before execution for #1064.

### Changes

* Added Stellar route revalidation service.
* Rechecks provider availability.
* Rechecks quote freshness.
* Rechecks route liquidity.
* Rechecks destination compatibility.
* Added structured `StellarRouteRevalidationResult`.
* Exposed route revalidation through the pre-signing validation boundary.
* Added tests covering the required validation scenarios.

### Validation

* 23 targeted tests passing.
* No new dependencies added.
* No changes to wallet safety, signing, route ranking, or destination-account/trustline validation.

Closes #1064
