### PR TITLE
feat: implement Stellar provider failure attribution

### DIFF
--- a/src/diagnostics/providers/index.ts
+++ b/src/diagnostics/providers/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { attributeProviderFailure } from './stellar-provider-failure-diagnostic';

--- a/src/diagnostics/providers/stellar-provider-failure-diagnostic.ts
+++ b/src/diagnostics/providers/stellar-provider-failure-diagnostic.ts
@@ -1,0 +1,26 @@
+import type { StellarBridgeProviderError } from '../../providers/stellar/interfaces/stellar-bridge-provider-adapter.interface';
+import { StellarProviderFailureAttributor } from '../../providers/errors/stellar/stellar-provider-failure-attributor';
+import type { AttributeProviderFailureContext } from '../../providers/errors/stellar/types';
+import type { StellarProviderFailureDiagnostic } from './types';
+
+const defaultAttributor = new StellarProviderFailureAttributor();
+
+export function attributeProviderFailure(
+  error: StellarBridgeProviderError,
+  context: AttributeProviderFailureContext = {},
+  attributor: StellarProviderFailureAttributor = defaultAttributor,
+): StellarProviderFailureDiagnostic {
+  const attribution = attributor.attribute(error, context);
+
+  return {
+    providerId: error.providerId,
+    operation: error.operation,
+    code: error.code,
+    failureClass: attribution.failureClass,
+    retryable: error.retryable,
+    message: error.message,
+    dependency: attribution.dependency,
+    details: attribution.details ?? error.details,
+    attributedAt: context.now?.() ?? Date.now(),
+  };
+}

--- a/src/diagnostics/providers/types.ts
+++ b/src/diagnostics/providers/types.ts
@@ -1,0 +1,23 @@
+import type {
+  StellarBridgeProviderErrorCode,
+  StellarBridgeProviderOperation,
+} from '../../providers/stellar/interfaces/stellar-bridge-provider-adapter.interface';
+import type { ProviderFailureClass } from '../../providers/errors/stellar/types';
+import type { ProviderDependencyAttribution } from '../../providers/errors/stellar/types';
+
+export interface StellarProviderFailureDiagnostic {
+  providerId: string;
+  operation: StellarBridgeProviderOperation;
+  code: StellarBridgeProviderErrorCode;
+  failureClass: ProviderFailureClass;
+  retryable: boolean;
+  message: string;
+  dependency?: ProviderDependencyAttribution;
+  details?: Record<string, unknown>;
+  attributedAt: number;
+}
+
+export type {
+  ProviderDependencyAttribution,
+  ProviderFailureClass,
+} from '../../providers/errors/stellar/types';

--- a/src/providers/errors/stellar/index.ts
+++ b/src/providers/errors/stellar/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export { StellarProviderFailureAttributor } from './stellar-provider-failure-attributor';

