### PR TITLE
Implement Stellar Bridge Execution Dry-Run Mode

### DIFF
--- a/src/execution/dry-run/stellar/index.ts
+++ b/src/execution/dry-run/stellar/index.ts
@@ -1,0 +1,8 @@
+export { StellarBridgeDryRunService } from './stellar-bridge-dry-run.service';
+export type {
+  DryRunExecutionPlanRequest,
+  DryRunExecutionResult,
+  DryRunPlanStep,
+  DryRunSafetyContextBuilder,
+  DryRunSimulationSummary,
+} from './types';

--- a/src/execution/dry-run/stellar/stellar-bridge-dry-run.service.ts
+++ b/src/execution/dry-run/stellar/stellar-bridge-dry-run.service.ts
@@ -1,0 +1,255 @@
+import { createHash } from 'crypto';
+import {
+  createSorobanInvocationPlan,
+  SorobanInvocationStep,
+} from '../../../soroban/planning/soroban-invocation-planner';
+import {
+  SorobanSimulationAdapter,
+  SorobanSimulationRpc,
+} from '../../../soroban/simulation/soroban-simulation.adapter';
+import { StellarPreExecutionSafetyPipeline } from '../../safety/stellar/stellar-pre-execution-safety-pipeline';
+import type { StellarPreExecutionSafetyContext } from '../../validation/types';
+import {
+  DryRunExecutionPlanRequest,
+  DryRunExecutionResult,
+  DryRunPlanStep,
+  DryRunSafetyContextBuilder,
+  DryRunSimulationSummary,
+} from './types';
+
+/**
+ * Builds the Soroban invocation steps for a Stellar bridge transfer.
+ *
+ * Each step represents a contract invocation that would be executed
+ * on-chain during a real transfer.
+ */
+function buildInvocationSteps(
+  request: DryRunExecutionPlanRequest,
+): SorobanInvocationStep[] {
+  return [
+    {
+      id: 'lock-source-asset',
+      invocation: {
+        contractAddress: request.bridgeContractAddress,
+        functionName: 'lock',
+        args: [request.sourceAccount, request.asset, request.amount],
+        description: 'Lock source-chain asset',
+      },
+      order: 0,
+    },
+    {
+      id: 'initiate-bridge',
+      invocation: {
+        contractAddress: request.bridgeContractAddress,
+        functionName: 'bridge',
+        args: [
+          request.sourceAccount,
+          request.destinationAccount,
+          request.asset,
+          request.amount,
+        ],
+        dependsOn: ['lock-source-asset'],
+        description: 'Initiate cross-chain bridge transfer',
+      },
+      order: 1,
+    },
+    {
+      id: 'confirm-transfer',
+      invocation: {
+        contractAddress: request.bridgeContractAddress,
+        functionName: 'confirm',
+        args: [request.transferId],
+        dependsOn: ['initiate-bridge'],
+        description: 'Confirm bridge transfer completion',
+      },
+      order: 2,
+    },
+  ];
+}
+
+/**
+ * Serialize an invocation step to a deterministic string representation
+ * suitable for simulation RPC.
+ */
+function serializeInvocationForSimulation(step: SorobanInvocationStep): string {
+  return JSON.stringify({
+    contractAddress: step.invocation.contractAddress,
+    functionName: step.invocation.functionName,
+    args: step.invocation.args,
+  });
+}
+
+/**
+ * Deterministic, read-only execution engine for Stellar bridge transfers.
+ *
+ * Builds an execution plan, simulates each step via Soroban RPC,
+ * runs the full safety pipeline, and returns expected results —
+ * all without submitting a transaction to the network.
+ */
+export class StellarBridgeDryRunService {
+  private readonly simulation: SorobanSimulationAdapter;
+  private readonly safetyPipeline: StellarPreExecutionSafetyPipeline;
+  private readonly now: () => number;
+
+  constructor(rpc: SorobanSimulationRpc, options?: { now?: () => number }) {
+    this.simulation = new SorobanSimulationAdapter(rpc);
+    this.safetyPipeline = new StellarPreExecutionSafetyPipeline({
+      now: options?.now,
+    });
+    this.now = options?.now ?? (() => Date.now());
+  }
+
+  /**
+   * Execute a dry-run for a Stellar bridge transfer.
+   *
+   * Steps:
+   * 1. Build the execution plan from the request.
+   * 2. Validate the plan structure.
+   * 3. Simulate each step via Soroban RPC.
+   * 4. Run the pre-execution safety pipeline.
+   * 5. Return results with `transactionSubmitted: false`.
+   *
+   * @throws {Error} If the execution plan cannot be built (empty steps,
+   *   dependency cycle, etc.).
+   */
+  async execute(
+    request: DryRunExecutionPlanRequest,
+    safetyContext: DryRunSafetyContextBuilder,
+  ): Promise<DryRunExecutionResult> {
+    this.validateRequest(request);
+
+    const invocationSteps = buildInvocationSteps(request);
+
+    const planResult = createSorobanInvocationPlan(invocationSteps);
+    if (!planResult.success) {
+      const codes = planResult.errors.map((e) => e.code).join(', ');
+      throw new Error(`Failed to build execution plan: ${codes}`);
+    }
+
+    const plan = planResult.plan!;
+
+    const executionSteps: DryRunPlanStep[] = [];
+
+    for (const step of plan.steps) {
+      const serialized = serializeInvocationForSimulation(step);
+      const simulationResult = await this.simulation.simulate(serialized);
+      executionSteps.push({
+        stepId: step.id,
+        invocation: step,
+        simulationResult,
+      });
+    }
+
+    const simulationSummary = this.buildSimulationSummary(executionSteps);
+
+    const fullSafetyContext: StellarPreExecutionSafetyContext = {
+      quoteQuotedAt: safetyContext.quoteQuotedAt,
+      quoteTtlMs: safetyContext.quoteTtlMs,
+      destinationAccount: request.destinationAccount,
+      destinationExists: safetyContext.destinationExists,
+      destinationFunded: safetyContext.destinationFunded,
+      transferAsset: request.asset,
+      transferAmount: parseFloat(request.amount),
+      availableTransferBalance: safetyContext.availableTransferBalance,
+      estimatedNetworkFee: safetyContext.estimatedNetworkFee,
+      availableFeeBalance: safetyContext.availableFeeBalance,
+      requiredTrustlines: safetyContext.requiredTrustlines,
+      existingTrustlines: safetyContext.existingTrustlines,
+      quotedOutput: safetyContext.quotedOutput,
+      minimumOutput: safetyContext.minimumOutput,
+      resources: safetyContext.resources,
+      resourceLimits: safetyContext.resourceLimits,
+      contractCompatible: safetyContext.contractCompatible,
+      contractCompatibilityReasons: safetyContext.contractCompatibilityReasons,
+    };
+    const safetyResult = this.safetyPipeline.run(fullSafetyContext);
+
+    const executionHash = this.computeExecutionHash(request, executionSteps);
+
+    return {
+      transferId: request.transferId,
+      dryRun: true,
+      executionPlan: executionSteps,
+      simulationSummary,
+      safetyResult,
+      transactionSubmitted: false,
+      executionHash,
+      completedAt: new Date(),
+    };
+  }
+
+  private validateRequest(request: DryRunExecutionPlanRequest): void {
+    if (!request.transferId?.trim()) {
+      throw new Error('transferId is required');
+    }
+    if (!request.sourceAccount?.trim()) {
+      throw new Error('sourceAccount is required');
+    }
+    if (!request.destinationAccount?.trim()) {
+      throw new Error('destinationAccount is required');
+    }
+    if (!request.asset?.trim()) {
+      throw new Error('asset is required');
+    }
+    const amountValue = parseFloat(request.amount);
+    if (Number.isNaN(amountValue) || amountValue <= 0) {
+      throw new Error('amount must be a positive numeric value');
+    }
+    if (!request.bridgeContractAddress?.trim()) {
+      throw new Error('bridgeContractAddress is required');
+    }
+  }
+
+  private buildSimulationSummary(
+    steps: DryRunPlanStep[],
+  ): DryRunSimulationSummary {
+    let estimatedCpuInstructions = 0;
+    let estimatedMemoryBytes = 0;
+    let estimatedFeeTotal = 0;
+    let successfulSteps = 0;
+    let failedSteps = 0;
+
+    for (const step of steps) {
+      if (step.simulationResult?.success) {
+        successfulSteps += 1;
+        estimatedCpuInstructions +=
+          step.simulationResult.resourceEstimates.cpuInstructions ?? 0;
+        estimatedMemoryBytes +=
+          step.simulationResult.resourceEstimates.memoryBytes ?? 0;
+        const fee = parseFloat(
+          step.simulationResult.resourceEstimates.fee ?? '0',
+        );
+        if (!Number.isNaN(fee)) {
+          estimatedFeeTotal += fee;
+        }
+      } else {
+        failedSteps += 1;
+      }
+    }
+
+    return {
+      totalSteps: steps.length,
+      successfulSteps,
+      failedSteps,
+      estimatedCpuInstructions,
+      estimatedMemoryBytes,
+      estimatedFee: estimatedFeeTotal.toFixed(7),
+    };
+  }
+
+  private computeExecutionHash(
+    request: DryRunExecutionPlanRequest,
+    steps: DryRunPlanStep[],
+  ): string {
+    const payload = JSON.stringify({
+      transferId: request.transferId,
+      sourceAccount: request.sourceAccount,
+      destinationAccount: request.destinationAccount,
+      asset: request.asset,
+      amount: request.amount,
+      bridgeContractAddress: request.bridgeContractAddress,
+      stepIds: steps.map((s) => s.stepId),
+    });
+    return createHash('sha256').update(payload).digest('hex');
+  }
+}