--- a/src/providers/errors/stellar/stellar-provider-failure-attributor.ts
+++ b/src/providers/errors/stellar/stellar-provider-failure-attributor.ts
@@ -1,0 +1,227 @@
+import type { StellarBridgeProviderError } from '../../stellar/interfaces/stellar-bridge-provider-adapter.interface';
+import type { StellarProviderDependencyGraph } from '../../dependencies/stellar/dependency-graph';
+import type {
+  DependencyHealth,
+  DependencyKind,
+  DependencyStatus,
+} from '../../dependencies/stellar/types';
+import type {
+  AttributeProviderFailureContext,
+  ProviderDependencyAttribution,
+  ProviderFailureAttribution,
+  ProviderFailureClass,
+} from './types';
+
+const STATUS_SEVERITY: Record<DependencyStatus, number> = {
+  healthy: 0,
+  unknown: 1,
+  degraded: 2,
+  unhealthy: 3,
+};
+
+const FAILURE_CLASS_KINDS: Partial<
+  Record<ProviderFailureClass, DependencyKind[]>
+> = {
+  rpc: ['rpc', 'horizon'],
+  liquidity: ['liquidity'],
+  execution: ['contract'],
+  availability: ['rpc', 'horizon', 'contract', 'liquidity', 'api', 'indexer'],
+};
+
+const RPC_SIGNALS =
+  /\b(timeout|timed\s*out|rpc|horizon|network|connection|socket|unavailable\s*endpoint|rate\s*limit)\b/i;
+const LIQUIDITY_SIGNALS =
+  /\b(liquidity|insufficient\s*liquidity|insufficient\s*funds|balance\s*unavailable|liquidity\s*provider)\b/i;
+const CONFIG_SIGNALS =
+  /\b(unsupported|invalid\s*request|invalid\s*parameter|configuration|route\s*not\s*supported)\b/i;
+
+const SENSITIVE_DETAIL_KEYS = new Set([
+  'authorization',
+  'apikey',
+  'api_key',
+  'token',
+  'secret',
+  'password',
+  'credentials',
+  'signedurl',
+  'signed_url',
+]);
+
+const PRIMARY_CODE_CLASS: Record<
+  StellarBridgeProviderError['code'],
+  ProviderFailureClass | 'ambiguous'
+> = {
+  PROVIDER_UNAVAILABLE: 'availability',
+  UNSUPPORTED_ROUTE: 'configuration',
+  INVALID_REQUEST: 'configuration',
+  EXECUTION_FAILED: 'execution',
+  STATUS_FAILED: 'execution',
+  TIMEOUT: 'rpc',
+  RATE_LIMITED: 'rpc',
+  UNKNOWN: 'unknown',
+  QUOTE_FAILED: 'ambiguous',
+  ROUTE_FAILED: 'ambiguous',
+};
+
+export class StellarProviderFailureAttributor {
+  attribute(
+    error: StellarBridgeProviderError,
+    context: AttributeProviderFailureContext = {},
+  ): ProviderFailureAttribution {
+    const failureClass = this.classifyFailureClass(error);
+    const dependency = context.dependencyGraph
+      ? this.selectFailingDependency(
+          context.dependencyGraph,
+          error.providerId,
+          failureClass,
+        )
+      : undefined;
+
+    return {
+      failureClass,
+      dependency,
+      details: this.buildDetails(error, context.rawError),
+    };
+  }
+
+  private classifyFailureClass(
+    error: StellarBridgeProviderError,
+  ): ProviderFailureClass {
+    const primary = PRIMARY_CODE_CLASS[error.code];
+
+    if (primary !== 'ambiguous') {
+      return primary;
+    }
+
+    const signalText = this.collectSignalText(error);
+
+    if (error.code === 'QUOTE_FAILED') {
+      if (LIQUIDITY_SIGNALS.test(signalText)) return 'liquidity';
+      if (RPC_SIGNALS.test(signalText)) return 'rpc';
+      if (CONFIG_SIGNALS.test(signalText)) return 'configuration';
+      return 'unknown';
+    }
+
+    if (RPC_SIGNALS.test(signalText)) return 'rpc';
+    if (CONFIG_SIGNALS.test(signalText)) return 'configuration';
+    return 'unknown';
+  }
+
+  private collectSignalText(error: StellarBridgeProviderError): string {
+    const parts = [error.message];
+
+    if (error.details) {
+      for (const [key, value] of Object.entries(error.details)) {
+        if (SENSITIVE_DETAIL_KEYS.has(key.toLowerCase())) continue;
+        if (typeof value === 'string' || typeof value === 'number') {
+          parts.push(String(value));
+        }
+      }
+    }
+
+    return parts.join(' ');
+  }
+
+  private selectFailingDependency(
+    graph: StellarProviderDependencyGraph,
+    providerId: string,
+    failureClass: ProviderFailureClass,
+  ): ProviderDependencyAttribution | undefined {
+    let failing: DependencyHealth[];
+
+    try {
+      failing = graph.providerHealth(providerId).failing;
+    } catch {
+      return undefined;
+    }
+
+    if (failing.length === 0) {
+      return undefined;
+    }
+
+    const preferredKinds = FAILURE_CLASS_KINDS[failureClass] ?? [];
+    const ranked = [...failing].sort((left, right) => {
+      const leftDependency = graph.getDependency(left.dependencyId);
+      const rightDependency = graph.getDependency(right.dependencyId);
+
+      const leftScore = this.dependencyScore(
+        left,
+        leftDependency?.kind,
+        leftDependency?.critical ?? false,
+        preferredKinds,
+      );
+      const rightScore = this.dependencyScore(
+        right,
+        rightDependency?.kind,
+        rightDependency?.critical ?? false,
+        preferredKinds,
+      );
+
+      return rightScore - leftScore;
+    });
+
+    const selected = ranked[0];
+    const dependency = graph.getDependency(selected.dependencyId);
+
+    if (!dependency) {
+      return undefined;
+    }
+
+    return {
+      dependencyId: selected.dependencyId,
+      kind: dependency.kind,
+      label: dependency.label,
+      status: selected.status,
+      reason: selected.reason,
+    };
+  }
+
+  private dependencyScore(
+    health: DependencyHealth,
+    kind: DependencyKind | undefined,
+    critical: boolean,
+    preferredKinds: DependencyKind[],
+  ): number {
+    const statusScore = STATUS_SEVERITY[health.status] * 100;
+    const kindScore = kind && preferredKinds.includes(kind) ? 10 : 0;
+    const criticalScore = critical ? 1 : 0;
+
+    return statusScore + kindScore + criticalScore;
+  }
+
+  private buildDetails(
+    error: StellarBridgeProviderError,
+    rawError?: unknown,
+  ): Record<string, unknown> | undefined {
+    const details = { ...(error.details ?? {}) };
+
+    if (details.providerErrorCode === undefined) {
+      const providerErrorCode = this.extractProviderErrorCode(rawError);
+      if (providerErrorCode !== undefined) {
+        details.providerErrorCode = providerErrorCode;
+      }
+    }
+
+    return Object.keys(details).length > 0 ? details : undefined;
+  }
+
+  private extractProviderErrorCode(rawError: unknown): string | undefined {
+    if (!rawError || typeof rawError !== 'object') {
+      return undefined;
+    }
+
+    const candidate = rawError as Record<string, unknown>;
+    const code =
+      candidate.code ?? candidate.errorCode ?? candidate.providerCode;
+
+    if (typeof code === 'string' && code.length > 0) {
+      return code;
+    }
+
+    if (typeof code === 'number') {
+      return String(code);
+    }
+
+    return undefined;
+  }
+}