--- a/src/execution/dry-run/stellar/types.ts
+++ b/src/execution/dry-run/stellar/types.ts
@@ -1,0 +1,65 @@
+import type { SorobanInvocationStep } from '../../../soroban/planning/soroban-invocation-planner';
+import type { SorobanSimulationResult } from '../../../soroban/simulation/soroban-simulation.adapter';
+import type { StellarPreExecutionSafetyResult } from '../../validation/types';
+
+export interface DryRunExecutionPlanRequest {
+  transferId: string;
+  sourceAccount: string;
+  destinationAccount: string;
+  asset: string;
+  amount: string;
+  bridgeContractAddress: string;
+  memo?: string;
+}
+
+export interface DryRunPlanStep {
+  stepId: string;
+  invocation: SorobanInvocationStep;
+  simulationResult: SorobanSimulationResult | null;
+}
+
+export interface DryRunSimulationSummary {
+  totalSteps: number;
+  successfulSteps: number;
+  failedSteps: number;
+  estimatedCpuInstructions: number;
+  estimatedMemoryBytes: number;
+  estimatedFee: string;
+}
+
+export interface DryRunExecutionResult {
+  transferId: string;
+  dryRun: true;
+  executionPlan: DryRunPlanStep[];
+  simulationSummary: DryRunSimulationSummary;
+  safetyResult: StellarPreExecutionSafetyResult;
+  transactionSubmitted: false;
+  executionHash: string;
+  completedAt: Date;
+}
+
+export interface DryRunSafetyContextBuilder {
+  quoteQuotedAt: number;
+  quoteTtlMs: number;
+  destinationExists: boolean;
+  destinationFunded: boolean;
+  availableTransferBalance: number;
+  estimatedNetworkFee: number;
+  availableFeeBalance: number;
+  requiredTrustlines: Array<{ code: string; issuer: string }>;
+  existingTrustlines: Array<{ code: string; issuer: string }>;
+  quotedOutput: number;
+  minimumOutput: number;
+  resources: {
+    cpuInstructions: number;
+    memoryBytes: number;
+    fee: number;
+  };
+  resourceLimits: {
+    cpuInstructions: number;
+    memoryBytes: number;
+    fee: number;
+  };
+  contractCompatible: boolean;
+  contractCompatibilityReasons?: string[];
+}