--- a/src/providers/errors/stellar/types.ts
+++ b/src/providers/errors/stellar/types.ts
@@ -1,0 +1,36 @@
+import type { StellarBridgeProviderError } from '../../stellar/interfaces/stellar-bridge-provider-adapter.interface';
+import type { StellarProviderDependencyGraph } from '../../dependencies/stellar/dependency-graph';
+import type {
+  DependencyKind,
+  DependencyStatus,
+} from '../../dependencies/stellar/types';
+
+export type ProviderFailureClass =
+  | 'rpc'
+  | 'liquidity'
+  | 'configuration'
+  | 'execution'
+  | 'availability'
+  | 'unknown';
+
+export interface ProviderDependencyAttribution {
+  dependencyId: string;
+  kind: DependencyKind;
+  label?: string;
+  status?: DependencyStatus;
+  reason?: string;
+}
+
+export interface AttributeProviderFailureContext {
+  rawError?: unknown;
+  dependencyGraph?: StellarProviderDependencyGraph;
+  now?: () => number;
+}
+
+export interface ProviderFailureAttribution {
+  failureClass: ProviderFailureClass;
+  dependency?: ProviderDependencyAttribution;
+  details?: Record<string, unknown>;
+}
+
+export type { StellarBridgeProviderError };

--- a/tests/providers/errors/stellar-provider-failure-attribution.spec.ts
+++ b/tests/providers/errors/stellar-provider-failure-attribution.spec.ts
@@ -1,0 +1,288 @@
+import type { StellarBridgeProviderError } from '../../../src/providers/stellar/interfaces/stellar-bridge-provider-adapter.interface';
+import { StellarProviderDependencyGraph } from '../../../src/providers/dependencies/stellar';
+import { attributeProviderFailure } from '../../../src/diagnostics/providers';
+
+const FIXED_NOW = 1_700_000_000_000;
+
+function makeError(
+  overrides: Partial<StellarBridgeProviderError> = {},
+): StellarBridgeProviderError {
+  return {
+    providerId: 'alpha',
+    operation: 'quote',
+    code: 'UNKNOWN',
+    message: 'provider failure',
+    retryable: false,
+    ...overrides,
+  };
+}
+
+function graphWithSharedRpc() {
+  const graph = new StellarProviderDependencyGraph({ now: () => FIXED_NOW });
+
+  graph.addDependency({
+    id: 'rpc-main',
+    kind: 'rpc',
+    label: 'Soroban RPC',
+    critical: true,
+  });
+  graph.addDependency({
+    id: 'pool-a',
+    kind: 'contract',
+    label: 'Pool A',
+    critical: true,
+  });
+  graph.addDependency({
+    id: 'liquidity-feed',
+    kind: 'liquidity',
+    label: 'Liquidity API',
+    critical: true,
+  });
+  graph.addDependency({
+    id: 'prices',
+    kind: 'api',
+    label: 'Price API',
+    critical: false,
+  });
+
+  graph.addProvider({
+    id: 'alpha',
+    name: 'Alpha Bridge',
+    dependencyIds: ['rpc-main', 'pool-a', 'liquidity-feed'],
+  });
+  graph.addProvider({
+    id: 'beta',
+    name: 'Beta Bridge',
+    dependencyIds: ['rpc-main', 'prices'],
+  });
+
+  return graph;
+}
+
+function allHealthy(graph: StellarProviderDependencyGraph) {
+  for (const dependency of graph.listDependencies()) {
+    graph.recordDependencyHealth(dependency.id, 'healthy');
+  }
+}
+
+describe('attributeProviderFailure (#1069)', () => {
+  const now = () => FIXED_NOW;
+
+  it('attributes TIMEOUT as rpc', () => {
+    const error = makeError({
+      code: 'TIMEOUT',
+      message: 'request timed out',
+      retryable: true,
+    });
+
+    const diagnostic = attributeProviderFailure(error, { now });
+
+    expect(diagnostic.failureClass).toBe('rpc');
+    expect(diagnostic.code).toBe('TIMEOUT');
+    expect(diagnostic.attributedAt).toBe(FIXED_NOW);
+  });
+
+  it('attributes QUOTE_FAILED with liquidity signals as liquidity', () => {
+    const error = makeError({
+      code: 'QUOTE_FAILED',
+      message: 'insufficient liquidity for requested amount',
+      retryable: false,
+    });
+
+    const diagnostic = attributeProviderFailure(error, { now });
+
+    expect(diagnostic.failureClass).toBe('liquidity');
+    expect(diagnostic.code).toBe('QUOTE_FAILED');
+  });
+
+  it.each([
+    ['INVALID_REQUEST', 'invalid request parameters'],
+    ['UNSUPPORTED_ROUTE', 'route not supported for this asset pair'],
+  ] as const)('attributes %s as configuration', (code, message) => {
+    const error = makeError({ code, message, retryable: false });
+
+    const diagnostic = attributeProviderFailure(error, { now });
+
+    expect(diagnostic.failureClass).toBe('configuration');
+    expect(diagnostic.code).toBe(code);
+  });
+
+  it.each([
+    ['EXECUTION_FAILED', 'transaction submission failed'],
+    ['STATUS_FAILED', 'status polling failed'],
+  ] as const)('attributes %s as execution', (code, message) => {
+    const error = makeError({ code, message, retryable: true });
+
+    const diagnostic = attributeProviderFailure(error, { now });
+
+    expect(diagnostic.failureClass).toBe('execution');
+    expect(diagnostic.code).toBe(code);
+  });
+
+  it('attributes an unhealthy rpc dependency when dependency context is provided', () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+    graph.recordDependencyHealth('rpc-main', 'unhealthy', 'connection refused');
+
+    const error = makeError({
+      code: 'TIMEOUT',
+      message: 'request timed out',
+      providerId: 'alpha',
+      retryable: true,
+    });
+
+    const diagnostic = attributeProviderFailure(error, {
+      dependencyGraph: graph,
+      now,
+    });
+
+    expect(diagnostic.failureClass).toBe('rpc');
+    expect(diagnostic.dependency).toEqual({
+      dependencyId: 'rpc-main',
+      kind: 'rpc',
+      label: 'Soroban RPC',
+      status: 'unhealthy',
+      reason: 'connection refused',
+    });
+  });
+
+  it('attributes an unhealthy liquidity dependency when dependency context is provided', () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+    graph.recordDependencyHealth(
+      'liquidity-feed',
+      'unhealthy',
+      'insufficient liquidity',
+    );
+
+    const error = makeError({
+      code: 'QUOTE_FAILED',
+      message: 'insufficient liquidity for quote request',
+      providerId: 'alpha',
+      retryable: false,
+    });
+
+    const diagnostic = attributeProviderFailure(error, {
+      dependencyGraph: graph,
+      now,
+    });
+
+    expect(diagnostic.failureClass).toBe('liquidity');
+    expect(diagnostic.dependency).toMatchObject({
+      dependencyId: 'liquidity-feed',
+      kind: 'liquidity',
+      status: 'unhealthy',
+      reason: 'insufficient liquidity',
+    });
+  });
+
+  it('preserves provider-specific error codes from details', () => {
+    const error = makeError({
+      code: 'EXECUTION_FAILED',
+      details: { providerErrorCode: 'SOME_PROVIDER_CODE' },
+    });
+
+    const diagnostic = attributeProviderFailure(error, { now });
+
+    expect(diagnostic.details?.providerErrorCode).toBe('SOME_PROVIDER_CODE');
+  });
+
+  it('does not overwrite an existing providerErrorCode in details', () => {
+    const error = makeError({
+      details: { providerErrorCode: 'EXISTING_CODE' },
+    });
+
+    const diagnostic = attributeProviderFailure(error, {
+      now,
+      rawError: { code: 'RAW_CODE' },
+    });
+
+    expect(diagnostic.details?.providerErrorCode).toBe('EXISTING_CODE');
+  });
+
+  it.each([
+    'PROVIDER_UNAVAILABLE',
+    'TIMEOUT',
+    'QUOTE_FAILED',
+    'EXECUTION_FAILED',
+  ] as const)('preserves original provider error code %s', (code) => {
+    const error = makeError({ code, message: `${code} occurred` });
+
+    const diagnostic = attributeProviderFailure(error, { now });
+
+    expect(diagnostic.code).toBe(code);
+  });
+
+  it('preserves provider error fields on the diagnostic', () => {
+    const error = makeError({
+      providerId: 'beta',
+      operation: 'execution',
+      code: 'STATUS_FAILED',
+      message: 'status unavailable',
+      retryable: true,
+      details: { requestId: 'req-42' },
+    });
+
+    const diagnostic = attributeProviderFailure(error, { now });
+
+    expect(diagnostic).toMatchObject({
+      providerId: 'beta',
+      operation: 'execution',
+      code: 'STATUS_FAILED',
+      retryable: true,
+      message: 'status unavailable',
+      details: { requestId: 'req-42' },
+    });
+  });
+
+  it('preserves retryability without overriding provider decisions', () => {
+    const retryableError = makeError({ code: 'TIMEOUT', retryable: true });
+    const permanentError = makeError({ code: 'INVALID_REQUEST', retryable: false });
+
+    expect(attributeProviderFailure(retryableError, { now }).retryable).toBe(true);
+    expect(attributeProviderFailure(permanentError, { now }).retryable).toBe(false);
+  });
+
+  it('attributes UNKNOWN without secondary signals as unknown', () => {
+    const error = makeError({
+      code: 'UNKNOWN',
+      message: 'something went wrong',
+      retryable: false,
+    });
+
+    const diagnostic = attributeProviderFailure(error, { now });
+
+    expect(diagnostic.failureClass).toBe('unknown');
+    expect(diagnostic.code).toBe('UNKNOWN');
+  });
+
+  it('extracts providerErrorCode from rawError when details do not include one', () => {
+    const error = makeError({ code: 'UNKNOWN', message: 'provider rejected request' });
+
+    const diagnostic = attributeProviderFailure(error, {
+      now,
+      rawError: { code: 'UPSTREAM_429' },
+    });
+
+    expect(diagnostic.details?.providerErrorCode).toBe('UPSTREAM_429');
+  });
+
+  it('omits dependency when the provider is not registered in the graph', () => {
+    const graph = graphWithSharedRpc();
+    allHealthy(graph);
+
+    const error = makeError({
+      providerId: 'missing-provider',
+      code: 'TIMEOUT',
+      retryable: true,
+    });
+
+    const diagnostic = attributeProviderFailure(error, {
+      dependencyGraph: graph,
+      now,
+    });
+
+    expect(diagnostic.dependency).toBeUndefined();
+    expect(diagnostic.failureClass).toBe('rpc');
+  });
+});


### PR DESCRIPTION
Issue #1069 is implemented as a small, additive attribution layer that takes a canonical StellarBridgeProviderError and returns a StellarProviderFailureDiagnostic with failure class, optional dependency attribution, and preserved provider error fields.

Closes #1069