--- a/src/soroban/planning/soroban-invocation-planner.ts
+++ b/src/soroban/planning/soroban-invocation-planner.ts
@@ -1,4 +1,3 @@
-```ts
 /**
  * Soroban Multi-Contract Invocation Planner
  *
@@ -519,4 +518,3 @@ export function toExecutableInvocations(
 ): SorobanInvocation[] {
   return plan.steps.map((step) => step.invocation);
 }
-```

--- a/tests/execution/dry-run/stellar-bridge-dry-run.spec.ts
+++ b/tests/execution/dry-run/stellar-bridge-dry-run.spec.ts
@@ -1,0 +1,207 @@
+import { StellarBridgeDryRunService } from '../../../src/execution/dry-run/stellar/stellar-bridge-dry-run.service';
+import type {
+  DryRunExecutionPlanRequest,
+  DryRunSafetyContextBuilder,
+} from '../../../src/execution/dry-run/stellar/types';
+
+function validRequest(
+  overrides: Partial<DryRunExecutionPlanRequest> = {},
+): DryRunExecutionPlanRequest {
+  return {
+    transferId: 'transfer-001',
+    sourceAccount: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    destinationAccount:
+      'GBCDEFGHJKLMNPQRSTUVWXYZBCDEFGHJKLMNPQRSTUVWXYZBCDEFGHJK',
+    asset: 'USDC',
+    amount: '100',
+    bridgeContractAddress:
+      'CBRIDGE2ABC34567890ABCDEFGHJKLMNPQRSTUVWXYZ1234567890ABC',
+    ...overrides,
+  };
+}
+
+function validSafetyContext(
+  overrides: Partial<DryRunSafetyContextBuilder> = {},
+): DryRunSafetyContextBuilder {
+  return {
+    quoteQuotedAt: 1_000,
+    quoteTtlMs: 5_000,
+    destinationExists: true,
+    destinationFunded: true,
+    availableTransferBalance: 150,
+    estimatedNetworkFee: 1,
+    availableFeeBalance: 10,
+    requiredTrustlines: [
+      {
+        code: 'USDC',
+        issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      },
+    ],
+    existingTrustlines: [
+      {
+        code: 'USDC',
+        issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      },
+    ],
+    quotedOutput: 98,
+    minimumOutput: 95,
+    resources: { cpuInstructions: 100, memoryBytes: 50, fee: 20 },
+    resourceLimits: { cpuInstructions: 1000, memoryBytes: 500, fee: 100 },
+    contractCompatible: true,
+    ...overrides,
+  };
+}
+
+function mockRpc() {
+  return {
+    simulateTransaction: jest.fn().mockResolvedValue({
+      result: {
+        status: 'SUCCESS',
+        cost: {
+          cpuInstructions: 50,
+          memoryBytes: 25,
+          fee: '0.00001',
+        },
+        retval: 'ok',
+      },
+    }),
+  };
+}
+
+describe('StellarBridgeDryRunService', () => {
+  it('should build an execution plan and return dry-run results', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc, { now: () => 2_000 });
+
+    const result = await service.execute(validRequest(), validSafetyContext());
+
+    expect(result.dryRun).toBe(true);
+    expect(result.transactionSubmitted).toBe(false);
+    expect(result.transferId).toBe('transfer-001');
+    expect(result.executionPlan).toHaveLength(3);
+    expect(result.executionPlan.map((s) => s.stepId)).toEqual([
+      'lock-source-asset',
+      'initiate-bridge',
+      'confirm-transfer',
+    ]);
+  });
+
+  it('should simulate each step via the RPC adapter', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc);
+
+    await service.execute(validRequest(), validSafetyContext());
+
+    expect(rpc.simulateTransaction).toHaveBeenCalledTimes(3);
+  });
+
+  it('should compute a deterministic execution hash', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc);
+
+    const result1 = await service.execute(validRequest(), validSafetyContext());
+    const result2 = await service.execute(validRequest(), validSafetyContext());
+
+    expect(result1.executionHash).toBe(result2.executionHash);
+    expect(result1.executionHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('should aggregate simulation summaries from successful steps', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc);
+
+    const result = await service.execute(validRequest(), validSafetyContext());
+
+    expect(result.simulationSummary.totalSteps).toBe(3);
+    expect(result.simulationSummary.successfulSteps).toBe(3);
+    expect(result.simulationSummary.failedSteps).toBe(0);
+    expect(result.simulationSummary.estimatedCpuInstructions).toBe(150);
+    expect(result.simulationSummary.estimatedMemoryBytes).toBe(75);
+  });
+
+  it('should run safety checks and return safe when all pass', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc, { now: () => 2_000 });
+
+    const result = await service.execute(validRequest(), validSafetyContext());
+
+    expect(result.safetyResult.safe).toBe(true);
+    expect(result.safetyResult.blocked).toBe(false);
+    expect(result.safetyResult.failures).toHaveLength(0);
+  });
+
+  it('should block when safety checks fail', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc, { now: () => 2_000 });
+
+    const result = await service.execute(
+      validRequest(),
+      validSafetyContext({
+        contractCompatible: false,
+        contractCompatibilityReasons: ['missing bridge()'],
+      }),
+    );
+
+    expect(result.safetyResult.safe).toBe(false);
+    expect(result.safetyResult.blocked).toBe(true);
+    expect(
+      result.safetyResult.failures.some(
+        (f) => f.code === 'CONTRACT_INCOMPATIBLE',
+      ),
+    ).toBe(true);
+  });
+
+  it('should report failed steps when simulation fails', async () => {
+    const rpc = {
+      simulateTransaction: jest.fn().mockResolvedValue({
+        error: { message: 'simulation failed' },
+      }),
+    };
+    const service = new StellarBridgeDryRunService(rpc);
+
+    const result = await service.execute(validRequest(), validSafetyContext());
+
+    expect(result.simulationSummary.failedSteps).toBe(3);
+    expect(result.simulationSummary.successfulSteps).toBe(0);
+  });
+
+  it('should throw for missing transferId', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc);
+
+    await expect(
+      service.execute(validRequest({ transferId: '' }), validSafetyContext()),
+    ).rejects.toThrow('transferId is required');
+  });
+
+  it('should throw for invalid amount', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc);
+
+    await expect(
+      service.execute(validRequest({ amount: '0' }), validSafetyContext()),
+    ).rejects.toThrow('amount must be a positive numeric value');
+  });
+
+  it('should throw for missing bridgeContractAddress', async () => {
+    const rpc = mockRpc();
+    const service = new StellarBridgeDryRunService(rpc);
+
+    await expect(
+      service.execute(
+        validRequest({ bridgeContractAddress: '' }),
+        validSafetyContext(),
+      ),
+    ).rejects.toThrow('bridgeContractAddress is required');
+  });
+
+  it('should include completedAt timestamp in the result', async () => {
+    const rpc = mockRpc();
+    const now = 1_700_000_000_000;
+    const service = new StellarBridgeDryRunService(rpc, { now: () => now });
+
+    const result = await service.execute(validRequest(), validSafetyContext());
+
+    expect(result.completedAt).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
## Summary

Implements a Stellar Bridge Execution Dry-Run Mode that allows applications to validate a Stellar bridge execution without submitting a transaction to the network. The service builds an invocation plan, simulates each step via Soroban RPC, runs the full pre-execution safety pipeline, and returns structured results — all while guaranteeing no transaction is submitted.

## What changed and why

- **Added `StellarBridgeDryRunService`** (`src/execution/dry-run/stellar/stellar-bridge-dry-run.service.ts`): Core dry-run engine that validates requests, builds a 3-step invocation plan (lock, bridge, confirm), simulates each step via `SorobanSimulationAdapter`, runs `StellarPreExecutionSafetyPipeline` (7 safety checks), computes a deterministic SHA-256 execution hash, and returns results with `transactionSubmitted: false`.
- **Added dry-run type definitions** (`src/execution/dry-run/stellar/types.ts`): Defines `DryRunExecutionPlanRequest`, `DryRunExecutionResult`, `DryRunPlanStep`, `DryRunSimulationSummary`, and `DryRunSafetyContextBuilder` interfaces for type-safe dry-run interactions.
- **Added barrel exports** (`src/execution/dry-run/stellar/index.ts`): Re-exports the service and all types for clean imports.
- **Added dry-run test suite** (`tests/execution/dry-run/stellar-bridge-dry-run.spec.ts`): 11 tests covering plan building, simulation delegation, hash determinism, summary aggregation, safety pass/block on incompatible contracts, failed simulation handling, input validation (missing transferId, invalid amount, missing contract address), and result structure.
- **Removed stale markdown code fences** (`src/soroban/planning/soroban-invocation-planner.ts`): Removed `` ```ts `` and `` ``` `` markers that were incorrectly present in the TypeScript source file.

## How to test

### CI checks run locally

```bash
# Build (matches CI: pnpm run build)
pnpm run build
# Expected: completes without errors

# Cargo tests (matches CI: cargo test)
cargo test
# Expected: 9 tests passed, 0 failed

# Dry-run tests
npx jest --testPathPattern='tests/execution/dry-run/' --no-coverage
# Expected: 11 tests passed, 0 failed

# Soroban simulation tests
npx jest --testPathPattern='tests/soroban/simulation/' --no-coverage
# Expected: 6 tests passed, 0 failed

# Safety pipeline tests
npx jest --testPathPattern='tests/execution/safety/' --no-coverage
# Expected: 4 tests passed, 0 failed
```

All checks passed locally. The CI workflow (`.github/workflows/ci.yml`) runs `pnpm install --frozen-lockfile`, `pnpm run build`, and `cargo test` — all of which pass. No lock files were modified. No formatting or linting issues were introduced in the changed files.

Closes #1070